### PR TITLE
FM2-178: Add patient search parameter where subject is allowed

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhir2/providers/r3/AllergyIntoleranceFhirResourceProvider.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/providers/r3/AllergyIntoleranceFhirResourceProvider.java
@@ -34,6 +34,7 @@ import org.hl7.fhir.dstu3.model.IdType;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.dstu3.model.Resource;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Provenance;
 import org.openmrs.module.fhir2.api.FhirAllergyIntoleranceService;
 import org.openmrs.module.fhir2.providers.util.FhirProviderUtils;
@@ -82,12 +83,18 @@ public class AllergyIntoleranceFhirResourceProvider implements IResourceProvider
 	public Bundle searchForAllergies(
 	        @OptionalParam(name = AllergyIntolerance.SP_PATIENT, chainWhitelist = { "", Patient.SP_IDENTIFIER,
 	                Patient.SP_GIVEN, Patient.SP_FAMILY,
-	                Patient.SP_NAME }, targetTypes = Patient.class) ReferenceAndListParam patientReference,
+					Patient.SP_NAME }, targetTypes = Patient.class) ReferenceAndListParam patientReference,
+			@OptionalParam(name = Observation.SP_SUBJECT, chainWhitelist = { "", Patient.SP_IDENTIFIER, Patient.SP_GIVEN,
+	                Patient.SP_FAMILY,
+	                Patient.SP_NAME }, targetTypes = Patient.class) ReferenceAndListParam subjectReference,		
 	        @OptionalParam(name = AllergyIntolerance.SP_CATEGORY) TokenAndListParam category,
 	        @OptionalParam(name = AllergyIntolerance.SP_CODE) TokenAndListParam allergen,
 	        @OptionalParam(name = AllergyIntolerance.SP_SEVERITY) TokenAndListParam severity,
 	        @OptionalParam(name = AllergyIntolerance.SP_MANIFESTATION) TokenAndListParam manifestationCode,
 	        @OptionalParam(name = AllergyIntolerance.SP_CLINICAL_STATUS) TokenAndListParam clinicalStatus) {
+				if (patientReference == null){
+					patientReference = subjectReference;
+				}
 		return Bundle30_40.convertBundle(FhirProviderUtils.convertSearchResultsToBundle(allergyIntoleranceService
 		        .searchForAllergies(patientReference, category, allergen, severity, manifestationCode, clinicalStatus)));
 	}

--- a/api/src/main/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProvider.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProvider.java
@@ -74,7 +74,12 @@ public class EncounterFhirResourceProvider implements IResourceProvider {
 	                Practitioner.SP_NAME }, targetTypes = Practitioner.class) ReferenceAndListParam participantReference,
 	        @OptionalParam(name = Encounter.SP_SUBJECT, chainWhitelist = { "", Patient.SP_IDENTIFIER, Patient.SP_GIVEN,
 	                Patient.SP_FAMILY,
-	                Patient.SP_NAME }, targetTypes = Patient.class) ReferenceAndListParam subjectReference) {
+					Patient.SP_NAME }, targetTypes = Patient.class) ReferenceAndListParam subjectReference,
+			@OptionalParam(name = Encounter.SP_PATIENT, chainWhitelist = { "", Patient.SP_IDENTIFIER, Patient.SP_GIVEN,
+	                Patient.SP_FAMILY, Patient.SP_NAME }, targetTypes = Patient.class) ReferenceAndListParam patientParam) {
+						if(patientParam != null){
+							subjectReference = patientParam;
+						}
 		return Bundle30_40.convertBundle(FhirProviderUtils.convertSearchResultsToBundle(
 		    encounterService.searchForEncounters(date, location, participantReference, subjectReference)));
 		

--- a/api/src/main/java/org/openmrs/module/fhir2/providers/r3/ObservationFhirResourceProvider.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/providers/r3/ObservationFhirResourceProvider.java
@@ -67,7 +67,9 @@ public class ObservationFhirResourceProvider implements IResourceProvider {
 	        @OptionalParam(name = Observation.SP_ENCOUNTER) ReferenceAndListParam encounterReference,
 	        @OptionalParam(name = Observation.SP_SUBJECT, chainWhitelist = { "", Patient.SP_IDENTIFIER, Patient.SP_GIVEN,
 	                Patient.SP_FAMILY,
-	                Patient.SP_NAME }, targetTypes = Patient.class) ReferenceAndListParam patientReference,
+					Patient.SP_NAME }, targetTypes = Patient.class) ReferenceAndListParam patientReference,
+			@OptionalParam(name = Observation.SP_PATIENT, chainWhitelist = { "", Patient.SP_IDENTIFIER, Patient.SP_GIVEN,
+	                Patient.SP_FAMILY, Patient.SP_NAME }, targetTypes = Patient.class) ReferenceAndListParam patientParam,		
 	        @OptionalParam(name = Observation.SP_RELATED_TYPE, chainWhitelist = { "",
 	                Observation.SP_CODE }, targetTypes = Observation.class) ReferenceParam hasMemberReference,
 	        @OptionalParam(name = Observation.SP_VALUE_CONCEPT) TokenAndListParam valueConcept,
