### PR TITLE
FM2-252: Add support for relative path with prefix 'openmrs:' for narrative templates

### DIFF
--- a/omod/src/main/java/org/openmrs/module/fhir2/narrative/OpenMRSNarrativeTemplate.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/narrative/OpenMRSNarrativeTemplate.java
@@ -1,0 +1,124 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+/*
+ * This class is derived and modified from the HAPI FHIR Core Library under the
+ * terms of the Apache License, Version 2.0. You may obtain a copy of the
+ * License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * The portions of this class that have not been modified by OpenMRS are
+ * Copyright (C) 2014 - 2020 University Health Network.
+ */
+
+package org.openmrs.module.fhir2.narrative;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import ca.uhn.fhir.narrative2.INarrativeTemplate;
+import ca.uhn.fhir.narrative2.TemplateTypeEnum;
+import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
+import org.hl7.fhir.instance.model.api.IBase;
+
+public class OpenMRSNarrativeTemplate implements INarrativeTemplate {
+	
+	private String contextPath;
+	
+	private Set<String> appliesToProfiles = new HashSet<>();
+	
+	private Set<String> appliesToResourceTypes = new HashSet<>();
+	
+	private Set<Class<? extends IBase>> appliesToResourceClasses = new HashSet<>();
+	
+	private TemplateTypeEnum templateType = TemplateTypeEnum.THYMELEAF;
+	
+	private String templateName;
+	
+	private String templateFilename;
+	
+	private Set<String> appliesToDatatypes = new HashSet<>();
+	
+	@Override
+	public String getContextPath() {
+		return this.contextPath;
+	}
+	
+	protected void setContextPath(String contextPath) {
+		this.contextPath = contextPath;
+	}
+	
+	@Override
+	public Set<String> getAppliesToProfiles() {
+		return Collections.unmodifiableSet(this.appliesToProfiles);
+	}
+	
+	protected void addAppliesToProfile(String profile) {
+		this.appliesToProfiles.add(profile);
+	}
+	
+	@Override
+	public Set<String> getAppliesToResourceTypes() {
+		return Collections.unmodifiableSet(this.appliesToResourceTypes);
+	}
+	
+	protected void addAppliesToResourceType(String resourceType) {
+		this.appliesToResourceTypes.add(resourceType);
+	}
+	
+	@Override
+	public Set<Class<? extends IBase>> getAppliesToResourceClasses() {
+		return Collections.unmodifiableSet(this.appliesToResourceClasses);
+	}
+	
+	@Override
+	public TemplateTypeEnum getTemplateType() {
+		return this.templateType;
+	}
+	
+	protected void setTemplateType(TemplateTypeEnum templateType) {
+		this.templateType = templateType;
+	}
+	
+	@Override
+	public String getTemplateName() {
+		return this.templateName;
+	}
+	
+	protected OpenMRSNarrativeTemplate setTemplateName(String templateName) {
+		this.templateName = templateName;
+		return this;
+	}
+	
+	@Override
+	public String getTemplateText() {
+		try {
+			return OpenMRSNarrativeTemplateManifest.loadResource(this.templateFilename);
+		}
+		catch (IOException e) {
+			throw new InternalErrorException(e);
+		}
+	}
+	
+	protected void setTemplateFileName(String templateFileName) {
+		this.templateFilename = templateFileName;
+	}
+	
+	public Set<String> getAppliesToDataTypes() {
+		return Collections.unmodifiableSet(this.appliesToDatatypes);
+	}
+	
+	protected void addAppliesToDatatype(String dataType) {
+		this.appliesToDatatypes.add(dataType);
+	}
+}

