### PR TITLE
FM2-193: Generate default narratives provided by HAPI FHIR

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhir2/FhirConstants.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/FhirConstants.java
@@ -201,4 +201,6 @@ public class FhirConstants {
 	public static final String LOCATION_REFERENCE_SEARCH_HANDLER = "location.reference.search.handler";
 	
 	public static final String TAG_SEARCH_HANDLER = "tag.search.handler";
+	
+	public static final String HAPI_DEFAULT_NARRATIVES_PROPERTY_FILE = "classpath:ca/uhn/fhir/narrative/narratives.properties";
 }

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -79,6 +79,18 @@
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.thymeleaf</groupId>
+			<artifactId>thymeleaf</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
@@ -12,6 +12,7 @@ package org.openmrs.module.fhir2.web.servlet;
 import java.util.Collection;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.narrative.CustomThymeleafNarrativeGenerator;
 import ca.uhn.fhir.rest.api.EncodingEnum;
 import ca.uhn.fhir.rest.server.FifoMemoryPagingProvider;
 import ca.uhn.fhir.rest.server.IResourceProvider;
@@ -60,6 +61,9 @@ public class FhirRestServlet extends RestfulServer {
 		setPagingProvider(pp);
 		setDefaultResponseEncoding(EncodingEnum.JSON);
 		registerInterceptor(loggingInterceptor);
+		
+		getFhirContext().setNarrativeGenerator(
+		    new CustomThymeleafNarrativeGenerator(FhirConstants.HAPI_DEFAULT_NARRATIVES_PROPERTY_FILE));
 	}
 	
 	@Override

--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,22 @@
 				<version>2.0.7</version>
 				<scope>test</scope>
 			</dependency>
+			<dependency>
+				<groupId>org.thymeleaf</groupId>
+				<artifactId>thymeleaf</artifactId>
+				<version>3.0.11.RELEASE</version>
+			</dependency>
+			<dependency>
+				<groupId>commons-io</groupId>
+				<artifactId>commons-io</artifactId>
+				<version>2.6</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.github.ben-manes.caffeine</groupId>
+				<artifactId>caffeine</artifactId>
+				<version>2.8.2</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,22 @@
 				<scope>test</scope>
 			</dependency>
 			<dependency>
+				<groupId>org.thymeleaf</groupId>
+				<artifactId>thymeleaf</artifactId>
+				<version>3.0.11.RELEASE</version>
+			</dependency>
+			<dependency>
+				<groupId>commons-io</groupId>
+				<artifactId>commons-io</artifactId>
+				<version>2.6</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.github.ben-manes.caffeine</groupId>
+				<artifactId>caffeine</artifactId>
+				<version>2.8.2</version>
+			</dependency>
+			<dependency>
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
 				<version>4.13</version>
@@ -267,22 +283,6 @@
 				<artifactId>hamcrest-date</artifactId>
 				<version>2.0.7</version>
 				<scope>test</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.thymeleaf</groupId>
-				<artifactId>thymeleaf</artifactId>
-				<version>3.0.11.RELEASE</version>
-			</dependency>
-			<dependency>
-				<groupId>commons-io</groupId>
-				<artifactId>commons-io</artifactId>
-				<version>2.6</version>
-				<scope>provided</scope>
-			</dependency>
-			<dependency>
-				<groupId>com.github.ben-manes.caffeine</groupId>
-				<artifactId>caffeine</artifactId>
-				<version>2.8.2</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
## Description of what I changed
Set Thymeleaf Narrative Generator (with `propFile` as the properties file of HAPI FHIR) while initialising `FhirRestServlet`.

## Issue I worked on
see https://issues.openmrs.org/browse/FM2-193

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.