@@ -77,6 +79,9 @@ public class ObservationFhirResourceProvider implements IResourceProvider {
 	        @OptionalParam(name = Observation.SP_DATE) DateRangeParam date,
 	        @OptionalParam(name = Observation.SP_CODE) TokenAndListParam code,
 	        @OptionalParam(name = Observation.SP_CATEGORY) TokenAndListParam category, @Sort SortSpec sort) {
+				if(patientParam != null){
+					patientReference = patientParam;
+				}
 		return observationService.searchForObservations(encounterReference, patientReference, hasMemberReference,
 		    valueConcept, valueDateParam, valueQuantityParam, valueStringParam, date, code, category, sort);
 	}

--- a/api/src/main/java/org/openmrs/module/fhir2/providers/r4/AllergyIntoleranceFhirResourceProvider.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/providers/r4/AllergyIntoleranceFhirResourceProvider.java
@@ -31,6 +31,7 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.AllergyIntolerance;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Resource;
 import org.openmrs.module.fhir2.api.FhirAllergyIntoleranceService;
@@ -77,12 +78,19 @@ public class AllergyIntoleranceFhirResourceProvider implements IResourceProvider
 	public Bundle searchForAllergies(
 	        @OptionalParam(name = AllergyIntolerance.SP_PATIENT, chainWhitelist = { "", Patient.SP_IDENTIFIER,
 	                Patient.SP_GIVEN, Patient.SP_FAMILY,
-	                Patient.SP_NAME }, targetTypes = Patient.class) ReferenceAndListParam patientReference,
+					Patient.SP_NAME }, targetTypes = Patient.class) ReferenceAndListParam patientReference,
+			
+			@OptionalParam(name = Observation.SP_SUBJECT, chainWhitelist = { "", Patient.SP_IDENTIFIER, Patient.SP_GIVEN,
+	                Patient.SP_FAMILY,
+	                Patient.SP_NAME }, targetTypes = Patient.class) ReferenceAndListParam subjectReference,	
 	        @OptionalParam(name = AllergyIntolerance.SP_CATEGORY) TokenAndListParam category,
 	        @OptionalParam(name = AllergyIntolerance.SP_CODE) TokenAndListParam allergen,
 	        @OptionalParam(name = AllergyIntolerance.SP_SEVERITY) TokenAndListParam severity,
 	        @OptionalParam(name = AllergyIntolerance.SP_MANIFESTATION) TokenAndListParam manifestationCode,
 	        @OptionalParam(name = AllergyIntolerance.SP_CLINICAL_STATUS) TokenAndListParam clinicalStatus) {
+				if (patientReference == null){
+					patientReference = subjectReference;
+				}
 		return FhirProviderUtils.convertSearchResultsToBundle(fhirAllergyIntoleranceService
 		        .searchForAllergies(patientReference, category, allergen, severity, manifestationCode, clinicalStatus));
 	}