--- a/omod/src/main/java/org/openmrs/module/fhir2/narrative/OpenMRSNarrativeTemplateManifest.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/narrative/OpenMRSNarrativeTemplateManifest.java
@@ -1,0 +1,231 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+/*
+ * This class is derived and modified from the HAPI FHIR Core Library under the
+ * terms of the Apache License, Version 2.0. You may obtain a copy of the
+ * License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * The portions of this class that have not been modified by OpenMRS are
+ * Copyright (C) 2014 - 2020 University Health Network.
+ */
+
+package org.openmrs.module.fhir2.narrative;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+import ca.uhn.fhir.context.ConfigurationException;
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.narrative.DefaultThymeleafNarrativeGenerator;
+import ca.uhn.fhir.narrative2.INarrativeTemplate;
+import ca.uhn.fhir.narrative2.INarrativeTemplateManifest;
+import ca.uhn.fhir.narrative2.TemplateTypeEnum;
+import com.google.common.base.Charsets;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
+import org.hl7.fhir.instance.model.api.IBase;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.openmrs.util.OpenmrsUtil;
+
+@Slf4j
+public class OpenMRSNarrativeTemplateManifest implements INarrativeTemplateManifest {
+	
+	private final Map<String, List<OpenMRSNarrativeTemplate>> styleToResourceTypeToTemplate;
+	
+	private final Map<String, List<OpenMRSNarrativeTemplate>> styleToDatatypeToTemplate;
+	
+	private final Map<String, List<OpenMRSNarrativeTemplate>> styleToNameToTemplate;
+	
+	private OpenMRSNarrativeTemplateManifest(Collection<OpenMRSNarrativeTemplate> templates) {
+		Map<String, List<OpenMRSNarrativeTemplate>> resourceTypeToTemplate = new HashMap<>();
+		Map<String, List<OpenMRSNarrativeTemplate>> datatypeToTemplate = new HashMap<>();
+		Map<String, List<OpenMRSNarrativeTemplate>> nameToTemplate = new HashMap<>();
+		
+		for (OpenMRSNarrativeTemplate nextTemplate : templates) {
+			nameToTemplate.computeIfAbsent(nextTemplate.getTemplateName(), t -> new ArrayList<>()).add(nextTemplate);
+			for (String nextResourceType : nextTemplate.getAppliesToResourceTypes()) {
+				resourceTypeToTemplate.computeIfAbsent(nextResourceType.toUpperCase(), t -> new ArrayList<>())
+				        .add(nextTemplate);
+			}
+			for (String nextDataType : nextTemplate.getAppliesToDataTypes()) {
+				datatypeToTemplate.computeIfAbsent(nextDataType.toUpperCase(), t -> new ArrayList<>()).add(nextTemplate);
+			}
+		}
+		
+		styleToNameToTemplate = makeImmutable(nameToTemplate);
+		styleToResourceTypeToTemplate = makeImmutable(resourceTypeToTemplate);
+		styleToDatatypeToTemplate = makeImmutable(datatypeToTemplate);
+	}
+	
+	@Override
+	public List<INarrativeTemplate> getTemplateByResourceName(FhirContext fhirContext, EnumSet<TemplateTypeEnum> styles,
+	        String resourceName) {
+		return getFromMap(styles, resourceName.toUpperCase(), styleToResourceTypeToTemplate);
+	}
+	
+	@Override
+	public List<INarrativeTemplate> getTemplateByName(FhirContext fhirContext, EnumSet<TemplateTypeEnum> styles,
+	        String name) {
+		return getFromMap(styles, name, styleToNameToTemplate);
+	}
+	
+	@Override
+	public List<INarrativeTemplate> getTemplateByElement(FhirContext fhirContext, EnumSet<TemplateTypeEnum> styles,
+	        IBase element) {
+		if (element instanceof IBaseResource) {
+			String resourceName = fhirContext.getResourceDefinition((IBaseResource) element).getName();
+			return getTemplateByResourceName(fhirContext, styles, resourceName);
+		}
+		String datatypeName = fhirContext.getElementDefinition(element.getClass()).getName();
+		return getFromMap(styles, datatypeName.toUpperCase(), styleToDatatypeToTemplate);
+	}
+	
+	public static OpenMRSNarrativeTemplateManifest forManifestFileLocation(Collection<String> propertyFilePaths)
+	        throws IOException {
+		log.debug("Loading narrative properties file(s): {}", propertyFilePaths);
+		List<String> manifestFileContents = new ArrayList<>(propertyFilePaths.size());
+		for (String next : propertyFilePaths) {
+			String resource = loadResource(next);
+			manifestFileContents.add(resource);
+		}
+		return forManifestFileContents(manifestFileContents);
+	}
+	
+	public static OpenMRSNarrativeTemplateManifest forManifestFileContents(Collection<String> resources) throws IOException {
+		List<OpenMRSNarrativeTemplate> templates = new ArrayList<>();
+		for (String next : resources) {
+			templates.addAll(loadProperties(next));
+		}
+		return new OpenMRSNarrativeTemplateManifest(templates);
+	}
+	
+	private static Collection<OpenMRSNarrativeTemplate> loadProperties(String manifestText) throws IOException {
+		Map<String, OpenMRSNarrativeTemplate> nameToTemplate = new HashMap<>();
+		
+		Properties file = new Properties();
+		
+		file.load(new StringReader(manifestText));
+		for (Object nextKeyObj : file.keySet()) {
+			String nextKey = (String) nextKeyObj;
+			Validate.isTrue(StringUtils.countMatches(nextKey, ".") == 1, "Invalid narrative property file key: %s", nextKey);
+			String name = nextKey.substring(0, nextKey.indexOf('.'));
+			Validate.notBlank(name, "Invalid narrative property file key: %s", nextKey);
+			
+			OpenMRSNarrativeTemplate nextTemplate = nameToTemplate.computeIfAbsent(name,
+			    t -> new OpenMRSNarrativeTemplate().setTemplateName(name));
+			
+			Validate.isTrue(!nextKey.endsWith(".class"),
+			    "Narrative manifest does not support specifying templates by class name - Use \"[name].resourceType=[resourceType]\" instead");
+			
+			if (nextKey.endsWith(".profile")) {
+				String profile = file.getProperty(nextKey);
+				if (isNotBlank(profile)) {
+					nextTemplate.addAppliesToProfile(profile);
+				}
+			} else if (nextKey.endsWith(".resourceType")) {
+				String resourceType = file.getProperty(nextKey);
+				Arrays.stream(resourceType.split(",")).map(t -> t.trim()).filter(t -> isNotBlank(t))
+				        .forEach(t -> nextTemplate.addAppliesToResourceType(t));
+			} else if (nextKey.endsWith(".dataType")) {
+				String dataType = file.getProperty(nextKey);
+				Arrays.stream(dataType.split(",")).map(t -> t.trim()).filter(t -> isNotBlank(t))
+				        .forEach(t -> nextTemplate.addAppliesToDatatype(t));
+			} else if (nextKey.endsWith(".style")) {
+				String templateTypeName = file.getProperty(nextKey).toUpperCase();
+				TemplateTypeEnum templateType = TemplateTypeEnum.valueOf(templateTypeName);
+				nextTemplate.setTemplateType(templateType);
+			} else if (nextKey.endsWith(".contextPath")) {
+				String contextPath = file.getProperty(nextKey);
+				nextTemplate.setContextPath(contextPath);
+			} else if (nextKey.endsWith(".narrative")) {
+				String narrativePropName = name + ".narrative";
+				String narrativeName = file.getProperty(narrativePropName);
+				if (isNotBlank(narrativeName)) {
+					nextTemplate.setTemplateFileName(narrativeName);
+				}
+			} else if (nextKey.endsWith(".title")) {
+				log.debug("Ignoring title property as narrative generator no longer generates titles: {}", nextKey);
+			} else {
+				throw new ConfigurationException("Invalid property name: " + nextKey
+				        + " - the key must end in one of the expected extensions "
+				        + "'.profile', '.resourceType', '.dataType', '.style', '.contextPath', '.narrative', '.title'");
+			}
+		}
+		return nameToTemplate.values();
+	}
+	
+	static String loadResource(String name) throws IOException {
+		if (name.startsWith("classpath:")) {
+			String cpName = name.substring("classpath:".length());
+			try (InputStream resource = DefaultThymeleafNarrativeGenerator.class.getResourceAsStream(cpName)) {
+				if (resource == null) {
+					try (InputStream resource2 = DefaultThymeleafNarrativeGenerator.class
+					        .getResourceAsStream("/" + cpName)) {
+						if (resource2 == null) {
+							throw new IOException("Can not find '" + cpName + "' on classpath");
+						}
+						return IOUtils.toString(resource2, Charsets.UTF_8);
+					}
+				}
+				return IOUtils.toString(resource, Charsets.UTF_8);
+			}
+		} else if (name.startsWith("file:")) {
+			File file = new File(name.substring("file:".length()));
+			if (file.exists() == false) {
+				throw new IOException("File not found: " + file.getAbsolutePath());
+			}
+			try (FileInputStream inputStream = new FileInputStream(file)) {
+				return IOUtils.toString(inputStream, Charsets.UTF_8);
+			}
+		} else if (name.startsWith("openmrs:")) {
+			File file = new File(OpenmrsUtil.getApplicationDataDirectory(), name.substring("openmrs:".length()));
+			if (file.exists() == false) {
+				throw new IOException("File not found: " + file.getAbsolutePath());
+			}
+			try (FileInputStream inputStream = new FileInputStream(file)) {
+				return IOUtils.toString(inputStream, Charsets.UTF_8);
+			}
+		} else {
+			throw new IOException("Invalid resource name: '" + name + "' (must start with classpath: or file: or openmrs:)");
+		}
+	}
+	
+	private static <T> List<INarrativeTemplate> getFromMap(EnumSet<TemplateTypeEnum> styles, T key,
+	        Map<T, List<OpenMRSNarrativeTemplate>> map) {
+		return map.getOrDefault(key, Collections.emptyList()).stream().filter(t -> styles.contains(t.getTemplateType()))
+		        .collect(Collectors.toList());
+	}
+	
+	private static <T> Map<T, List<OpenMRSNarrativeTemplate>> makeImmutable(
+	        Map<T, List<OpenMRSNarrativeTemplate>> styleToResourceTypeToTemplate) {
+		styleToResourceTypeToTemplate.replaceAll((key, value) -> Collections.unmodifiableList(value));
+		return Collections.unmodifiableMap(styleToResourceTypeToTemplate);
+	}
+}

