### PR TITLE
fixes version determination for /ms/ paths

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhir2/FhirConstants.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/FhirConstants.java
@@ -235,4 +235,8 @@ public class FhirConstants {
 	public static final String ID_PROPERTY = "_id.property";
 	
 	public static final String LAST_UPDATED_PROPERTY = "_lastUpdated.property";
+	
+	public static final String SERVLET_PATH_R4 = "/ms/fhir2Servlet";
+	
+	public static final String SERVLET_PATH_R3 = "/ms/fhir2R3Servlet";
 }

--- a/omod/src/main/java/org/openmrs/module/fhir2/web/filter/ForwardingFilter.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/web/filter/ForwardingFilter.java
@@ -21,6 +21,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 import lombok.extern.slf4j.Slf4j;
+import org.openmrs.module.fhir2.FhirConstants;
 import org.openmrs.module.fhir2.web.util.FhirVersionUtils;
 
 @Slf4j
@@ -44,11 +45,11 @@ public class ForwardingFilter implements Filter {
 			switch (fhirVersion) {
 				case R3:
 					prefix.append(fhirVersion.toString());
-					replacement = "/ms/fhir2R3Servlet";
+					replacement = FhirConstants.SERVLET_PATH_R3;
 					break;
 				case R4:
 					prefix.append(fhirVersion.toString());
-					replacement = "/ms/fhir2Servlet";
+					replacement = FhirConstants.SERVLET_PATH_R4;
 					break;
 				default:
 					((HttpServletResponse) res).sendError(HttpServletResponse.SC_NOT_FOUND);

--- a/omod/src/main/java/org/openmrs/module/fhir2/web/util/FhirVersionUtils.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/web/util/FhirVersionUtils.java
@@ -11,6 +11,10 @@ package org.openmrs.module.fhir2.web.util;
 
 import javax.servlet.http.HttpServletRequest;
 
+import lombok.extern.slf4j.Slf4j;
+import org.openmrs.module.fhir2.FhirConstants;
+
+@Slf4j
 public class FhirVersionUtils {
 	
 	public enum FhirVersion {
@@ -34,6 +38,8 @@ public class FhirVersionUtils {
 					String version = requestURI.substring(prefixEnd, pathIdx);
 					
 					if (version.isEmpty()) {
+						log.error(String.format("Could not determine FHIR version for URI %s and path %s.", requestURI,
+						    contextPath));
 						return FhirVersion.UNKNOWN;
 					}
 					
@@ -47,12 +53,22 @@ public class FhirVersionUtils {
 						case "R4":
 							return FhirVersion.R4;
 						default:
+							log.error(String.format("Could not determine FHIR version for URI %s and path %s.", requestURI,
+							    contextPath));
 							return FhirVersion.UNKNOWN;
 					}
 				}
 			}
 		}
 		
+		if (requestURI.startsWith(contextPath + FhirConstants.SERVLET_PATH_R4)) {
+			return FhirVersion.R4;
+		}
+		if (requestURI.startsWith(contextPath + FhirConstants.SERVLET_PATH_R3)) {
+			return FhirVersion.R3;
+		}
+		
+		log.error(String.format("Could not determine FHIR version for URI %s and path %s.", requestURI, contextPath));
 		return FhirVersion.UNKNOWN;
 	}
 }

--- a/omod/src/test/java/org/openmrs/module/fhir2/web/util/FhirVersionUtilsTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/web/util/FhirVersionUtilsTest.java
@@ -1,0 +1,69 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.fhir2.web.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openmrs.module.fhir2.web.util.FhirVersionUtils.FhirVersion;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FhirVersionUtilsTest {
+	
+	@Mock
+	private HttpServletRequest httpServletRequest;
+	
+	@Test
+	public void shouldReturnR4ForWs() {
+		when(httpServletRequest.getRequestURI()).thenReturn("/openmrs/ws/fhir2/R4/Patient");
+		when(httpServletRequest.getContextPath()).thenReturn("/openmrs");
+		FhirVersion version = FhirVersionUtils.getFhirVersion(httpServletRequest);
+		assertThat(version, equalTo(FhirVersion.R4));
+	}
+	
+	@Test
+	public void shouldReturnR3ForWs() {
+		when(httpServletRequest.getRequestURI()).thenReturn("/openmrs/ws/fhir2/R3/Patient");
+		when(httpServletRequest.getContextPath()).thenReturn("/openmrs");
+		FhirVersion version = FhirVersionUtils.getFhirVersion(httpServletRequest);
+		assertThat(version, equalTo(FhirVersion.R3));
+	}
+	
+	@Test
+	public void shouldReturnUnknowForWs() {
+		when(httpServletRequest.getRequestURI()).thenReturn("/openmrs/ws/fhir2/Patient");
+		when(httpServletRequest.getContextPath()).thenReturn("/openmrs");
+		FhirVersion version = FhirVersionUtils.getFhirVersion(httpServletRequest);
+		assertThat(version, equalTo(FhirVersion.UNKNOWN));
+	}
+	
+	@Test
+	public void shouldReturnR4ForMs() {
+		when(httpServletRequest.getRequestURI()).thenReturn("/openmrs/ms/fhir2Servlet/Patient");
+		when(httpServletRequest.getContextPath()).thenReturn("/openmrs");
+		FhirVersion version = FhirVersionUtils.getFhirVersion(httpServletRequest);
+		assertThat(version, equalTo(FhirVersion.R4));
+	}
+	
+	@Test
+	public void shouldReturnR3ForMs() {
+		when(httpServletRequest.getRequestURI()).thenReturn("/openmrs/ms/fhir2R3Servlet/Patient");
+		when(httpServletRequest.getContextPath()).thenReturn("/openmrs");
+		FhirVersion version = FhirVersionUtils.getFhirVersion(httpServletRequest);
+		assertThat(version, equalTo(FhirVersion.R3));
+	}
+}


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'FM2-8: Implement the Person Resource' -->
<!--- 'FM2-JiraIssueNumber: JiraIssueTitle' -->
## Description of what I changed
When the /ws/* paths are forwarded to /ms/* ones, FHIR version determination fails which causes the mentioned bug. This change fixes that bug.
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/FM2-259

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