--- a/api/src/main/java/org/openmrs/module/fhir2/providers/r4/DiagnosticReportFhirResourceProvider.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/providers/r4/DiagnosticReportFhirResourceProvider.java
@@ -85,9 +85,14 @@ public class DiagnosticReportFhirResourceProvider implements IResourceProvider {
 	                "" }, targetTypes = Encounter.class) ReferenceAndListParam encounterReference,
 	        @OptionalParam(name = DiagnosticReport.SP_PATIENT, chainWhitelist = { "", Patient.SP_IDENTIFIER,
 	                Patient.SP_GIVEN, Patient.SP_FAMILY,
-	                Patient.SP_NAME }, targetTypes = Patient.class) ReferenceAndListParam patientReference,
+					Patient.SP_NAME }, targetTypes = Patient.class) ReferenceAndListParam patientReference,
+			@OptionalParam(name = DiagnosticReport.SP_SUBJECT, chainWhitelist = { "", Patient.SP_IDENTIFIER, Patient.SP_NAME,
+	                Patient.SP_GIVEN, Patient.SP_FAMILY }) ReferenceAndListParam subjectReference,		
 	        @OptionalParam(name = DiagnosticReport.SP_ISSUED) DateRangeParam issueDate,
 	        @OptionalParam(name = DiagnosticReport.SP_CODE) TokenAndListParam code, @Sort SortSpec sort) {
+				if (patientReference == null){
+					patientReference = subjectReference;
+				}
 		return FhirProviderUtils.convertSearchResultsToBundle(
 		    service.searchForDiagnosticReports(encounterReference, patientReference, issueDate, code, sort));
 	}

--- a/api/src/main/java/org/openmrs/module/fhir2/providers/r4/EncounterFhirResourceProvider.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/providers/r4/EncounterFhirResourceProvider.java
@@ -80,7 +80,13 @@ public class EncounterFhirResourceProvider implements IResourceProvider {
 	                Practitioner.SP_NAME }, targetTypes = Practitioner.class) ReferenceAndListParam participantReference,
 	        @OptionalParam(name = Encounter.SP_SUBJECT, chainWhitelist = { "", Patient.SP_IDENTIFIER, Patient.SP_GIVEN,
 	                Patient.SP_FAMILY,
-	                Patient.SP_NAME }, targetTypes = Patient.class) ReferenceAndListParam subjectReference) {
+					Patient.SP_NAME }, targetTypes = Patient.class) ReferenceAndListParam subjectReference,
+			@OptionalParam(name = Encounter.SP_PATIENT, chainWhitelist = { "", Patient.SP_IDENTIFIER, Patient.SP_GIVEN,
+	                Patient.SP_FAMILY, Patient.SP_NAME }, targetTypes = Patient.class) ReferenceAndListParam patientParam) {
+						if(patientParam != null){
+							subjectReference = patientParam;
+						}
+						
 		return FhirProviderUtils.convertSearchResultsToBundle(
 		    encounterService.searchForEncounters(date, location, participantReference, subjectReference));
 		

--- a/api/src/main/java/org/openmrs/module/fhir2/providers/r4/ObservationFhirResourceProvider.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/providers/r4/ObservationFhirResourceProvider.java
@@ -89,7 +89,12 @@ public class ObservationFhirResourceProvider implements IResourceProvider {
 	        @OptionalParam(name = Observation.SP_VALUE_STRING) StringAndListParam valueStringParam,
 	        @OptionalParam(name = Observation.SP_DATE) DateRangeParam date,
 	        @OptionalParam(name = Observation.SP_CODE) TokenAndListParam code,
-	        @OptionalParam(name = Observation.SP_CATEGORY) TokenAndListParam category, @Sort SortSpec sort) {
+			@OptionalParam(name = Observation.SP_CATEGORY) TokenAndListParam category, @Sort SortSpec sort,
+			@OptionalParam(name = Observation.SP_PATIENT, chainWhitelist = { "", Patient.SP_IDENTIFIER, Patient.SP_GIVEN,
+	                Patient.SP_FAMILY, Patient.SP_NAME }, targetTypes = Patient.class) ReferenceAndListParam patientParam) {
+						if(patientParam != null){
+							patientReference = patientParam;
+						}
 		return observationService.searchForObservations(encounterReference, patientReference, hasMemberReference,
 		    valueConcept, valueDateParam, valueQuantityParam, valueStringParam, date, code, category, sort);
 	}

--- a/api/src/test/java/org/openmrs/module/fhir2/providers/r3/AllergyIntoleranceFhirR3ResourceProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/providers/r3/AllergyIntoleranceFhirR3ResourceProviderTest.java
@@ -134,7 +134,7 @@ public class AllergyIntoleranceFhirR3ResourceProviderTest extends BaseFhirR3Prov
 		when(service.searchForAllergies(argThat(is(patient)), isNull(), isNull(), isNull(), isNull(), isNull()))
 		        .thenReturn(Collections.singletonList(allergyIntolerance));
 		
-		Bundle results = resourceProvider.searchForAllergies(patient, null, null, null, null, null);
+		Bundle results = resourceProvider.searchForAllergies(patient,null, null, null, null, null, null);
 		assertThat(results, notNullValue());
 		assertThat(results.isResource(), is(true));
 		assertThat(results.getEntry().size(), greaterThanOrEqualTo(1));
@@ -148,12 +148,26 @@ public class AllergyIntoleranceFhirR3ResourceProviderTest extends BaseFhirR3Prov
 		when(service.searchForAllergies(argThat(is(patient)), isNull(), isNull(), isNull(), isNull(), isNull()))
 		        .thenReturn(Collections.singletonList(allergyIntolerance));
 		
-		Bundle results = resourceProvider.searchForAllergies(patient, null, null, null, null, null);
+		Bundle results = resourceProvider.searchForAllergies(patient,null, null, null, null, null, null);
 		assertThat(results, notNullValue());
 		assertThat(results.isResource(), is(true));
 		assertThat(results.getEntry().size(), greaterThanOrEqualTo(1));
 	}
 	
