### PR TITLE
FM2-251: Add support for overriding default narratives

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhir2/FhirConstants.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/FhirConstants.java
@@ -218,6 +218,8 @@ public class FhirConstants {
 	
 	public static final String OPENMRS_NARRATIVES_PROPERTY_FILE = "classpath:org/openmrs/module/fhir2/narratives.properties";
 	
+	public static final String NARRATIVES_OVERRIDE_PROPERTY_FILE = "fhir2.narrativesOverridePropertyFile";
+	
 	public static final String ALLERGEN_SEARCH_HANDLER = "allergen.search.handler";
 	
 	public static final String SEVERITY_SEARCH_HANDLER = "severity.search.handler";

--- a/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
@@ -24,6 +24,7 @@ import lombok.Setter;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.openmrs.module.fhir2.FhirConstants;
 import org.openmrs.module.fhir2.api.FhirGlobalPropertyService;
+import org.openmrs.module.fhir2.web.util.NarrativeUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -62,8 +63,19 @@ public class FhirRestServlet extends RestfulServer {
 		setDefaultResponseEncoding(EncodingEnum.JSON);
 		registerInterceptor(loggingInterceptor);
 		
-		getFhirContext().setNarrativeGenerator(new CustomThymeleafNarrativeGenerator(
-		        FhirConstants.HAPI_NARRATIVES_PROPERTY_FILE, FhirConstants.OPENMRS_NARRATIVES_PROPERTY_FILE));
+		String narrativesOverridePropertyFile = NarrativeUtils.getValidatedPropertiesFilePath(
+		    globalPropertyService.getGlobalProperty(FhirConstants.NARRATIVES_OVERRIDE_PROPERTY_FILE, ""));
+		
+		String[] narrativePropertiesFiles;
+		if (narrativesOverridePropertyFile != null) {
+			narrativePropertiesFiles = new String[] { narrativesOverridePropertyFile,
+			        FhirConstants.HAPI_NARRATIVES_PROPERTY_FILE, FhirConstants.OPENMRS_NARRATIVES_PROPERTY_FILE };
+		} else {
+			narrativePropertiesFiles = new String[] { FhirConstants.HAPI_NARRATIVES_PROPERTY_FILE,
+			        FhirConstants.OPENMRS_NARRATIVES_PROPERTY_FILE };
+		}
+		
+		getFhirContext().setNarrativeGenerator(new CustomThymeleafNarrativeGenerator(narrativePropertiesFiles));
 	}
 	
 	@Override

--- a/omod/src/main/java/org/openmrs/module/fhir2/web/util/NarrativeUtils.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/web/util/NarrativeUtils.java
@@ -1,0 +1,63 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.fhir2.web.util;
+
+import javax.validation.constraints.NotNull;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class NarrativeUtils {
+	
+	private static boolean validatePropertiesFilePath(@NotNull String path) {
+		
+		if (path.startsWith("file:")) {
+			String filepath = path.substring("file:".length());
+			
+			if (filepath == null || filepath.trim().isEmpty()) {
+				log.error("Properties File path must not be empty");
+				return false;
+			}
+			
+			if (!filepath.endsWith(".properties")) {
+				log.error("Properties File must have extension '.properties'");
+				return false;
+			}
+		} else if (path.startsWith("classpath:")) {
+			String classpath = path.substring("classpath:".length());
+			
+			if (classpath == null || classpath.trim().isEmpty()) {
+				log.error("Properties File classpath must not be empty");
+				return false;
+			}
+		}
+		
+		return true;
+	}
+	
+	public static String getValidatedPropertiesFilePath(String path) {
+		if (path == null || path.isEmpty()) {
+			return null;
+		}
+		
+		// add "file:" prefix if the path doesn't start with "classpath:" or "file:"
+		// since NarrativeTemplateManifest.loadResource() method requires one of these prefixes
+		if (!(path.startsWith("file:") || path.startsWith("classpath:"))) {
+			path = "file:" + path;
+		}
+		
+		if (validatePropertiesFilePath(path)) {
+			return path;
+		}
+		
+		return null;
+	}
+	
+}

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -128,5 +128,10 @@
 		<description>Set provider attribute type uuid</description>
 	</globalProperty>
 
-</module>
+	<globalProperty>
+		<property>${project.parent.artifactId}.narrativesOverridePropertyFile</property>
+		<defaultValue></defaultValue>
+		<description>Path of narrative override properties file</description>
+	</globalProperty>
 
+</module>

--- a/omod/src/test/java/org/openmrs/module/fhir2/web/util/NarrativeUtilTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/web/util/NarrativeUtilTest.java
@@ -1,0 +1,65 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.fhir2.web.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.junit.Test;
+
+public class NarrativeUtilTest {
+	
+	@Test
+	public void shouldReturnNullWhenPathIsNull() {
+		String propFilePathGiven = null;
+		
+		String propFilePathResult = NarrativeUtils.getValidatedPropertiesFilePath(propFilePathGiven);
+		
+		assertThat(propFilePathResult, nullValue());
+	}
+	
+	@Test
+	public void shouldReturnNullWhenFilePathIsEmpty() {
+		String propFilePathGiven = "file:";
+		
+		String propFilePathResult = NarrativeUtils.getValidatedPropertiesFilePath(propFilePathGiven);
+		
+		assertThat(propFilePathResult, nullValue());
+	}
+	
+	@Test
+	public void shouldReturnNullWhenDoesNotEndWithProperties() {
+		String propFilePathGiven = "file:somepath/which/does/not/end/with/properties/extension";
+		
+		String propFilePathResult = NarrativeUtils.getValidatedPropertiesFilePath(propFilePathGiven);
+		
+		assertThat(propFilePathResult, nullValue());
+	}
+	
+	@Test
+	public void shouldReturnFilePrefixedPathIfPrefixNotPresent() {
+		String propFilePathGiven = "somepath/which/does/not/have/file/prefix/filename.properties";
+		
+		String propFilePathResult = NarrativeUtils.getValidatedPropertiesFilePath(propFilePathGiven);
+		
+		assertThat(propFilePathResult, equalTo(String.join(":", "file", propFilePathGiven)));
+	}
+	
+	@Test
+	public void shouldReturnNullWhenClassPathIsEmpty() {
+		String propFilePathGiven = "classpath: ";
+		
+		String propFilePathResult = NarrativeUtils.getValidatedPropertiesFilePath(propFilePathGiven);
+		
+		assertThat(propFilePathResult, nullValue());
+	}
+	
+}


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'FM2-8: Implement the Person Resource' -->
<!--- 'FM2-JiraIssueNumber: JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
Added support for overriding default narratives, with the narrative override property file location to be stored as the global property `narrativesOverridePropertyFile`.

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/FM2-251

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.