--- a/omod/src/main/java/org/openmrs/module/fhir2/narrative/OpenMRSThymeleafNarrativeGenerator.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/narrative/OpenMRSThymeleafNarrativeGenerator.java
@@ -1,0 +1,78 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+/*
+ * This class is derived and modified from the HAPI FHIR Core Library under the
+ * terms of the Apache License, Version 2.0. You may obtain a copy of the
+ * License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * The portions of this class that have not been modified by OpenMRS are
+ * Copyright (C) 2014 - 2020 University Health Network.
+ */
+
+package org.openmrs.module.fhir2.narrative;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.narrative2.ThymeleafNarrativeGenerator;
+import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
+import org.apache.commons.lang.Validate;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+
+public class OpenMRSThymeleafNarrativeGenerator extends ThymeleafNarrativeGenerator {
+	
+	private boolean isInitialized;
+	
+	private List<String> propertyFile;
+	
+	public OpenMRSThymeleafNarrativeGenerator(String... thePropertyFile) {
+		super();
+		setPropertyFile(thePropertyFile);
+	}
+	
+	public void setPropertyFile(String... propertyFile) {
+		Validate.notNull(propertyFile, "Property file can not be null");
+		this.propertyFile = Arrays.asList(propertyFile);
+	}
+	
+	public List<String> getPropertyFile() {
+		return propertyFile;
+	}
+	
+	@Override
+	public boolean populateResourceNarrative(FhirContext theFhirContext, IBaseResource theResource) {
+		if (!isInitialized) {
+			initialize();
+		}
+		super.populateResourceNarrative(theFhirContext, theResource);
+		return false;
+	}
+	
+	private synchronized void initialize() {
+		if (!isInitialized) {
+			List<String> propertyFile = getPropertyFile();
+			try {
+				OpenMRSNarrativeTemplateManifest manifest = OpenMRSNarrativeTemplateManifest
+				        .forManifestFileLocation(propertyFile);
+				setManifest(manifest);
+			}
+			catch (IOException e) {
+				throw new InternalErrorException(e);
+			}
+			
+			isInitialized = true;
+		}
+	}
+}