+	@Test
+	public void searchForAllergies_shouldReturnMatchingBundleOfAllergiesWhenPatientGivenNameIsSpecifiedAsSubject() {
+		ReferenceAndListParam subject = new ReferenceAndListParam();
+		subject.addValue(new ReferenceOrListParam().add(new ReferenceParam().setValue("John").setChain(Patient.SP_GIVEN)));
+		
+		when(service.searchForAllergies(argThat(is(subject)), isNull(), isNull(), isNull(), isNull(), isNull()))
+		        .thenReturn(Collections.singletonList(allergyIntolerance));
+		
+		Bundle results = resourceProvider.searchForAllergies(null,subject, null, null, null, null, null);
+		assertThat(results, notNullValue());
+		assertThat(results.isResource(), is(true));
+		assertThat(results.getEntry().size(), greaterThanOrEqualTo(1));
+	}
+
 	@Test
 	public void searchForAllergies_shouldReturnMatchingBundleOfAllergiesByPatientFamilyName() {
 		ReferenceAndListParam patient = new ReferenceAndListParam();
@@ -162,7 +176,7 @@ public class AllergyIntoleranceFhirR3ResourceProviderTest extends BaseFhirR3Prov
 		when(service.searchForAllergies(argThat(is(patient)), isNull(), isNull(), isNull(), isNull(), isNull()))
 		        .thenReturn(Collections.singletonList(allergyIntolerance));
 		
-		Bundle results = resourceProvider.searchForAllergies(patient, null, null, null, null, null);
+		Bundle results = resourceProvider.searchForAllergies(patient,null, null, null, null, null, null);
 		assertThat(results, notNullValue());
 		assertThat(results.isResource(), is(true));
 		assertThat(results.getEntry().size(), greaterThanOrEqualTo(1));
@@ -177,7 +191,7 @@ public class AllergyIntoleranceFhirR3ResourceProviderTest extends BaseFhirR3Prov
 		when(service.searchForAllergies(argThat(is(patient)), isNull(), isNull(), isNull(), isNull(), isNull()))
 		        .thenReturn(Collections.singletonList(allergyIntolerance));
 		
-		Bundle results = resourceProvider.searchForAllergies(patient, null, null, null, null, null);
+		Bundle results = resourceProvider.searchForAllergies(patient,null, null, null, null, null, null);
 		assertThat(results, notNullValue());
 		assertThat(results.isResource(), is(true));
 		assertThat(results.getEntry().size(), greaterThanOrEqualTo(1));
@@ -191,7 +205,7 @@ public class AllergyIntoleranceFhirR3ResourceProviderTest extends BaseFhirR3Prov
 		when(service.searchForAllergies(isNull(), argThat(is(category)), isNull(), isNull(), isNull(), isNull()))
 		        .thenReturn(Collections.singletonList(allergyIntolerance));
 		
-		Bundle results = resourceProvider.searchForAllergies(null, category, null, null, null, null);
+		Bundle results = resourceProvider.searchForAllergies(null,null, category, null, null, null, null);
 		assertThat(results, notNullValue());
 		assertThat(results.isResource(), is(true));
 		assertThat(results.getEntry().size(), greaterThanOrEqualTo(1));
@@ -205,7 +219,7 @@ public class AllergyIntoleranceFhirR3ResourceProviderTest extends BaseFhirR3Prov
 		when(service.searchForAllergies(isNull(), isNull(), argThat(is(allergen)), isNull(), isNull(), isNull()))
 		        .thenReturn(Collections.singletonList(allergyIntolerance));
 		
-		Bundle results = resourceProvider.searchForAllergies(null, null, allergen, null, null, null);
+		Bundle results = resourceProvider.searchForAllergies(null,null, null, allergen, null, null, null);
 		
 		assertThat(results, notNullValue());
 		assertThat(results.isResource(), is(true));
@@ -220,7 +234,7 @@ public class AllergyIntoleranceFhirR3ResourceProviderTest extends BaseFhirR3Prov
 		when(service.searchForAllergies(isNull(), isNull(), isNull(), argThat(is(severity)), isNull(), isNull()))
 		        .thenReturn(Collections.singletonList(allergyIntolerance));
 		
-		Bundle results = resourceProvider.searchForAllergies(null, null, null, severity, null, null);
+		Bundle results = resourceProvider.searchForAllergies(null,null, null, null, severity, null, null);
 		assertThat(results, notNullValue());
 		assertThat(results.isResource(), is(true));
 		assertThat(results.getEntry().size(), greaterThanOrEqualTo(1));
@@ -234,7 +248,7 @@ public class AllergyIntoleranceFhirR3ResourceProviderTest extends BaseFhirR3Prov
 		when(service.searchForAllergies(isNull(), isNull(), isNull(), isNull(), argThat(is(manifestation)), isNull()))
 		        .thenReturn(Collections.singletonList(allergyIntolerance));
 		
-		Bundle results = resourceProvider.searchForAllergies(null, null, null, null, manifestation, null);
+		Bundle results = resourceProvider.searchForAllergies(null,null, null, null, null, manifestation, null);
 		assertThat(results, notNullValue());
 		assertThat(results.isResource(), is(true));
 		assertThat(results.getEntry().size(), greaterThanOrEqualTo(1));
@@ -248,7 +262,7 @@ public class AllergyIntoleranceFhirR3ResourceProviderTest extends BaseFhirR3Prov
 		when(service.searchForAllergies(isNull(), isNull(), isNull(), isNull(), isNull(), argThat(is(status))))
 		        .thenReturn(Collections.singletonList(allergyIntolerance));
 		
-		Bundle results = resourceProvider.searchForAllergies(null, null, null, null, null, status);
+		Bundle results = resourceProvider.searchForAllergies(null,null, null, null, null, null, status);
 		assertThat(results, notNullValue());
 		assertThat(results.isResource(), is(true));
 		assertThat(results.getEntry().size(), greaterThanOrEqualTo(1));

--- a/api/src/test/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProviderTest.java
@@ -105,7 +105,7 @@ public class EncounterFhirResourceProviderTest extends BaseFhirR3ProvenanceResou
 		ReferenceAndListParam subjectreference = new ReferenceAndListParam();
 		subjectreference.addValue(new ReferenceOrListParam().add(new ReferenceParam().setChain(Patient.SP_NAME)));
 		
-		Bundle results = resourceProvider.searchEncounter(null, null, null, subjectreference);
+		Bundle results = resourceProvider.searchEncounter(null, null, null, subjectreference,null);
 		assertThat(results, notNullValue());
 		assertThat(results.getTotal(), equalTo(1));
 		assertThat(results.getEntry(), notNullValue());
@@ -113,6 +113,22 @@ public class EncounterFhirResourceProviderTest extends BaseFhirR3ProvenanceResou
 		assertThat(results.getEntry().get(0).getResource().getId(), equalTo(ENCOUNTER_UUID));
 	}
 	
