### PR TITLE
Encounter has medication request spike

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhir2/FhirConstants.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/FhirConstants.java
@@ -313,4 +313,6 @@ public class FhirConstants {
 	public static final String EVERYTHING_SEARCH_HANDLER = "everything.search.handler";
 	
 	public static final String CONDITION_OBSERVATION_CONCEPT_UUID = "1284AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+	
+	public static final String HAS_SEARCH_HANDLER = "_has";
 }

--- a/api/src/main/java/org/openmrs/module/fhir2/FhirConstants.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/FhirConstants.java
@@ -302,10 +302,6 @@ public class FhirConstants {
 	
 	public static final String INCLUDE_OWNER_PARAM = "owner";
 	
-	public static final String INCLUDE_INTENT_PARAM = "intent";
-	
-	public static final String INCLUDE_STATUS_PARAM = "status";
-	
 	public static final String REVERSE_INCLUDE_SEARCH_HANDLER = "_revinclude.search.handler";
 	
 	public static final String MAX_SEARCH_HANDLER = "max.search.handler";

--- a/api/src/main/java/org/openmrs/module/fhir2/FhirConstants.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/FhirConstants.java
@@ -302,6 +302,10 @@ public class FhirConstants {
 	
 	public static final String INCLUDE_OWNER_PARAM = "owner";
 	
+	public static final String INCLUDE_INTENT_PARAM = "intent";
+	
+	public static final String INCLUDE_STATUS_PARAM = "status";
+	
 	public static final String REVERSE_INCLUDE_SEARCH_HANDLER = "_revinclude.search.handler";
 	
 	public static final String MAX_SEARCH_HANDLER = "max.search.handler";

--- a/api/src/main/java/org/openmrs/module/fhir2/api/FhirEncounterService.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/FhirEncounterService.java
@@ -15,6 +15,7 @@ import ca.uhn.fhir.model.api.Include;
 import ca.uhn.fhir.rest.api.SortSpec;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.HasAndListParam;
 import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.TokenAndListParam;
 import ca.uhn.fhir.rest.param.TokenParam;
@@ -25,7 +26,7 @@ public interface FhirEncounterService extends FhirService<Encounter> {
 	IBundleProvider searchForEncounters(DateRangeParam date, ReferenceAndListParam location,
 	        ReferenceAndListParam participant, ReferenceAndListParam subject, TokenAndListParam encounterType,
 	        TokenAndListParam id, DateRangeParam lastUpdated, SortSpec sort, HashSet<Include> includes,
-	        HashSet<Include> revIncludes);
+	        HashSet<Include> revIncludes, HasAndListParam hasMedicationRequestParam);
 	
 	IBundleProvider getEncounterEverything(TokenParam identifier);
 }

--- a/api/src/main/java/org/openmrs/module/fhir2/api/FhirEncounterService.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/FhirEncounterService.java
@@ -26,7 +26,7 @@ public interface FhirEncounterService extends FhirService<Encounter> {
 	IBundleProvider searchForEncounters(DateRangeParam date, ReferenceAndListParam location,
 	        ReferenceAndListParam participant, ReferenceAndListParam subject, TokenAndListParam encounterType,
 	        TokenAndListParam id, DateRangeParam lastUpdated, SortSpec sort, HashSet<Include> includes,
-	        HashSet<Include> revIncludes, HasAndListParam hasMedicationRequestParam);
+	        HashSet<Include> revIncludes, HasAndListParam hasAndListParam);
 	
 	IBundleProvider getEncounterEverything(TokenParam identifier);
 }