--- a/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
@@ -12,7 +12,6 @@ package org.openmrs.module.fhir2.web.servlet;
 import java.util.Collection;
 
 import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.narrative.CustomThymeleafNarrativeGenerator;
 import ca.uhn.fhir.rest.api.EncodingEnum;
 import ca.uhn.fhir.rest.server.FifoMemoryPagingProvider;
 import ca.uhn.fhir.rest.server.IResourceProvider;
@@ -24,6 +23,7 @@ import lombok.Setter;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.openmrs.module.fhir2.FhirConstants;
 import org.openmrs.module.fhir2.api.FhirGlobalPropertyService;
+import org.openmrs.module.fhir2.narrative.OpenMRSThymeleafNarrativeGenerator;
 import org.openmrs.module.fhir2.web.util.NarrativeUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -75,7 +75,7 @@ public class FhirRestServlet extends RestfulServer {
 			        FhirConstants.OPENMRS_NARRATIVES_PROPERTY_FILE };
 		}
 		
-		getFhirContext().setNarrativeGenerator(new CustomThymeleafNarrativeGenerator(narrativePropertiesFiles));
+		getFhirContext().setNarrativeGenerator(new OpenMRSThymeleafNarrativeGenerator(narrativePropertiesFiles));
 	}
 	
 	@Override

