### PR TITLE
FM2-251: Add support for overriding default narratives

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhir2/FhirConstants.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/FhirConstants.java
@@ -218,6 +218,8 @@ public class FhirConstants {
 	
 	public static final String OPENMRS_NARRATIVES_PROPERTY_FILE = "classpath:org/openmrs/module/fhir2/narratives.properties";
 	
+	public static final String NARRATIVES_OVERRIDE_PROPERTY_FILE = "fhir2.narrativesOverridePropertyFile";
+	
 	public static final String ALLERGEN_SEARCH_HANDLER = "allergen.search.handler";
 	
 	public static final String SEVERITY_SEARCH_HANDLER = "severity.search.handler";

--- a/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
@@ -62,8 +62,15 @@ public class FhirRestServlet extends RestfulServer {
 		setDefaultResponseEncoding(EncodingEnum.JSON);
 		registerInterceptor(loggingInterceptor);
 		
-		getFhirContext().setNarrativeGenerator(new CustomThymeleafNarrativeGenerator(
-		        FhirConstants.HAPI_NARRATIVES_PROPERTY_FILE, FhirConstants.OPENMRS_NARRATIVES_PROPERTY_FILE));
+		String narrativeOverridePropertyFile = globalPropertyService
+		        .getGlobalProperty(FhirConstants.NARRATIVES_OVERRIDE_PROPERTY_FILE, "");
+		if (narrativeOverridePropertyFile.isEmpty()) {
+			getFhirContext().setNarrativeGenerator(new CustomThymeleafNarrativeGenerator(
+			        FhirConstants.HAPI_NARRATIVES_PROPERTY_FILE, FhirConstants.OPENMRS_NARRATIVES_PROPERTY_FILE));
+		} else {
+			getFhirContext().setNarrativeGenerator(new CustomThymeleafNarrativeGenerator(narrativeOverridePropertyFile,
+			        FhirConstants.HAPI_NARRATIVES_PROPERTY_FILE, FhirConstants.OPENMRS_NARRATIVES_PROPERTY_FILE));
+		}
 	}
 	
 	@Override

--- a/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
@@ -9,7 +9,10 @@
  */
 package org.openmrs.module.fhir2.web.servlet;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.narrative.CustomThymeleafNarrativeGenerator;
@@ -62,15 +65,12 @@ public class FhirRestServlet extends RestfulServer {
 		setDefaultResponseEncoding(EncodingEnum.JSON);
 		registerInterceptor(loggingInterceptor);
 		
-		String narrativeOverridePropertyFile = globalPropertyService
-		        .getGlobalProperty(FhirConstants.NARRATIVES_OVERRIDE_PROPERTY_FILE, "");
-		if (narrativeOverridePropertyFile.isEmpty()) {
-			getFhirContext().setNarrativeGenerator(new CustomThymeleafNarrativeGenerator(
-			        FhirConstants.HAPI_NARRATIVES_PROPERTY_FILE, FhirConstants.OPENMRS_NARRATIVES_PROPERTY_FILE));
-		} else {
-			getFhirContext().setNarrativeGenerator(new CustomThymeleafNarrativeGenerator(narrativeOverridePropertyFile,
-			        FhirConstants.HAPI_NARRATIVES_PROPERTY_FILE, FhirConstants.OPENMRS_NARRATIVES_PROPERTY_FILE));
-		}
+		List<String> propertyFiles = new ArrayList<>(
+		        Arrays.asList(globalPropertyService.getGlobalProperty(FhirConstants.NARRATIVES_OVERRIDE_PROPERTY_FILE, ""),
+		            FhirConstants.HAPI_NARRATIVES_PROPERTY_FILE, FhirConstants.OPENMRS_NARRATIVES_PROPERTY_FILE));
+		propertyFiles.removeAll(Arrays.asList("", null));
+		getFhirContext().setNarrativeGenerator(
+		    new CustomThymeleafNarrativeGenerator(propertyFiles.toArray(new String[propertyFiles.size()])));
 	}
 	
 	@Override

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -128,5 +128,10 @@
 		<description>Set provider attribute type uuid</description>
 	</globalProperty>
 
-</module>
+	<globalProperty>
+		<property>${project.parent.artifactId}.narrativesOverridePropertyFile</property>
+		<defaultValue></defaultValue>
+		<description>Absolute path of narrative override properties file (prefixed with "file:")</description>
+	</globalProperty>
 
+</module>


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'FM2-8: Implement the Person Resource' -->
<!--- 'FM2-JiraIssueNumber: JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
Added support for overriding default narratives, with the narrative override property file location to be stored as the global property `narrativesOverridePropertyFile`.

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/FM2-251

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.