+	@Test
+	public void searchEncounters_shouldReturnMatchingEncountersWhenPatientParamIsSpecified() {
+		List<org.hl7.fhir.r4.model.Encounter> encounters = new ArrayList<>();
+		encounters.add(encounter);
+		when(encounterService.searchForEncounters(any(), any(), any(), any())).thenReturn(encounters);
+		
+		ReferenceAndListParam patientParam = new ReferenceAndListParam();
+		patientParam.addValue(new ReferenceOrListParam().add(new ReferenceParam().setChain(Patient.SP_NAME)));
+		
+		Bundle results = resourceProvider.searchEncounter(null, null, null,null, patientParam);
+		assertThat(results, notNullValue());
+		assertThat(results.getTotal(), equalTo(1));
+		assertThat(results.getEntry(), notNullValue());
+		assertThat(results.getEntry().get(0).getResource().fhirType(), equalTo("Encounter"));
+		assertThat(results.getEntry().get(0).getResource().getId(), equalTo(ENCOUNTER_UUID));
+	}
 	@Test
 	public void getEncounterHistory_shouldReturnProvenanceResources() {
 		IdType id = new IdType();

--- a/api/src/test/java/org/openmrs/module/fhir2/providers/r4/AllergyIntoleranceFhirResourceProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/providers/r4/AllergyIntoleranceFhirResourceProviderTest.java
@@ -137,7 +137,7 @@ public class AllergyIntoleranceFhirResourceProviderTest extends BaseFhirProvenan
 		when(service.searchForAllergies(argThat(is(patient)), isNull(), isNull(), isNull(), isNull(), isNull()))
 		        .thenReturn(Collections.singletonList(allergyIntolerance));
 		
-		Bundle results = resourceProvider.searchForAllergies(patient, null, null, null, null, null);
+		Bundle results = resourceProvider.searchForAllergies(patient,null, null, null, null, null, null);
 		assertThat(results, notNullValue());
 		assertThat(results.isResource(), is(true));
 		assertThat(results.getEntry().size(), greaterThanOrEqualTo(1));
@@ -151,7 +151,7 @@ public class AllergyIntoleranceFhirResourceProviderTest extends BaseFhirProvenan
 		when(service.searchForAllergies(argThat(is(patient)), isNull(), isNull(), isNull(), isNull(), isNull()))
 		        .thenReturn(Collections.singletonList(allergyIntolerance));
 		
-		Bundle results = resourceProvider.searchForAllergies(patient, null, null, null, null, null);
+		Bundle results = resourceProvider.searchForAllergies(patient,null, null, null, null, null, null);
 		assertThat(results, notNullValue());
 		assertThat(results.isResource(), is(true));
 		assertThat(results.getEntry().size(), greaterThanOrEqualTo(1));
@@ -165,7 +165,7 @@ public class AllergyIntoleranceFhirResourceProviderTest extends BaseFhirProvenan
 		when(service.searchForAllergies(argThat(is(patient)), isNull(), isNull(), isNull(), isNull(), isNull()))
 		        .thenReturn(Collections.singletonList(allergyIntolerance));
 		
-		Bundle results = resourceProvider.searchForAllergies(patient, null, null, null, null, null);
+		Bundle results = resourceProvider.searchForAllergies(patient,null, null, null, null, null, null);
 		assertThat(results, notNullValue());
 		assertThat(results.isResource(), is(true));
 		assertThat(results.getEntry().size(), greaterThanOrEqualTo(1));
@@ -180,7 +180,21 @@ public class AllergyIntoleranceFhirResourceProviderTest extends BaseFhirProvenan
 		when(service.searchForAllergies(argThat(is(patient)), isNull(), isNull(), isNull(), isNull(), isNull()))
 		        .thenReturn(Collections.singletonList(allergyIntolerance));
 		
-		Bundle results = resourceProvider.searchForAllergies(patient, null, null, null, null, null);
+		Bundle results = resourceProvider.searchForAllergies(patient,null, null, null, null, null, null);
+		assertThat(results, notNullValue());
+		assertThat(results.isResource(), is(true));
+		assertThat(results.getEntry().size(), greaterThanOrEqualTo(1));
+	}
+	
+	@Test
+	public void searchForAllergies_shouldReturnMatchingBundleOfAllergiesWhenPatientGivenNameIsSpecifiedAsSubject() {
+		ReferenceAndListParam subject = new ReferenceAndListParam();
+		subject.addValue(new ReferenceOrListParam().add(new ReferenceParam().setValue("John").setChain(Patient.SP_GIVEN)));
+		
+		when(service.searchForAllergies(argThat(is(subject)), isNull(), isNull(), isNull(), isNull(), isNull()))
+		        .thenReturn(Collections.singletonList(allergyIntolerance));
+		
+		Bundle results = resourceProvider.searchForAllergies(null,subject, null, null, null, null, null);
 		assertThat(results, notNullValue());
 		assertThat(results.isResource(), is(true));
 		assertThat(results.getEntry().size(), greaterThanOrEqualTo(1));
@@ -194,7 +208,7 @@ public class AllergyIntoleranceFhirResourceProviderTest extends BaseFhirProvenan
 		when(service.searchForAllergies(isNull(), argThat(is(category)), isNull(), isNull(), isNull(), isNull()))
 		        .thenReturn(Collections.singletonList(allergyIntolerance));
 		
-		Bundle results = resourceProvider.searchForAllergies(null, category, null, null, null, null);
+		Bundle results = resourceProvider.searchForAllergies(null,null, category, null, null, null, null);
 		assertThat(results, notNullValue());
 		assertThat(results.isResource(), is(true));
 		assertThat(results.getEntry().size(), greaterThanOrEqualTo(1));
@@ -208,7 +222,7 @@ public class AllergyIntoleranceFhirResourceProviderTest extends BaseFhirProvenan
 		when(service.searchForAllergies(isNull(), isNull(), argThat(is(allergen)), isNull(), isNull(), isNull()))
 		        .thenReturn(Collections.singletonList(allergyIntolerance));
 		
-		Bundle results = resourceProvider.searchForAllergies(null, null, allergen, null, null, null);
+		Bundle results = resourceProvider.searchForAllergies(null,null, null, allergen, null, null, null);
 		
 		assertThat(results, notNullValue());
 		assertThat(results.isResource(), is(true));
@@ -223,7 +237,7 @@ public class AllergyIntoleranceFhirResourceProviderTest extends BaseFhirProvenan
 		when(service.searchForAllergies(isNull(), isNull(), isNull(), argThat(is(severity)), isNull(), isNull()))
 		        .thenReturn(Collections.singletonList(allergyIntolerance));
 		
-		Bundle results = resourceProvider.searchForAllergies(null, null, null, severity, null, null);
+		Bundle results = resourceProvider.searchForAllergies(null,null, null, null, severity, null, null);
 		assertThat(results, notNullValue());
 		assertThat(results.isResource(), is(true));
 		assertThat(results.getEntry().size(), greaterThanOrEqualTo(1));
@@ -237,7 +251,7 @@ public class AllergyIntoleranceFhirResourceProviderTest extends BaseFhirProvenan
 		when(service.searchForAllergies(isNull(), isNull(), isNull(), isNull(), argThat(is(manifestation)), isNull()))
 		        .thenReturn(Collections.singletonList(allergyIntolerance));
 		
-		Bundle results = resourceProvider.searchForAllergies(null, null, null, null, manifestation, null);
+		Bundle results = resourceProvider.searchForAllergies(null,null, null, null, null, manifestation, null);
 		assertThat(results, notNullValue());
 		assertThat(results.isResource(), is(true));
 		assertThat(results.getEntry().size(), greaterThanOrEqualTo(1));
@@ -251,7 +265,7 @@ public class AllergyIntoleranceFhirResourceProviderTest extends BaseFhirProvenan
 		when(service.searchForAllergies(isNull(), isNull(), isNull(), isNull(), isNull(), argThat(is(status))))
 		        .thenReturn(Collections.singletonList(allergyIntolerance));
 		
-		Bundle results = resourceProvider.searchForAllergies(null, null, null, null, null, status);
+		Bundle results = resourceProvider.searchForAllergies(null,null, null, null, null, null, status);
 		assertThat(results, notNullValue());
 		assertThat(results.isResource(), is(true));
 		assertThat(results.getEntry().size(), greaterThanOrEqualTo(1));

--- a/api/src/test/java/org/openmrs/module/fhir2/providers/r4/DiagnosticReportFhirResourceProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/providers/r4/DiagnosticReportFhirResourceProviderTest.java
@@ -18,14 +18,21 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import ca.uhn.fhir.rest.api.MethodOutcome;
+import ca.uhn.fhir.rest.param.ReferenceAndListParam;
+import ca.uhn.fhir.rest.param.ReferenceOrListParam;
+import ca.uhn.fhir.rest.param.ReferenceParam;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.MethodNotAllowedException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import lombok.AccessLevel;
 import lombok.Getter;
+
+import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.DiagnosticReport;
 import org.hl7.fhir.r4.model.IdType;
@@ -145,7 +152,25 @@ public class DiagnosticReportFhirResourceProviderTest {
 		when(service.searchForDiagnosticReports(any(), any(), any(), any(), any()))
 		        .thenReturn(Collections.singletonList(diagnosticReport));
 		
-		Bundle results = resourceProvider.searchForDiagnosticReports(null, null, null, null, null);
+		Bundle results = resourceProvider.searchForDiagnosticReports(null, null,null, null, null, null);
+		
+		assertThat(results, notNullValue());
+		assertThat(results.isResource(), is(true));
+		assertThat(results.getEntry().size(), greaterThanOrEqualTo(1));
+		assertThat(results.getEntry().get(0).getResource().fhirType(), equalTo("DiagnosticReport"));
+		assertThat(results.getEntry().get(0).getResource().getId(), equalTo(UUID));
+	}
+
+	@Test
+	public void findDiagnosticReports_shouldReturnMatchingBundleOfDiagnosticReportsWhenSubjectIsSpecified() {
+	
+		ReferenceAndListParam subject = new ReferenceAndListParam();
+		subject.addValue(new ReferenceOrListParam().add(new ReferenceParam().setChain(Patient.SP_NAME)));
+	
+		when(service.searchForDiagnosticReports(any(), any(), any(), any(), any()))
+		        .thenReturn(Collections.singletonList(diagnosticReport));
+		
+		Bundle results = resourceProvider.searchForDiagnosticReports(null, null,subject, null, null, null);
 		
 		assertThat(results, notNullValue());
 		assertThat(results.isResource(), is(true));

--- a/api/src/test/java/org/openmrs/module/fhir2/providers/r4/EncounterFhirResourceProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/providers/r4/EncounterFhirResourceProviderTest.java
@@ -106,7 +106,7 @@ public class EncounterFhirResourceProviderTest extends BaseFhirProvenanceResourc
 		ReferenceAndListParam subjectreference = new ReferenceAndListParam();
 		subjectreference.addValue(new ReferenceOrListParam().add(new ReferenceParam().setChain(Patient.SP_NAME)));
 		
-		Bundle results = resourceProvider.searchEncounter(null, null, null, subjectreference);
+		Bundle results = resourceProvider.searchEncounter(null, null, null, subjectreference,null);
 		assertThat(results, notNullValue());
 		assertThat(results.getTotal(), equalTo(1));
 		assertThat(results.getEntry(), notNullValue());
@@ -114,6 +114,22 @@ public class EncounterFhirResourceProviderTest extends BaseFhirProvenanceResourc
 		assertThat(results.getEntry().get(0).getResource().getId(), equalTo(ENCOUNTER_UUID));
 	}
 	
+	@Test
+	public void searchEncounters_shouldReturnMatchingEncountersWhenPatientParamIsSpecified() {
+		List<org.hl7.fhir.r4.model.Encounter> encounters = new ArrayList<>();
+		encounters.add(encounter);
+		when(encounterService.searchForEncounters(any(), any(), any(), any())).thenReturn(encounters);
+		
+		ReferenceAndListParam patientParam = new ReferenceAndListParam();
+		patientParam.addValue(new ReferenceOrListParam().add(new ReferenceParam().setChain(Patient.SP_NAME)));
+		
+		Bundle results = resourceProvider.searchEncounter(null, null, null,null, patientParam);
+		assertThat(results, notNullValue());
+		assertThat(results.getTotal(), equalTo(1));
+		assertThat(results.getEntry(), notNullValue());
+		assertThat(results.getEntry().get(0).getResource().fhirType(), equalTo("Encounter"));
+		assertThat(results.getEntry().get(0).getResource().getId(), equalTo(ENCOUNTER_UUID));
+	}
 	@Test
 	public void getEncounterHistory_shouldReturnProvenanceResources() {
 		IdType id = new IdType();


### PR DESCRIPTION
https://issues.openmrs.org/browse/FM2-178
Added an option parameter "patient" that is evaluated before subject.