--- a/omod/src/main/java/org/openmrs/module/fhir2/web/util/NarrativeUtils.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/web/util/NarrativeUtils.java
@@ -37,6 +37,13 @@ public class NarrativeUtils {
 				log.error("Properties File classpath must not be empty");
 				return false;
 			}
+		} else if (path.startsWith("openmrs:")) {
+			String openmrsRelativePath = path.substring("openmrs:".length());
+			
+			if (openmrsRelativePath == null || openmrsRelativePath.trim().isEmpty()) {
+				log.error("Properties File OpenMRS relative path must not be empty");
+				return false;
+			}
 		}
 		
 		return true;
@@ -47,9 +54,9 @@ public class NarrativeUtils {
 			return null;
 		}
 		
-		// add "file:" prefix if the path doesn't start with "classpath:" or "file:"
-		// since NarrativeTemplateManifest.loadResource() method requires one of these prefixes
-		if (!(path.startsWith("file:") || path.startsWith("classpath:"))) {
+		// add "file:" prefix if the path doesn't start with "classpath:" or "file:" or "openmrs:"
+		// since OpenMRSNarrativeTemplateManifest.loadResource() method requires one of these prefixes
+		if (!(path.startsWith("file:") || path.startsWith("classpath:") || path.startsWith("openmrs:"))) {
 			path = "file:" + path;
 		}
 		

--- a/omod/src/test/java/org/openmrs/module/fhir2/narrative/BaseFhirNarrativeTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/narrative/BaseFhirNarrativeTest.java
@@ -14,7 +14,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.TimeZone;
 
 import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.narrative.CustomThymeleafNarrativeGenerator;
 import ca.uhn.fhir.parser.IParser;
 import org.apache.commons.io.IOUtils;
 import org.junit.AfterClass;
@@ -38,7 +37,7 @@ public class BaseFhirNarrativeTest {
 	
 	@Before
 	public void setup() {
-		ctx.setNarrativeGenerator(new CustomThymeleafNarrativeGenerator(FhirConstants.HAPI_NARRATIVES_PROPERTY_FILE,
+		ctx.setNarrativeGenerator(new OpenMRSThymeleafNarrativeGenerator(FhirConstants.HAPI_NARRATIVES_PROPERTY_FILE,
 		        FhirConstants.OPENMRS_NARRATIVES_PROPERTY_FILE));
 		parser = ctx.newJsonParser();
 	}

--- a/omod/src/test/java/org/openmrs/module/fhir2/narrative/NarrativeGeneratorTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/narrative/NarrativeGeneratorTest.java
@@ -1,0 +1,123 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.fhir2.narrative;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Set;
+
+import ca.uhn.fhir.context.ConfigurationException;
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.narrative2.INarrativeTemplate;
+import ca.uhn.fhir.narrative2.TemplateTypeEnum;
+import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
+import org.hl7.fhir.r4.model.BaseResource;
+import org.hl7.fhir.r4.model.Patient;
+import org.junit.Test;
+import org.openmrs.util.OpenmrsUtil;
+
+public class NarrativeGeneratorTest {
+	
+	protected final FhirContext ctx = FhirContext.forR4();
+	
+	protected final BaseResource dummyResource = new Patient();
+	
+	@Test
+	public void shouldThrowIOExcpetionWhenNoValidPrefixInPath() {
+		String givenPath = "some/random/path/without/prefix.properties";
+		ctx.setNarrativeGenerator(new OpenMRSThymeleafNarrativeGenerator(givenPath));
+		
+		String expectedErrorMessage = "Invalid resource name: '" + givenPath
+		        + "' (must start with classpath: or file: or openmrs:)";
+		
+		Throwable e = assertThrows(InternalErrorException.class,
+		    () -> ctx.getNarrativeGenerator().populateResourceNarrative(ctx, dummyResource));
+		assertEquals(e.getMessage(), expectedErrorMessage);
+	}
+	
+	@Test
+	public void shouldThrowIOExcpetionForIncorrectClassPath() {
+		String givenPath = "classpath:some/random/class/path.properties";
+		ctx.setNarrativeGenerator(new OpenMRSThymeleafNarrativeGenerator(givenPath));
+		
+		String expectedErrorMessage = "Can not find '" + givenPath.substring("classpath:".length()) + "' on classpath";
+		
+		Throwable e = assertThrows(InternalErrorException.class,
+		    () -> ctx.getNarrativeGenerator().populateResourceNarrative(ctx, dummyResource));
+		assertEquals(e.getMessage(), expectedErrorMessage);
+	}
+	
+	@Test
+	public void shouldThrowIOExcpetionForIncorrectFilePath() {
+		String givenPath = "file:some/random/file/path.properties";
+		ctx.setNarrativeGenerator(new OpenMRSThymeleafNarrativeGenerator(givenPath));
+		
+		File file = new File(givenPath.substring("file:".length()));
+		String expectedErrorMessage = "File not found: " + file.getAbsolutePath();
+		
+		Throwable e = assertThrows(InternalErrorException.class,
+		    () -> ctx.getNarrativeGenerator().populateResourceNarrative(ctx, dummyResource));
+		assertEquals(e.getMessage(), expectedErrorMessage);
+	}
+	
+	@Test
+	public void shouldThrowIOExcpetionForIncorrectOpenmrsPath() {
+		String givenPath = "openmrs:some/random/openmrs/path.properties";
+		ctx.setNarrativeGenerator(new OpenMRSThymeleafNarrativeGenerator(givenPath));
+		
+		File file = new File(OpenmrsUtil.getApplicationDataDirectory(), givenPath.substring("openmrs:".length()));
+		String expectedErrorMessage = "File not found: " + file.getAbsolutePath();
+		
+		Throwable e = assertThrows(InternalErrorException.class,
+		    () -> ctx.getNarrativeGenerator().populateResourceNarrative(ctx, dummyResource));
+		assertEquals(e.getMessage(), expectedErrorMessage);
+	}
+	
+	@Test
+	public void shouldMapValuesFromPropertiesFileToTemplate() throws IOException {
+		String testNarrativePropFile = "classpath:org/openmrs/module/fhir2/narrative/testNarratives.properties";
+		Set<String> expectedProfiles = new HashSet<>();
+		expectedProfiles.add("testProfile");
+		Set<String> expectedResourceType = new HashSet<>();
+		expectedResourceType.add("testResourceType");
+		TemplateTypeEnum expectedTemplateType = TemplateTypeEnum.THYMELEAF;
+		String expectedContextPath = "testContextPath";
+		String expectedNarrative = "<div>testNarrativeContent</div>\n";
+		
+		OpenMRSNarrativeTemplateManifest manifest = OpenMRSNarrativeTemplateManifest
+		        .forManifestFileLocation(Arrays.asList(testNarrativePropFile));
+		INarrativeTemplate template = manifest.getTemplateByName(ctx, EnumSet.of(TemplateTypeEnum.THYMELEAF), "testRes")
+		        .get(0);
+		
+		assertEquals(template.getAppliesToProfiles(), expectedProfiles);
+		assertEquals(template.getAppliesToResourceTypes(), expectedResourceType);
+		assertEquals(template.getTemplateType(), expectedTemplateType);
+		assertEquals(template.getContextPath(), expectedContextPath);
+		assertEquals(template.getTemplateText(), expectedNarrative);
+	}
+	
+	@Test
+	public void shouldThrowConfigurationExceptionWhenPropertyNameInvalid() {
+		String testNarrativePropFile = "classpath:org/openmrs/module/fhir2/narrative/testNarrativesWithInvalidProperty.properties";
+		String expectedErrorMessage = "Invalid property name: testRes.invalidPropertyName"
+		        + " - the key must end in one of the expected extensions "
+		        + "'.profile', '.resourceType', '.dataType', '.style', '.contextPath', '.narrative', '.title'";
+		
+		Throwable e = assertThrows(ConfigurationException.class,
+		    () -> OpenMRSNarrativeTemplateManifest.forManifestFileLocation(Arrays.asList(testNarrativePropFile)));
+		assertEquals(e.getMessage(), expectedErrorMessage);
+	}
+}

--- a/omod/src/test/java/org/openmrs/module/fhir2/web/util/NarrativeUtilTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/web/util/NarrativeUtilTest.java
@@ -61,5 +61,14 @@ public class NarrativeUtilTest {
 		
 		assertThat(propFilePathResult, nullValue());
 	}
+
+	@Test
+	public void shouldReturnNullWhenOpenmrsRelativePathIsEmpty() {
+		String propFilePathGiven = "openmrs: ";
+
+		String propFilePathResult = NarrativeUtils.getValidatedPropertiesFilePath(propFilePathGiven);
+
+		assertThat(propFilePathResult, nullValue());
+	}
 	
 }

--- a/omod/src/test/resources/org/openmrs/module/fhir2/narrative/testNarrative.html
+++ b/omod/src/test/resources/org/openmrs/module/fhir2/narrative/testNarrative.html
@@ -1,0 +1,1 @@
+<div>testNarrativeContent</div>

--- a/omod/src/test/resources/org/openmrs/module/fhir2/narrative/testNarratives.properties
+++ b/omod/src/test/resources/org/openmrs/module/fhir2/narrative/testNarratives.properties
@@ -1,0 +1,16 @@
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+# the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+#
+# Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+# graphic logo is a trademark of OpenMRS Inc.
+#
+
+testRes.profile = testProfile
+testRes.resourceType = testResourceType
+testRes.dataType = testDataType
+testRes.style = THYMELEAF
+testRes.contextPath = testContextPath
+testRes.narrative = classpath:org/openmrs/module/fhir2/narrative/testNarrative.html

--- a/omod/src/test/resources/org/openmrs/module/fhir2/narrative/testNarrativesWithInvalidProperty.properties
+++ b/omod/src/test/resources/org/openmrs/module/fhir2/narrative/testNarrativesWithInvalidProperty.properties
@@ -1,0 +1,11 @@
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+# the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+#
+# Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+# graphic logo is a trademark of OpenMRS Inc.
+#
+
+testRes.invalidPropertyName = someInvalidProperty


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'FM2-8: Implement the Person Resource' -->
<!--- 'FM2-JiraIssueNumber: JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
Added support for relative paths prefixed with `openmrs:` for location of narratives and properties file. 
For example, the relative path `openmrs:configuration/Patient.html` would point to the location `<OPENMRS_APPLICATION_DATA_DIRECTORY>/configuration/Patient.html`.

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/FM2-252

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.