--- a/api/src/main/java/org/openmrs/module/fhir2/api/dao/impl/BaseEncounterDao.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/dao/impl/BaseEncounterDao.java
@@ -71,7 +71,7 @@ public abstract class BaseEncounterDao<T extends OpenmrsObject & Auditable> exte
 			handleAndListParam(hasAndListParam, hasParam -> {
 				if (hasParam != null) {
 					if (FhirConstants.MEDICATION_REQUEST.equals(hasParam.getTargetResourceType())) {
-						if (FhirConstants.INCLUDE_ENCOUNTER_PARAM.equals(hasParam.getReferenceFieldName())) {
+						if (MedicationRequest.SP_ENCOUNTER.equals(hasParam.getReferenceFieldName())) {
 							if (lacksAlias(criteria, "orders")) {
 								if (Encounter.class.isAssignableFrom(typeToken.getRawType())) {
 									criteria.createAlias("orders", "orders");
@@ -89,12 +89,12 @@ public abstract class BaseEncounterDao<T extends OpenmrsObject & Auditable> exte
 							String paramName = hasParam.getParameterName();
 							String paramValue = hasParam.getParameterValue();
 							if (StringUtils.isNotBlank(paramName) && StringUtils.isNotBlank(paramValue)) {
-								if (FhirConstants.INCLUDE_INTENT_PARAM.equals(paramName)) {
+								if (MedicationRequest.SP_INTENT.equals(paramName)) {
 									if (MedicationRequest.MedicationRequestIntent.ORDER.toCode().equals(paramValue)) {
 										// Do not constrain, all Orders are given this intent
 									}
 								}
-								if (FhirConstants.INCLUDE_STATUS_PARAM.equals(paramName)) {
+								if (MedicationRequest.SP_STATUS.equals(paramName)) {
 									Date now = new Date();
 									if (MedicationRequest.MedicationRequestStatus.ACTIVE.toCode().equals(paramValue)) {
 										criteria.add(Restrictions.ne("orders.action", Order.Action.DISCONTINUE));

--- a/api/src/main/java/org/openmrs/module/fhir2/api/impl/FhirEncounterServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/impl/FhirEncounterServiceImpl.java
@@ -148,7 +148,6 @@ public class FhirEncounterServiceImpl extends BaseFhirService<Encounter, org.ope
 	        ReferenceAndListParam participant, ReferenceAndListParam subject, TokenAndListParam encounterType,
 	        TokenAndListParam id, DateRangeParam lastUpdated, SortSpec sort, HashSet<Include> includes,
 	        HashSet<Include> revIncludes, HasAndListParam hasAndListParam) {
-		
 		SearchParameterMap theParams = new SearchParameterMap().addParameter(FhirConstants.DATE_RANGE_SEARCH_HANDLER, date)
 		        .addParameter(FhirConstants.LOCATION_REFERENCE_SEARCH_HANDLER, location)
 		        .addParameter(FhirConstants.PARTICIPANT_REFERENCE_SEARCH_HANDLER, participant)
@@ -161,7 +160,6 @@ public class FhirEncounterServiceImpl extends BaseFhirService<Encounter, org.ope
 		        .addParameter(FhirConstants.HAS_SEARCH_HANDLER, hasAndListParam).setSortSpec(sort);
 		
 		IBundleProvider visitBundle = visitService.searchForVisits(theParams);
-		
 		IBundleProvider encounterBundle = searchQuery.getQueryResults(theParams, dao, translator, searchQueryInclude);
 		
 		if (!encounterBundle.isEmpty() && !visitBundle.isEmpty()) {

--- a/api/src/main/java/org/openmrs/module/fhir2/api/impl/FhirEncounterServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/impl/FhirEncounterServiceImpl.java
@@ -17,6 +17,7 @@ import ca.uhn.fhir.model.api.Include;
 import ca.uhn.fhir.rest.api.SortSpec;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.HasAndListParam;
 import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.TokenAndListParam;
 import ca.uhn.fhir.rest.param.TokenParam;
@@ -146,7 +147,8 @@ public class FhirEncounterServiceImpl extends BaseFhirService<Encounter, org.ope
 	public IBundleProvider searchForEncounters(DateRangeParam date, ReferenceAndListParam location,
 	        ReferenceAndListParam participant, ReferenceAndListParam subject, TokenAndListParam encounterType,
 	        TokenAndListParam id, DateRangeParam lastUpdated, SortSpec sort, HashSet<Include> includes,
-	        HashSet<Include> revIncludes) {
+	        HashSet<Include> revIncludes, HasAndListParam hasAndListParam) {
+		
 		SearchParameterMap theParams = new SearchParameterMap().addParameter(FhirConstants.DATE_RANGE_SEARCH_HANDLER, date)
 		        .addParameter(FhirConstants.LOCATION_REFERENCE_SEARCH_HANDLER, location)
 		        .addParameter(FhirConstants.PARTICIPANT_REFERENCE_SEARCH_HANDLER, participant)
@@ -155,9 +157,11 @@ public class FhirEncounterServiceImpl extends BaseFhirService<Encounter, org.ope
 		        .addParameter(FhirConstants.COMMON_SEARCH_HANDLER, FhirConstants.ID_PROPERTY, id)
 		        .addParameter(FhirConstants.COMMON_SEARCH_HANDLER, FhirConstants.LAST_UPDATED_PROPERTY, lastUpdated)
 		        .addParameter(FhirConstants.INCLUDE_SEARCH_HANDLER, includes)
-		        .addParameter(FhirConstants.REVERSE_INCLUDE_SEARCH_HANDLER, revIncludes).setSortSpec(sort);
+		        .addParameter(FhirConstants.REVERSE_INCLUDE_SEARCH_HANDLER, revIncludes)
+		        .addParameter(FhirConstants.HAS_SEARCH_HANDLER, hasAndListParam).setSortSpec(sort);
 		
 		IBundleProvider visitBundle = visitService.searchForVisits(theParams);
+		
 		IBundleProvider encounterBundle = searchQuery.getQueryResults(theParams, dao, translator, searchQueryInclude);
 		
 		if (!encounterBundle.isEmpty() && !visitBundle.isEmpty()) {

--- a/api/src/main/java/org/openmrs/module/fhir2/api/search/SearchQueryInclude.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/search/SearchQueryInclude.java
@@ -207,7 +207,8 @@ public class SearchQueryInclude<U extends IBaseResource> {
 				return locationService.searchForLocations(null, null, null, null, null, null, params, null, null, null, null,
 				    null);
 			case FhirConstants.ENCOUNTER:
-				return encounterService.searchForEncounters(null, params, null, null, null, null, null, null, null, null);
+				return encounterService.searchForEncounters(null, params, null, null, null, null, null, null, null, null,
+				    null);
 		}
 		
 		return null;
@@ -229,7 +230,8 @@ public class SearchQueryInclude<U extends IBaseResource> {
 	private IBundleProvider handlePractitionerReverseInclude(ReferenceAndListParam params, String targetType) {
 		switch (targetType) {
 			case FhirConstants.ENCOUNTER:
-				return encounterService.searchForEncounters(null, null, params, null, null, null, null, null, null, null);
+				return encounterService.searchForEncounters(null, null, params, null, null, null, null, null, null, null,
+				    null);
 			case FhirConstants.MEDICATION_REQUEST:
 				return medicationRequestService.searchForMedicationRequests(null, null, null, params, null, null, null,
 				    null);
@@ -282,7 +284,8 @@ public class SearchQueryInclude<U extends IBaseResource> {
 				return allergyIntoleranceService.searchForAllergies(params, null, null, null, null, null, null, null, null,
 				    null);
 			case FhirConstants.ENCOUNTER:
-				return encounterService.searchForEncounters(null, null, null, params, null, null, null, null, null, null);
+				return encounterService.searchForEncounters(null, null, null, params, null, null, null, null, null, null,
+				    null);
 			case FhirConstants.MEDICATION_REQUEST:
 				return medicationRequestService.searchForMedicationRequests(params, null, null, null, null, null, null,
 				    null);

--- a/api/src/main/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProvider.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProvider.java
@@ -30,6 +30,7 @@ import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.api.SortSpec;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.HasAndListParam;
 import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.TokenAndListParam;
 import ca.uhn.fhir.rest.server.IResourceProvider;
@@ -49,6 +50,7 @@ import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.dstu3.model.Practitioner;
 import org.hl7.fhir.dstu3.model.ProcedureRequest;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.openmrs.module.fhir2.FhirConstants;
 import org.openmrs.module.fhir2.api.FhirEncounterService;
 import org.openmrs.module.fhir2.api.annotations.R3Provider;
 import org.openmrs.module.fhir2.api.search.SearchQueryBundleProviderR3Wrapper;
@@ -123,6 +125,7 @@ public class EncounterFhirResourceProvider implements IResourceProvider {
 	        @OptionalParam(name = Encounter.SP_TYPE) TokenAndListParam encounterType,
 	        @OptionalParam(name = Encounter.SP_RES_ID) TokenAndListParam id,
 	        @OptionalParam(name = "_lastUpdated") DateRangeParam lastUpdated, @Sort SortSpec sort,
+	        @OptionalParam(name = FhirConstants.HAS_SEARCH_HANDLER) HasAndListParam hasAndListParam,
 	        @IncludeParam(allow = { "Encounter:" + Encounter.SP_LOCATION, "Encounter:" + Encounter.SP_PATIENT,
 	                "Encounter:" + Encounter.SP_PARTICIPANT }) HashSet<Include> includes,
 	        @IncludeParam(reverse = true, allow = { "Observation:" + Observation.SP_ENCOUNTER,
@@ -140,8 +143,9 @@ public class EncounterFhirResourceProvider implements IResourceProvider {
 			revIncludes = null;
 		}
 		
-		return new SearchQueryBundleProviderR3Wrapper(encounterService.searchForEncounters(date, location,
-		    participantReference, subjectReference, encounterType, id, lastUpdated, sort, includes, revIncludes));
+		return new SearchQueryBundleProviderR3Wrapper(
+		        encounterService.searchForEncounters(date, location, participantReference, subjectReference, encounterType,
+		            id, lastUpdated, sort, includes, revIncludes, hasAndListParam));
 	}
 	
 }

--- a/api/src/main/java/org/openmrs/module/fhir2/providers/r4/EncounterFhirResourceProvider.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/providers/r4/EncounterFhirResourceProvider.java
@@ -32,6 +32,7 @@ import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.api.SortSpec;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.HasAndListParam;
 import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.TokenAndListParam;
 import ca.uhn.fhir.rest.param.TokenParam;
@@ -51,6 +52,7 @@ import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Practitioner;
 import org.hl7.fhir.r4.model.ServiceRequest;
+import org.openmrs.module.fhir2.FhirConstants;
 import org.openmrs.module.fhir2.api.FhirEncounterService;
 import org.openmrs.module.fhir2.api.annotations.R4Provider;
 import org.openmrs.module.fhir2.providers.util.FhirProviderUtils;
@@ -118,6 +120,7 @@ public class EncounterFhirResourceProvider implements IResourceProvider {
 	        @OptionalParam(name = Encounter.SP_TYPE) TokenAndListParam encounterType,
 	        @OptionalParam(name = Encounter.SP_RES_ID) TokenAndListParam id,
 	        @OptionalParam(name = "_lastUpdated") DateRangeParam lastUpdated, @Sort SortSpec sort,
+	        @OptionalParam(name = FhirConstants.HAS_SEARCH_HANDLER) HasAndListParam hasAndListParam,
 	        @IncludeParam(allow = { "Encounter:" + Encounter.SP_LOCATION, "Encounter:" + Encounter.SP_PATIENT,
 	                "Encounter:" + Encounter.SP_PARTICIPANT }) HashSet<Include> includes,
 	        @IncludeParam(reverse = true, allow = { "Observation:" + Observation.SP_ENCOUNTER,
@@ -137,7 +140,7 @@ public class EncounterFhirResourceProvider implements IResourceProvider {
 		}
 		
 		return encounterService.searchForEncounters(date, location, participantReference, subjectReference, encounterType,
-		    id, lastUpdated, sort, includes, revIncludes);
+		    id, lastUpdated, sort, includes, revIncludes, hasAndListParam);
 	}
 	
 	/**

--- a/api/src/test/java/org/openmrs/module/fhir2/api/dao/impl/FhirEncounterDaoImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/dao/impl/FhirEncounterDaoImplTest.java
@@ -95,7 +95,7 @@ public class FhirEncounterDaoImplTest extends BaseModuleContextSensitiveTest {
 		}
 		
 		HasOrListParam hasOrListParam = new HasOrListParam();
-		hasOrListParam.add(new HasParam("MedicationRequest", "encounter", "meta:tag:code", "Encounter"));
+		hasOrListParam.add(new HasParam("MedicationRequest", "encounter", "intent", "order"));
 		HasAndListParam hasAndListParam = new HasAndListParam();
 		hasAndListParam.addAnd(hasOrListParam);
 		SearchParameterMap theParams = new SearchParameterMap().addParameter(FhirConstants.HAS_SEARCH_HANDLER,

--- a/api/src/test/java/org/openmrs/module/fhir2/api/dao/impl/FhirEncounterDaoImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/dao/impl/FhirEncounterDaoImplTest.java
@@ -82,7 +82,7 @@ public class FhirEncounterDaoImplTest extends BaseModuleContextSensitiveTest {
 	}
 	
 	@Test
-	public void shouldOnlyReturnEncountersThatHaveAtLeastOneHasParamResource() {
+	public void shouldOnlyReturnEncountersThatHaveAssociatedMedicationRequests() {
 		Encounter withNoDrugOrders = dao.get(ENCOUNTER_WITH_NO_DRUG_ORDERS);
 		assertThat(withNoDrugOrders, notNullValue());
 		assertThat("Orders is empty", withNoDrugOrders.getOrders().isEmpty());

--- a/api/src/test/java/org/openmrs/module/fhir2/api/dao/impl/FhirEncounterDaoImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/dao/impl/FhirEncounterDaoImplTest.java
@@ -9,20 +9,30 @@
  */
 package org.openmrs.module.fhir2.api.dao.impl;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-
+import ca.uhn.fhir.rest.param.HasAndListParam;
+import ca.uhn.fhir.rest.param.HasOrListParam;
+import ca.uhn.fhir.rest.param.HasParam;
 import org.hibernate.SessionFactory;
 import org.junit.Before;
 import org.junit.Test;
+import org.openmrs.DrugOrder;
 import org.openmrs.Encounter;
+import org.openmrs.Order;
+import org.openmrs.module.fhir2.FhirConstants;
 import org.openmrs.module.fhir2.TestFhirSpringConfiguration;
+import org.openmrs.module.fhir2.api.search.param.SearchParameterMap;
 import org.openmrs.test.BaseModuleContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.context.ContextConfiguration;
+
+import java.util.List;
+import java.util.Properties;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @ContextConfiguration(classes = TestFhirSpringConfiguration.class, inheritLocations = false)
 public class FhirEncounterDaoImplTest extends BaseModuleContextSensitiveTest {
@@ -31,6 +41,10 @@ public class FhirEncounterDaoImplTest extends BaseModuleContextSensitiveTest {
 	
 	private static final String UNKNOWN_ENCOUNTER_UUID = "xx923xx-3423kk-2323-232jk23";
 	
+	private static final String ENCOUNTER_WITH_DRUG_ORDERS = "6519d653-393b-4118-9c83-a3715b82d4ac"; // 3 in standard test dataset
+	
+	private static final String ENCOUNTER_WITH_NO_DRUG_ORDERS = "eec646cb-c847-45a7-98bc-91c8c4f70add"; // 4 in standard test dataset
+	
 	private static final String ENCOUNTER_INITIAL_DATA_XML = "org/openmrs/module/fhir2/api/dao/impl/FhirEncounterDaoImplTest_initial_data.xml";
 	
 	@Autowired
@@ -38,6 +52,13 @@ public class FhirEncounterDaoImplTest extends BaseModuleContextSensitiveTest {
 	private SessionFactory sessionFactory;
 	
 	private FhirEncounterDaoImpl dao;
+	
+	@Override
+	public Properties getRuntimeProperties() {
+		Properties p = super.getRuntimeProperties();
+		//p.put("hibernate.show_sql", "true");
+		return p;
+	}
 	
 	@Before
 	public void setUp() throws Exception {
@@ -58,5 +79,35 @@ public class FhirEncounterDaoImplTest extends BaseModuleContextSensitiveTest {
 	public void shouldReturnNullWithUnknownEncounterUuid() {
 		Encounter encounter = dao.get(UNKNOWN_ENCOUNTER_UUID);
 		assertThat(encounter, nullValue());
+	}
+	
+	@Test
+	public void shouldOnlyReturnEncountersThatHaveAtLeastOneHasParamResource() {
+		Encounter withNoDrugOrders = dao.get(ENCOUNTER_WITH_NO_DRUG_ORDERS);
+		assertThat(withNoDrugOrders, notNullValue());
+		assertThat("Orders is empty", withNoDrugOrders.getOrders().isEmpty());
+		
+		Encounter withDrugOrders = dao.get(ENCOUNTER_WITH_DRUG_ORDERS);
+		assertThat(withDrugOrders, notNullValue());
+		assertThat("Orders is not empty", !withDrugOrders.getOrders().isEmpty());
+		for (Order order : withDrugOrders.getOrders()) {
+			assertThat(order.getClass(), equalTo(DrugOrder.class));
+		}
+		
+		HasOrListParam hasOrListParam = new HasOrListParam();
+		hasOrListParam.add(new HasParam(
+				"MedicationRequest",
+				"encounter",
+				"meta:tag:code",
+				"Encounter")
+		);
+		HasAndListParam hasAndListParam = new HasAndListParam();
+		hasAndListParam.addAnd(hasOrListParam);
+		SearchParameterMap theParams = new SearchParameterMap()
+				.addParameter(FhirConstants.HAS_SEARCH_HANDLER, hasAndListParam);
+		
+		List<String> matchingUuids = dao.getSearchResultUuids(theParams);
+		assertThat("Encounter with Drug Orders is returned", matchingUuids.contains(ENCOUNTER_WITH_DRUG_ORDERS));
+		assertThat("Encounter without Drug Orders is not returned", !matchingUuids.contains(ENCOUNTER_WITH_NO_DRUG_ORDERS));
 	}
 }

--- a/api/src/test/java/org/openmrs/module/fhir2/api/dao/impl/FhirEncounterDaoImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/dao/impl/FhirEncounterDaoImplTest.java
@@ -9,6 +9,14 @@
  */
 package org.openmrs.module.fhir2.api.dao.impl;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.List;
+import java.util.Properties;
+
 import ca.uhn.fhir.rest.param.HasAndListParam;
 import ca.uhn.fhir.rest.param.HasOrListParam;
 import ca.uhn.fhir.rest.param.HasParam;
@@ -25,14 +33,6 @@ import org.openmrs.test.BaseModuleContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.context.ContextConfiguration;
-
-import java.util.List;
-import java.util.Properties;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 @ContextConfiguration(classes = TestFhirSpringConfiguration.class, inheritLocations = false)
 public class FhirEncounterDaoImplTest extends BaseModuleContextSensitiveTest {
@@ -95,16 +95,11 @@ public class FhirEncounterDaoImplTest extends BaseModuleContextSensitiveTest {
 		}
 		
 		HasOrListParam hasOrListParam = new HasOrListParam();
-		hasOrListParam.add(new HasParam(
-				"MedicationRequest",
-				"encounter",
-				"meta:tag:code",
-				"Encounter")
-		);
+		hasOrListParam.add(new HasParam("MedicationRequest", "encounter", "meta:tag:code", "Encounter"));
 		HasAndListParam hasAndListParam = new HasAndListParam();
 		hasAndListParam.addAnd(hasOrListParam);
-		SearchParameterMap theParams = new SearchParameterMap()
-				.addParameter(FhirConstants.HAS_SEARCH_HANDLER, hasAndListParam);
+		SearchParameterMap theParams = new SearchParameterMap().addParameter(FhirConstants.HAS_SEARCH_HANDLER,
+		    hasAndListParam);
 		
 		List<String> matchingUuids = dao.getSearchResultUuids(theParams);
 		assertThat("Encounter with Drug Orders is returned", matchingUuids.contains(ENCOUNTER_WITH_DRUG_ORDERS));

--- a/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirEncounterServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirEncounterServiceImplTest.java
@@ -608,9 +608,9 @@ public class FhirEncounterServiceImplTest {
 	}
 	
 	@Test
-	public void searchForEncounter_shouldOnlyReturnEncountersThatHaveAtLeastOneHasParamResourceIfNoValueIsSpecified() {
+	public void searchForEncounter_shouldOnlyReturnEncountersThatHaveAtLeastOneHasParamResource() {
 		HasOrListParam hasOrListParam = new HasOrListParam();
-		hasOrListParam.add(new HasParam("MedicationRequest", "encounter", null, null));
+		hasOrListParam.add(new HasParam("MedicationRequest", "encounter", "intent", "order"));
 		HasAndListParam hasAndListParam = new HasAndListParam();
 		hasAndListParam.addAnd(hasOrListParam);
 		SearchParameterMap theParams = new SearchParameterMap().addParameter(FhirConstants.HAS_SEARCH_HANDLER,

--- a/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirEncounterServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirEncounterServiceImplTest.java
@@ -608,7 +608,7 @@ public class FhirEncounterServiceImplTest {
 	}
 	
 	@Test
-	public void searchForEncounter_shouldOnlyReturnEncountersThatHaveAtLeastOneHasParamResource() {
+	public void searchForEncounter_shouldOnlyReturnEncountersThatHaveAssociatedMedicationRequests() {
 		HasOrListParam hasOrListParam = new HasOrListParam();
 		hasOrListParam.add(new HasParam("MedicationRequest", "encounter", "intent", "order"));
 		HasAndListParam hasAndListParam = new HasAndListParam();

--- a/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirEncounterServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirEncounterServiceImplTest.java
@@ -31,6 +31,9 @@ import ca.uhn.fhir.model.api.Include;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.param.DateParam;
 import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.HasAndListParam;
+import ca.uhn.fhir.rest.param.HasOrListParam;
+import ca.uhn.fhir.rest.param.HasParam;
 import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.ReferenceOrListParam;
 import ca.uhn.fhir.rest.param.ReferenceParam;
@@ -308,7 +311,7 @@ public class FhirEncounterServiceImplTest {
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
 		IBundleProvider results = encounterService.searchForEncounters(dateRangeParam, null, null, null, null, null, null,
-		    null, null, null);
+		    null, null, null, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -339,7 +342,7 @@ public class FhirEncounterServiceImplTest {
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
 		IBundleProvider results = encounterService.searchForEncounters(null, location, null, null, null, null, null, null,
-		    null, null);
+		    null, null, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -373,7 +376,7 @@ public class FhirEncounterServiceImplTest {
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
 		IBundleProvider results = encounterService.searchForEncounters(null, null, participant, null, null, null, null, null,
-		    null, null);
+		    null, null, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -407,7 +410,7 @@ public class FhirEncounterServiceImplTest {
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
 		IBundleProvider results = encounterService.searchForEncounters(null, null, null, subject, null, null, null, null,
-		    null, null);
+		    null, null, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -433,7 +436,7 @@ public class FhirEncounterServiceImplTest {
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
 		IBundleProvider results = encounterService.searchForEncounters(null, null, null, null, null, uuid, null, null, null,
-		    null);
+		    null, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -463,7 +466,7 @@ public class FhirEncounterServiceImplTest {
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
 		IBundleProvider results = encounterService.searchForEncounters(null, null, null, null, typeUuid, null, null, null,
-		    null, null);
+		    null, null, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -489,7 +492,7 @@ public class FhirEncounterServiceImplTest {
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
 		IBundleProvider results = encounterService.searchForEncounters(null, null, null, null, null, null, lastUpdated, null,
-		    null, null);
+		    null, null, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -515,7 +518,7 @@ public class FhirEncounterServiceImplTest {
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
 		IBundleProvider results = encounterService.searchForEncounters(null, null, null, null, null, null, null, null,
-		    includes, null);
+		    includes, null, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -541,7 +544,7 @@ public class FhirEncounterServiceImplTest {
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
 		IBundleProvider results = encounterService.searchForEncounters(null, null, null, null, null, null, null, null,
-		    includes, null);
+		    includes, null, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -568,7 +571,7 @@ public class FhirEncounterServiceImplTest {
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
 		IBundleProvider results = encounterService.searchForEncounters(null, null, null, null, null, null, null, null, null,
-		    revIncludes);
+		    revIncludes, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -595,7 +598,35 @@ public class FhirEncounterServiceImplTest {
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
 		IBundleProvider results = encounterService.searchForEncounters(null, null, null, null, null, null, null, null, null,
-		    revIncludes);
+		    revIncludes, null);
+		
+		List<IBaseResource> resultList = get(results);
+		
+		assertThat(results, notNullValue());
+		assertThat(resultList, not(empty()));
+		assertThat(resultList, hasSize(greaterThanOrEqualTo(1)));
+	}
+	
+	@Test
+	public void searchForEncounter_shouldOnlyReturnEncountersThatHaveAtLeastOneHasParamResourceIfNoValueIsSpecified() {
+		HasOrListParam hasOrListParam = new HasOrListParam();
+		hasOrListParam.add(new HasParam("MedicationRequest", "encounter", null, null));
+		HasAndListParam hasAndListParam = new HasAndListParam();
+		hasAndListParam.addAnd(hasOrListParam);
+		SearchParameterMap theParams = new SearchParameterMap().addParameter(FhirConstants.HAS_SEARCH_HANDLER,
+		    hasAndListParam);
+		
+		when(dao.getSearchResults(any(), any())).thenReturn(Collections.singletonList(openMrsEncounter));
+		when(dao.getSearchResultUuids(any())).thenReturn(Collections.singletonList(ENCOUNTER_UUID));
+		when(encounterTranslator.toFhirResource(openMrsEncounter)).thenReturn(fhirEncounter);
+		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
+		    new SearchQueryBundleProvider<>(theParams, dao, encounterTranslator, globalPropertyService, searchQueryInclude));
+		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
+		
+		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
+		
+		IBundleProvider results = encounterService.searchForEncounters(null, null, null, null, null, null, null, null, null,
+		    null, hasAndListParam);
 		
 		List<IBaseResource> resultList = get(results);
 		

--- a/api/src/test/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProviderTest.java
@@ -30,6 +30,9 @@ import java.util.stream.Collectors;
 import ca.uhn.fhir.model.api.Include;
 import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.rest.param.HasAndListParam;
+import ca.uhn.fhir.rest.param.HasOrListParam;
+import ca.uhn.fhir.rest.param.HasParam;
 import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.ReferenceOrListParam;
 import ca.uhn.fhir.rest.param.ReferenceParam;
@@ -229,6 +232,27 @@ public class EncounterFhirResourceProviderTest extends BaseFhirR3ProvenanceResou
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
 		    null, null, revIncludes);
+		
+		List<IBaseResource> resultList = results.getResources(START_INDEX, END_INDEX);
+		
+		assertThat(results, notNullValue());
+		assertThat(resultList.size(), equalTo(1));
+		assertThat(resultList.get(0).fhirType(), equalTo(FhirConstants.ENCOUNTER));
+		assertThat(((Encounter) resultList.iterator().next()).getId(), equalTo(ENCOUNTER_UUID));
+	}
+	
+	@Test
+	public void searchEncounters_shouldIncludeAddResourcesThatMatchHasAndListParam() {
+		HasOrListParam hasOrListParam = new HasOrListParam();
+		hasOrListParam.add(new HasParam("MedicationRequest", "encounter", "intent", "order"));
+		HasAndListParam hasAndListParam = new HasAndListParam();
+		hasAndListParam.addAnd(hasOrListParam);
+		
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+		    any())).thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
+		
+		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
+		    hasAndListParam, null, null);
 		
 		List<IBaseResource> resultList = results.getResources(START_INDEX, END_INDEX);
 		

--- a/api/src/test/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProviderTest.java
@@ -123,14 +123,14 @@ public class EncounterFhirResourceProviderTest extends BaseFhirR3ProvenanceResou
 	public void searchEncounters_shouldReturnMatchingEncounters() {
 		List<org.hl7.fhir.r4.model.Encounter> encounters = new ArrayList<>();
 		encounters.add(encounter);
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
-		        .thenReturn(new MockIBundleProvider<>(encounters, PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+		    any())).thenReturn(new MockIBundleProvider<>(encounters, PREFERRED_SIZE, COUNT));
 		
 		ReferenceAndListParam subjectReference = new ReferenceAndListParam();
 		subjectReference.addValue(new ReferenceOrListParam().add(new ReferenceParam().setChain(Patient.SP_NAME)));
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, subjectReference, null, null, null,
-		    null, null, null, null);
+		    null, null, null, null, null);
 		
 		List<Encounter> resultList = get(results);
 		
@@ -144,14 +144,14 @@ public class EncounterFhirResourceProviderTest extends BaseFhirR3ProvenanceResou
 	public void searchEncounters_shouldReturnMatchingEncountersWhenPatientParamIsSpecified() {
 		List<org.hl7.fhir.r4.model.Encounter> encounters = new ArrayList<>();
 		encounters.add(encounter);
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
-		        .thenReturn(new MockIBundleProvider<>(encounters, PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+		    any())).thenReturn(new MockIBundleProvider<>(encounters, PREFERRED_SIZE, COUNT));
 		
 		ReferenceAndListParam patientParam = new ReferenceAndListParam();
 		patientParam.addValue(new ReferenceOrListParam().add(new ReferenceParam().setChain(Patient.SP_NAME)));
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, patientParam, null, null, null,
-		    null, null, null);
+		    null, null, null, null);
 		
 		List<Encounter> resultList = get(results);
 		
@@ -163,14 +163,14 @@ public class EncounterFhirResourceProviderTest extends BaseFhirR3ProvenanceResou
 	
 	@Test
 	public void searchEncounters_shouldAddRelatedResourcesForInclude() {
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
-		        .thenReturn(new MockIBundleProvider<>(Arrays.asList(encounter, new Patient()), PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+		    any())).thenReturn(new MockIBundleProvider<>(Arrays.asList(encounter, new Patient()), PREFERRED_SIZE, COUNT));
 		
 		HashSet<Include> includes = new HashSet<>();
 		includes.add(new Include("Encounter:patient"));
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
-		    includes, null);
+		    null, includes, null);
 		
 		List<IBaseResource> resultList = results.getResources(START_INDEX, END_INDEX);
 		
@@ -183,13 +183,13 @@ public class EncounterFhirResourceProviderTest extends BaseFhirR3ProvenanceResou
 	
 	@Test
 	public void searchEncounters_shouldNotAddResourcesForEmptyInclude() {
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), isNull(), any()))
-		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), isNull(), any(),
+		    any())).thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
 		
 		HashSet<Include> includes = new HashSet<>();
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
-		    includes, null);
+		    null, includes, null);
 		
 		List<IBaseResource> resultList = results.getResources(START_INDEX, END_INDEX);
 		
@@ -201,14 +201,15 @@ public class EncounterFhirResourceProviderTest extends BaseFhirR3ProvenanceResou
 	
 	@Test
 	public void searchEncounters_shouldAddRelatedResourcesForRevInclude() {
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
-		        .thenReturn(new MockIBundleProvider<>(Arrays.asList(encounter, new Observation()), PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+		    any())).thenReturn(
+		        new MockIBundleProvider<>(Arrays.asList(encounter, new Observation()), PREFERRED_SIZE, COUNT));
 		
 		HashSet<Include> revIncludes = new HashSet<>();
 		revIncludes.add(new Include("Observation:encounter"));
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
-		    null, revIncludes);
+		    null, null, revIncludes);
 		
 		List<IBaseResource> resultList = results.getResources(START_INDEX, END_INDEX);
 		
@@ -221,13 +222,13 @@ public class EncounterFhirResourceProviderTest extends BaseFhirR3ProvenanceResou
 	
 	@Test
 	public void searchEncounters_shouldNotAddResourcesForEmptyRevInclude() {
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), isNull()))
-		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), isNull(),
+		    any())).thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
 		
 		HashSet<Include> revIncludes = new HashSet<>();
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
-		    null, revIncludes);
+		    null, null, revIncludes);
 		
 		List<IBaseResource> resultList = results.getResources(START_INDEX, END_INDEX);
 		

--- a/api/src/test/java/org/openmrs/module/fhir2/providers/r4/EncounterFhirResourceProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/providers/r4/EncounterFhirResourceProviderTest.java
@@ -120,14 +120,14 @@ public class EncounterFhirResourceProviderTest extends BaseFhirProvenanceResourc
 	public void searchEncounters_shouldReturnMatchingEncounters() {
 		List<Encounter> encounters = new ArrayList<>();
 		encounters.add(encounter);
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
-		        .thenReturn(new MockIBundleProvider<>(encounters, PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+		    any())).thenReturn(new MockIBundleProvider<>(encounters, PREFERRED_SIZE, COUNT));
 		
 		ReferenceAndListParam subjectReference = new ReferenceAndListParam();
 		subjectReference.addValue(new ReferenceOrListParam().add(new ReferenceParam().setChain(Patient.SP_NAME)));
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, subjectReference, null, null, null,
-		    null, null, null, null);
+		    null, null, null, null, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -141,14 +141,14 @@ public class EncounterFhirResourceProviderTest extends BaseFhirProvenanceResourc
 	public void searchEncounters_shouldReturnMatchingEncountersWhenPatientParamIsSpecified() {
 		List<Encounter> encounters = new ArrayList<>();
 		encounters.add(encounter);
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
-		        .thenReturn(new MockIBundleProvider<>(encounters, PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+		    any())).thenReturn(new MockIBundleProvider<>(encounters, PREFERRED_SIZE, COUNT));
 		
 		ReferenceAndListParam patientParam = new ReferenceAndListParam();
 		patientParam.addValue(new ReferenceOrListParam().add(new ReferenceParam().setChain(Patient.SP_NAME)));
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, patientParam, null, null, null,
-		    null, null, null);
+		    null, null, null, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -160,14 +160,14 @@ public class EncounterFhirResourceProviderTest extends BaseFhirProvenanceResourc
 	
 	@Test
 	public void searchEncounters_shouldAddRelatedResourcesForInclude() {
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
-		        .thenReturn(new MockIBundleProvider<>(Arrays.asList(encounter, new Patient()), PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+		    any())).thenReturn(new MockIBundleProvider<>(Arrays.asList(encounter, new Patient()), PREFERRED_SIZE, COUNT));
 		
 		HashSet<Include> includes = new HashSet<>();
 		includes.add(new Include("Encounter:patient"));
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
-		    includes, null);
+		    null, includes, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -180,13 +180,13 @@ public class EncounterFhirResourceProviderTest extends BaseFhirProvenanceResourc
 	
 	@Test
 	public void searchEncounters_shouldNotAddResourcesForEmptyInclude() {
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), isNull(), any()))
-		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), isNull(), any(),
+		    any())).thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
 		
 		HashSet<Include> includes = new HashSet<>();
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
-		    includes, null);
+		    null, includes, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -198,14 +198,15 @@ public class EncounterFhirResourceProviderTest extends BaseFhirProvenanceResourc
 	
 	@Test
 	public void searchEncounters_shouldAddRelatedResourcesForRevInclude() {
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
-		        .thenReturn(new MockIBundleProvider<>(Arrays.asList(encounter, new Observation()), PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+		    any())).thenReturn(
+		        new MockIBundleProvider<>(Arrays.asList(encounter, new Observation()), PREFERRED_SIZE, COUNT));
 		
 		HashSet<Include> revIncludes = new HashSet<>();
 		revIncludes.add(new Include("Observation:encounter"));
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
-		    null, revIncludes);
+		    null, null, revIncludes);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -218,13 +219,13 @@ public class EncounterFhirResourceProviderTest extends BaseFhirProvenanceResourc
 	
 	@Test
 	public void searchEncounters_shouldNotAddResourcesForEmptyRevInclude() {
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), isNull()))
-		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), isNull(),
+		    any())).thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
 		
 		HashSet<Include> revIncludes = new HashSet<>();
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
-		    null, revIncludes);
+		    null, null, revIncludes);
 		
 		List<IBaseResource> resultList = get(results);
 		

--- a/api/src/test/java/org/openmrs/module/fhir2/providers/r4/EncounterFhirResourceProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/providers/r4/EncounterFhirResourceProviderTest.java
@@ -29,6 +29,9 @@ import java.util.List;
 import ca.uhn.fhir.model.api.Include;
 import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.rest.param.HasAndListParam;
+import ca.uhn.fhir.rest.param.HasOrListParam;
+import ca.uhn.fhir.rest.param.HasParam;
 import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.ReferenceOrListParam;
 import ca.uhn.fhir.rest.param.ReferenceParam;
@@ -228,6 +231,27 @@ public class EncounterFhirResourceProviderTest extends BaseFhirProvenanceResourc
 		    null, null, revIncludes);
 		
 		List<IBaseResource> resultList = get(results);
+		
+		assertThat(results, notNullValue());
+		assertThat(resultList.size(), equalTo(1));
+		assertThat(resultList.get(0).fhirType(), equalTo(FhirConstants.ENCOUNTER));
+		assertThat(((Encounter) resultList.iterator().next()).getId(), equalTo(ENCOUNTER_UUID));
+	}
+	
+	@Test
+	public void searchEncounters_shouldIncludeAddResourcesThatMatchHasAndListParam() {
+		HasOrListParam hasOrListParam = new HasOrListParam();
+		hasOrListParam.add(new HasParam("MedicationRequest", "encounter", "intent", "order"));
+		HasAndListParam hasAndListParam = new HasAndListParam();
+		hasAndListParam.addAnd(hasOrListParam);
+		
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+		    any())).thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
+		
+		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
+		    hasAndListParam, null, null);
+		
+		List<IBaseResource> resultList = results.getResources(START_INDEX, END_INDEX);
 		
 		assertThat(results, notNullValue());
 		assertThat(resultList.size(), equalTo(1));

--- a/api/src/test/resources/log4j.xml
+++ b/api/src/test/resources/log4j.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+-->
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<!-- ######################################################
+     #                                                    #
+     # This log4j file is only used by the unit tests.    #
+     # The /metadata/api/log4j/log4j.xml file is put into #
+     # the api jar and war files.                         #
+     #                                                    #
+     ###################################################### -->
+ 
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+
+	<appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+		<layout class="org.apache.log4j.PatternLayout">
+			<param name="ConversionPattern"
+				value="%p - %C{1}.%M(%L) |%d{ISO8601}| %m%n" />
+		</layout>
+	</appender>
+
+	<!-- Hide unnecessary errors logged by Hibernate during unit testing -->
+	<logger name="org.hibernate.tool.hbm2ddl.SchemaExport">
+		<level value="FATAL" />
+	</logger>
+
+	<!-- 
+		This controls the LoggingAdvice class that wraps around the OpenMRS services 
+		WARN == don't log anything special for the services
+		INFO == log all setters
+		DEBUG == log all setters & getters &  execution time
+	-->
+	<logger name="org.openmrs.api">
+		<level value="WARN" />
+	</logger>
+	
+	<logger name="org.openmrs.test">
+		<level value="INFO" />
+	</logger>
+	
+	<logger name="org.hibernate.SQL">
+		<level value="ERROR" />
+	</logger>
+
+	<logger name="org.hibernate.type">
+		<level value="ERROR" />
+	</logger>
+
+    <root>
+		<level value="ERROR" />
+		<appender-ref ref="CONSOLE" />
+	</root>
+
+</log4j:configuration>

--- a/omod/src/test/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProviderWebTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProviderWebTest.java
@@ -161,7 +161,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter?subject:Patient=%s", PATIENT_UUID));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), subjectCaptor.capture(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		assertThat(subjectCaptor.getValue(), notNullValue());
 		assertThat(subjectCaptor.getAllValues().iterator().next().getValuesAsQueryTokens().iterator().next()
 		        .getValuesAsQueryTokens().iterator().next().getIdPart(),
@@ -173,7 +173,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter/?date=ge1975-02-02");
 		
 		verify(encounterService).searchForEncounters(dateRangeCaptor.capture(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		assertThat(dateRangeCaptor.getValue(), notNullValue());
 		
 		Calendar calendar = Calendar.getInstance();
@@ -189,7 +189,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter/?location.address-city=%s", ENCOUNTER_ADDRESS_CITY));
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -204,7 +204,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter/?location.address-state=%s", ENCOUNTER_ADDRESS_STATE));
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -219,7 +219,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter/?location.address-postalcode=%s", ENCOUNTER_POSTALCODE));
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -234,7 +234,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter/?location.address-country=%s", ENCOUNTER_ADDRESS_COUNTRY));
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -249,7 +249,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter/?location.address-country=%s,%s", ENCOUNTER_ADDRESS_COUNTRY, "USA"));
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -265,7 +265,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter/?location.address-country=INDIA&location.address-country=USA");
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -281,7 +281,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter/?participant:Practitioner.given=%s", PARTICIPANT_GIVEN_NAME));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -296,7 +296,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter/?participant:Practitioner.family=%s", PARTICIPANT_FAMILY_NAME));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -311,7 +311,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter/?participant:Practitioner.family=%s,%s", PARTICIPANT_FAMILY_NAME, "Vox"));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -328,7 +328,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		    PARTICIPANT_FAMILY_NAME, "Vox"));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -345,7 +345,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		    "op87yh-34fd-34egs-56h34-34f7"));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -361,7 +361,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter/?subject.given=%s", PATIENT_GIVEN_NAME));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), subjectCaptor.capture(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = subjectCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -376,7 +376,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter?subject.family=%s", PATIENT_FAMILY_NAME));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), subjectCaptor.capture(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = subjectCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -391,7 +391,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter?subject.identifier=%s", PATIENT_IDENTIFIER));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), subjectCaptor.capture(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = subjectCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -406,7 +406,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter?subject.given=Hannibal&location.address-postalcode=248001");
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), subjectCaptor.capture(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParamsSubject = subjectCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParamSubject = orListParamsSubject.get(0).getValuesAsQueryTokens().get(0);
@@ -427,7 +427,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter?subject.given=Hannibal&location.address-postalcode=248001,854796");
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), subjectCaptor.capture(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParamsSubject = subjectCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParamSubject = orListParamsSubject.get(0).getValuesAsQueryTokens().get(0);
@@ -449,7 +449,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter?subject.given=Hannibal&location.address-postalcode=248001&location.address-postalcode=854796");
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), subjectCaptor.capture(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParamsSubject = subjectCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParamSubject = orListParamsSubject.get(0).getValuesAsQueryTokens().get(0);
@@ -471,7 +471,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter?participant:Practitioner.identifier=1000WF&location.address-postalcode=248001");
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), participantCaptor.capture(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParamsParticipant = participantCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParamParticipant = orListParamsParticipant.get(0).getValuesAsQueryTokens().get(0);
@@ -492,7 +492,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter?participant:Practitioner.identifier=1000WF,670WD&date=ge1975-02-02");
 		
 		verify(encounterService).searchForEncounters(dateRangeCaptor.capture(), isNull(), participantCaptor.capture(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParamsParticipant = participantCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParamParticipant = orListParamsParticipant.get(0).getValuesAsQueryTokens().get(0);
@@ -515,7 +515,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter?_id=%s", ENCOUNTER_UUID));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(),
-		    tokenAndListParamArgumentCaptor.capture(), isNull(), isNull(), isNull(), isNull());
+		    tokenAndListParamArgumentCaptor.capture(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		assertThat(tokenAndListParamArgumentCaptor.getValue(), notNullValue());
 		assertThat(tokenAndListParamArgumentCaptor.getValue().getValuesAsQueryTokens(), not(empty()));
@@ -529,7 +529,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter?type=%s", ENCOUNTER_TYPE_UUID));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(),
-		    tokenAndListParamArgumentCaptor.capture(), isNull(), isNull(), isNull(), isNull(), isNull());
+		    tokenAndListParamArgumentCaptor.capture(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		assertThat(tokenAndListParamArgumentCaptor.getValue(), notNullValue());
 		assertThat(tokenAndListParamArgumentCaptor.getValue().getValuesAsQueryTokens(), not(empty()));
@@ -543,7 +543,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter?_lastUpdated=%s", LAST_UPDATED_DATE));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    dateRangeCaptor.capture(), isNull(), isNull(), isNull());
+		    dateRangeCaptor.capture(), isNull(), isNull(), isNull(), isNull());
 		
 		assertThat(dateRangeCaptor.getValue(), notNullValue());
 		
@@ -561,7 +561,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter?_include=Encounter:patient");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), includeArgumentCaptor.capture(), isNull());
+		    isNull(), includeArgumentCaptor.capture(), isNull(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
@@ -575,7 +575,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter?_include=Encounter:location");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), includeArgumentCaptor.capture(), isNull());
+		    isNull(), includeArgumentCaptor.capture(), isNull(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
@@ -589,7 +589,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter?_include=Encounter:participant");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), includeArgumentCaptor.capture(), isNull());
+		    isNull(), includeArgumentCaptor.capture(), isNull(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
@@ -603,7 +603,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter?_include=Encounter:participant&_include=Encounter:location");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), includeArgumentCaptor.capture(), isNull());
+		    isNull(), includeArgumentCaptor.capture(), isNull(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(2));
@@ -621,7 +621,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter?_revinclude=Observation:encounter");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), includeArgumentCaptor.capture());
+		    isNull(), isNull(), includeArgumentCaptor.capture(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
@@ -635,7 +635,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter?_revinclude=DiagnosticReport:encounter");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), includeArgumentCaptor.capture());
+		    isNull(), isNull(), includeArgumentCaptor.capture(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
@@ -650,7 +650,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter?_revinclude=MedicationRequest:context");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), includeArgumentCaptor.capture());
+		    isNull(), isNull(), includeArgumentCaptor.capture(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
@@ -665,7 +665,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter?_revinclude=ProcedureRequest:encounter");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), includeArgumentCaptor.capture());
+		    isNull(), isNull(), includeArgumentCaptor.capture(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
@@ -680,7 +680,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter?_revinclude=DiagnosticReport:encounter&_revinclude=Observation:encounter");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), includeArgumentCaptor.capture());
+		    isNull(), isNull(), includeArgumentCaptor.capture(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(2));
@@ -696,8 +696,8 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 	private void verifyUri(String uri) throws Exception {
 		Encounter encounter = new Encounter();
 		encounter.setId(ENCOUNTER_UUID);
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
-		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), 10, 1));
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+		    any())).thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), 10, 1));
 		
 		MockHttpServletResponse response = get(uri).accept(FhirMediaTypes.JSON).go();
 		

--- a/omod/src/test/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProviderWebTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProviderWebTest.java
@@ -30,6 +30,7 @@ import javax.servlet.ServletException;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.HashSet;
@@ -38,6 +39,8 @@ import java.util.Objects;
 
 import ca.uhn.fhir.model.api.Include;
 import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.HasAndListParam;
+import ca.uhn.fhir.rest.param.HasOrListParam;
 import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.ReferenceOrListParam;
 import ca.uhn.fhir.rest.param.ReferenceParam;
@@ -125,6 +128,9 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 	
 	@Captor
 	private ArgumentCaptor<HashSet<Include>> includeArgumentCaptor;
+	
+	@Captor
+	private ArgumentCaptor<HasAndListParam> hasAndListParamArgumentCaptor;
 	
 	@Before
 	@Override
@@ -691,6 +697,39 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		assertThat(includeArgumentCaptor.getValue(),
 		    hasItem(allOf(hasProperty("paramName", equalTo(FhirConstants.INCLUDE_ENCOUNTER_PARAM)),
 		        hasProperty("paramType", equalTo(FhirConstants.DIAGNOSTIC_REPORT)))));
+	}
+	
+	@Test
+	public void shouldHandleHasAndListParameter() throws Exception {
+		verifyUri(
+		    "/Encounter?_has:MedicationRequest:encounter:intent=order&_has:MedicationRequest:encounter:status=active,draft");
+		
+		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
+		    isNull(), isNull(), isNull(), hasAndListParamArgumentCaptor.capture());
+		
+		assertThat(hasAndListParamArgumentCaptor.getValue(), notNullValue());
+		
+		HasAndListParam hasAndListParam = hasAndListParamArgumentCaptor.getValue();
+		assertThat(hasAndListParam.size(), equalTo(2));
+		
+		List<HasOrListParam> hasOrListParams = hasAndListParam.getValuesAsQueryTokens();
+		assertThat(hasOrListParams.size(), equalTo(2));
+		
+		List<String> valuesFound = new ArrayList<>();
+		
+		for (HasOrListParam hasOrListParam : hasOrListParams) {
+			hasOrListParam.getValuesAsQueryTokens().forEach(hasParam -> {
+				assertThat(hasParam.getTargetResourceType(), equalTo(FhirConstants.MEDICATION_REQUEST));
+				assertThat(hasParam.getReferenceFieldName(), equalTo("encounter"));
+				valuesFound.add(hasParam.getParameterName() + "=" + hasParam.getParameterValue());
+			});
+		}
+		Collections.sort(valuesFound);
+		
+		assertThat(valuesFound.size(), equalTo(3));
+		assertThat(valuesFound.get(0), equalTo("intent=order"));
+		assertThat(valuesFound.get(1), equalTo("status=active"));
+		assertThat(valuesFound.get(2), equalTo("status=draft"));
 	}
 	
 	private void verifyUri(String uri) throws Exception {

--- a/omod/src/test/java/org/openmrs/module/fhir2/providers/r4/EncounterFhirResourceProviderWebTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/providers/r4/EncounterFhirResourceProviderWebTest.java
@@ -172,7 +172,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter?subject:Patient=%s", PATIENT_UUID));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), subjectCaptor.capture(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		assertThat(subjectCaptor.getValue(), notNullValue());
 		assertThat(subjectCaptor.getAllValues().iterator().next().getValuesAsQueryTokens().iterator().next()
 		        .getValuesAsQueryTokens().iterator().next().getIdPart(),
@@ -187,7 +187,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter/?date=ge1975-02-02");
 		
 		verify(encounterService).searchForEncounters(dateRangeCaptor.capture(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		assertThat(dateRangeCaptor.getValue(), notNullValue());
 		
 		Calendar calendar = Calendar.getInstance();
@@ -203,7 +203,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter/?location=%s", LOCATION_UUID));
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -218,7 +218,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter/?location.address-city=%s", ENCOUNTER_ADDRESS_CITY));
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -233,7 +233,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter/?location.address-state=%s", ENCOUNTER_ADDRESS_STATE));
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -248,7 +248,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter/?location.address-postalcode=%s", ENCOUNTER_POSTALCODE));
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -263,7 +263,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter/?location.address-country=%s", ENCOUNTER_ADDRESS_COUNTRY));
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -278,7 +278,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter/?location.address-country=%s,%s", ENCOUNTER_ADDRESS_COUNTRY, "USA"));
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -294,7 +294,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter/?location.address-country=INDIA&location.address-country=USA");
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -310,7 +310,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter/?participant:Practitioner=%s", PARTICIPANT_UUID));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -325,7 +325,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter/?participant:Practitioner.given=%s", PARTICIPANT_GIVEN_NAME));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -340,7 +340,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter/?participant:Practitioner.family=%s", PARTICIPANT_FAMILY_NAME));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -355,7 +355,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter/?participant:Practitioner.family=%s,%s", PARTICIPANT_FAMILY_NAME, "Vox"));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -372,7 +372,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		    PARTICIPANT_FAMILY_NAME, "Vox"));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -389,7 +389,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		    "op87yh-34fd-34egs-56h34-34f7"));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -405,7 +405,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter/?subject.given=%s", PATIENT_GIVEN_NAME));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), subjectCaptor.capture(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = subjectCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -420,7 +420,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter?subject.family=%s", PATIENT_FAMILY_NAME));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), subjectCaptor.capture(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = subjectCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -435,7 +435,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter?subject.identifier=%s", PATIENT_IDENTIFIER));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), subjectCaptor.capture(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = subjectCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -450,7 +450,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter?subject.given=Hannibal&location.address-postalcode=248001");
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), subjectCaptor.capture(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParamsSubject = subjectCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParamSubject = orListParamsSubject.get(0).getValuesAsQueryTokens().get(0);
@@ -471,7 +471,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter?subject.given=Hannibal&location.address-postalcode=248001,854796");
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), subjectCaptor.capture(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParamsSubject = subjectCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParamSubject = orListParamsSubject.get(0).getValuesAsQueryTokens().get(0);
@@ -493,7 +493,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter?subject.given=Hannibal&location.address-postalcode=248001&location.address-postalcode=854796");
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), subjectCaptor.capture(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParamsSubject = subjectCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParamSubject = orListParamsSubject.get(0).getValuesAsQueryTokens().get(0);
@@ -515,7 +515,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter?participant:Practitioner.identifier=1000WF&location.address-postalcode=248001");
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), participantCaptor.capture(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParamsParticipant = participantCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParamParticipant = orListParamsParticipant.get(0).getValuesAsQueryTokens().get(0);
@@ -536,7 +536,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter?participant:Practitioner.identifier=1000WF,670WD&date=ge1975-02-02");
 		
 		verify(encounterService).searchForEncounters(dateRangeCaptor.capture(), isNull(), participantCaptor.capture(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParamsParticipant = participantCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParamParticipant = orListParamsParticipant.get(0).getValuesAsQueryTokens().get(0);
@@ -559,7 +559,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter?_id=%s", ENCOUNTER_UUID));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(),
-		    tokenAndListParamArgumentCaptor.capture(), isNull(), isNull(), isNull(), isNull());
+		    tokenAndListParamArgumentCaptor.capture(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		assertThat(tokenAndListParamArgumentCaptor.getValue(), notNullValue());
 		assertThat(tokenAndListParamArgumentCaptor.getValue().getValuesAsQueryTokens(), not(empty()));
@@ -573,7 +573,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter?type=%s", ENCOUNTER_TYPE_UUID));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(),
-		    tokenAndListParamArgumentCaptor.capture(), isNull(), isNull(), isNull(), isNull(), isNull());
+		    tokenAndListParamArgumentCaptor.capture(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		assertThat(tokenAndListParamArgumentCaptor.getValue(), notNullValue());
 		assertThat(tokenAndListParamArgumentCaptor.getValue().getValuesAsQueryTokens(), not(empty()));
@@ -587,7 +587,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter?_lastUpdated=%s", LAST_UPDATED_DATE));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    dateRangeCaptor.capture(), isNull(), isNull(), isNull());
+		    dateRangeCaptor.capture(), isNull(), isNull(), isNull(), isNull());
 		
 		assertThat(dateRangeCaptor.getValue(), notNullValue());
 		
@@ -605,7 +605,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter?_include=Encounter:patient");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), includeArgumentCaptor.capture(), isNull());
+		    isNull(), includeArgumentCaptor.capture(), isNull(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
@@ -619,7 +619,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter?_include=Encounter:location");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), includeArgumentCaptor.capture(), isNull());
+		    isNull(), includeArgumentCaptor.capture(), isNull(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
@@ -633,7 +633,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter?_include=Encounter:participant");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), includeArgumentCaptor.capture(), isNull());
+		    isNull(), includeArgumentCaptor.capture(), isNull(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
@@ -647,7 +647,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter?_include=Encounter:participant&_include=Encounter:location");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), includeArgumentCaptor.capture(), isNull());
+		    isNull(), includeArgumentCaptor.capture(), isNull(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(2));
@@ -665,7 +665,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter?_revinclude=Observation:encounter");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), includeArgumentCaptor.capture());
+		    isNull(), isNull(), includeArgumentCaptor.capture(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
@@ -679,7 +679,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter?_revinclude=DiagnosticReport:encounter");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), includeArgumentCaptor.capture());
+		    isNull(), isNull(), includeArgumentCaptor.capture(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
@@ -694,7 +694,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter?_revinclude=MedicationRequest:encounter");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), includeArgumentCaptor.capture());
+		    isNull(), isNull(), includeArgumentCaptor.capture(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
@@ -709,7 +709,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter?_revinclude=ServiceRequest:encounter");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), includeArgumentCaptor.capture());
+		    isNull(), isNull(), includeArgumentCaptor.capture(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
@@ -724,7 +724,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter?_revinclude=DiagnosticReport:encounter&_revinclude=Observation:encounter");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), includeArgumentCaptor.capture());
+		    isNull(), isNull(), includeArgumentCaptor.capture(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(2));
@@ -740,8 +740,8 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 	private void verifyUri(String uri) throws Exception {
 		Encounter encounter = new Encounter();
 		encounter.setId(ENCOUNTER_UUID);
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
-		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), 10, 1));
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+		    any())).thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), 10, 1));
 		
 		MockHttpServletResponse response = get(uri).accept(FhirMediaTypes.JSON).go();
 		


### PR DESCRIPTION
Draft PR for supporting "nested reverse chaining" - i.e. the ":has..." parameters, with an objective of getting just those Encounter resources that have associated MedicationRequests.
