### PR TITLE
FM2-477 and FM2-478: Support limiting to only Encounters that have medication requests

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhir2/FhirConstants.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/FhirConstants.java
@@ -313,4 +313,6 @@ public class FhirConstants {
 	public static final String EVERYTHING_SEARCH_HANDLER = "everything.search.handler";
 	
 	public static final String CONDITION_OBSERVATION_CONCEPT_UUID = "1284AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+	
+	public static final String HAS_SEARCH_HANDLER = "_has";
 }

--- a/api/src/main/java/org/openmrs/module/fhir2/FhirConstants.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/FhirConstants.java
@@ -315,8 +315,8 @@ public class FhirConstants {
 	public static final String CONDITION_OBSERVATION_CONCEPT_UUID = "1284AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 	
 	public static final String HAS_SEARCH_HANDLER = "_has";
-
+	
 	public static final String SNOMED_SYSTEM_URI = "http://snomed.info/sct";
-
+	
 	public static final String RX_NORM_SYSTEM_URI = "http://www.nlm.nih.gov/research/umls/rxnorm";
 }

--- a/api/src/main/java/org/openmrs/module/fhir2/FhirConstants.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/FhirConstants.java
@@ -302,10 +302,6 @@ public class FhirConstants {
 	
 	public static final String INCLUDE_OWNER_PARAM = "owner";
 	
-	public static final String INCLUDE_INTENT_PARAM = "intent";
-	
-	public static final String INCLUDE_STATUS_PARAM = "status";
-	
 	public static final String REVERSE_INCLUDE_SEARCH_HANDLER = "_revinclude.search.handler";
 	
 	public static final String MAX_SEARCH_HANDLER = "max.search.handler";

--- a/api/src/main/java/org/openmrs/module/fhir2/FhirConstants.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/FhirConstants.java
@@ -302,6 +302,10 @@ public class FhirConstants {
 	
 	public static final String INCLUDE_OWNER_PARAM = "owner";
 	
+	public static final String INCLUDE_INTENT_PARAM = "intent";
+	
+	public static final String INCLUDE_STATUS_PARAM = "status";
+	
 	public static final String REVERSE_INCLUDE_SEARCH_HANDLER = "_revinclude.search.handler";
 	
 	public static final String MAX_SEARCH_HANDLER = "max.search.handler";

--- a/api/src/main/java/org/openmrs/module/fhir2/api/FhirEncounterService.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/FhirEncounterService.java
@@ -15,6 +15,7 @@ import ca.uhn.fhir.model.api.Include;
 import ca.uhn.fhir.rest.api.SortSpec;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.HasAndListParam;
 import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.TokenAndListParam;
 import ca.uhn.fhir.rest.param.TokenParam;
@@ -25,7 +26,7 @@ public interface FhirEncounterService extends FhirService<Encounter> {
 	IBundleProvider searchForEncounters(DateRangeParam date, ReferenceAndListParam location,
 	        ReferenceAndListParam participant, ReferenceAndListParam subject, TokenAndListParam encounterType,
 	        TokenAndListParam id, DateRangeParam lastUpdated, SortSpec sort, HashSet<Include> includes,
-	        HashSet<Include> revIncludes);
+	        HashSet<Include> revIncludes, HasAndListParam hasMedicationRequestParam);
 	
 	IBundleProvider getEncounterEverything(TokenParam identifier);
 }

--- a/api/src/main/java/org/openmrs/module/fhir2/api/FhirEncounterService.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/FhirEncounterService.java
@@ -26,7 +26,7 @@ public interface FhirEncounterService extends FhirService<Encounter> {
 	IBundleProvider searchForEncounters(DateRangeParam date, ReferenceAndListParam location,
 	        ReferenceAndListParam participant, ReferenceAndListParam subject, TokenAndListParam encounterType,
 	        TokenAndListParam id, DateRangeParam lastUpdated, SortSpec sort, HashSet<Include> includes,
-	        HashSet<Include> revIncludes, HasAndListParam hasMedicationRequestParam);
+	        HashSet<Include> revIncludes, HasAndListParam hasAndListParam);
 	
 	IBundleProvider getEncounterEverything(TokenParam identifier);
 }

--- a/api/src/main/java/org/openmrs/module/fhir2/api/FhirEncounterService.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/FhirEncounterService.java
@@ -9,24 +9,14 @@
  */
 package org.openmrs.module.fhir2.api;
 
-import java.util.HashSet;
-
-import ca.uhn.fhir.model.api.Include;
-import ca.uhn.fhir.rest.api.SortSpec;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
-import ca.uhn.fhir.rest.param.DateRangeParam;
-import ca.uhn.fhir.rest.param.HasAndListParam;
-import ca.uhn.fhir.rest.param.ReferenceAndListParam;
-import ca.uhn.fhir.rest.param.TokenAndListParam;
 import ca.uhn.fhir.rest.param.TokenParam;
 import org.hl7.fhir.r4.model.Encounter;
+import org.openmrs.module.fhir2.api.search.param.EncounterSearchParams;
 
 public interface FhirEncounterService extends FhirService<Encounter> {
 	
-	IBundleProvider searchForEncounters(DateRangeParam date, ReferenceAndListParam location,
-	        ReferenceAndListParam participant, ReferenceAndListParam subject, TokenAndListParam encounterType,
-	        TokenAndListParam id, DateRangeParam lastUpdated, SortSpec sort, HashSet<Include> includes,
-	        HashSet<Include> revIncludes, HasAndListParam hasAndListParam);
+	IBundleProvider searchForEncounters(EncounterSearchParams encounterSearchParams);
 	
 	IBundleProvider getEncounterEverything(TokenParam identifier);
 }

--- a/api/src/main/java/org/openmrs/module/fhir2/api/dao/impl/BaseEncounterDao.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/dao/impl/BaseEncounterDao.java
@@ -71,7 +71,7 @@ public abstract class BaseEncounterDao<T extends OpenmrsObject & Auditable> exte
 			handleAndListParam(hasAndListParam, hasParam -> {
 				if (hasParam != null) {
 					if (FhirConstants.MEDICATION_REQUEST.equals(hasParam.getTargetResourceType())) {
-						if (FhirConstants.INCLUDE_ENCOUNTER_PARAM.equals(hasParam.getReferenceFieldName())) {
+						if (MedicationRequest.SP_ENCOUNTER.equals(hasParam.getReferenceFieldName())) {
 							if (lacksAlias(criteria, "orders")) {
 								if (Encounter.class.isAssignableFrom(typeToken.getRawType())) {
 									criteria.createAlias("orders", "orders");
@@ -89,12 +89,12 @@ public abstract class BaseEncounterDao<T extends OpenmrsObject & Auditable> exte
 							String paramName = hasParam.getParameterName();
 							String paramValue = hasParam.getParameterValue();
 							if (StringUtils.isNotBlank(paramName) && StringUtils.isNotBlank(paramValue)) {
-								if (FhirConstants.INCLUDE_INTENT_PARAM.equals(paramName)) {
+								if (MedicationRequest.SP_INTENT.equals(paramName)) {
 									if (MedicationRequest.MedicationRequestIntent.ORDER.toCode().equals(paramValue)) {
 										// Do not constrain, all Orders are given this intent
 									}
 								}
-								if (FhirConstants.INCLUDE_STATUS_PARAM.equals(paramName)) {
+								if (MedicationRequest.SP_STATUS.equals(paramName)) {
 									Date now = new Date();
 									if (MedicationRequest.MedicationRequestStatus.ACTIVE.toCode().equals(paramValue)) {
 										criteria.add(Restrictions.ne("orders.action", Order.Action.DISCONTINUE));

--- a/api/src/main/java/org/openmrs/module/fhir2/api/impl/FhirEncounterServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/impl/FhirEncounterServiceImpl.java
@@ -148,7 +148,6 @@ public class FhirEncounterServiceImpl extends BaseFhirService<Encounter, org.ope
 	        ReferenceAndListParam participant, ReferenceAndListParam subject, TokenAndListParam encounterType,
 	        TokenAndListParam id, DateRangeParam lastUpdated, SortSpec sort, HashSet<Include> includes,
 	        HashSet<Include> revIncludes, HasAndListParam hasAndListParam) {
-		
 		SearchParameterMap theParams = new SearchParameterMap().addParameter(FhirConstants.DATE_RANGE_SEARCH_HANDLER, date)
 		        .addParameter(FhirConstants.LOCATION_REFERENCE_SEARCH_HANDLER, location)
 		        .addParameter(FhirConstants.PARTICIPANT_REFERENCE_SEARCH_HANDLER, participant)
@@ -161,7 +160,6 @@ public class FhirEncounterServiceImpl extends BaseFhirService<Encounter, org.ope
 		        .addParameter(FhirConstants.HAS_SEARCH_HANDLER, hasAndListParam).setSortSpec(sort);
 		
 		IBundleProvider visitBundle = visitService.searchForVisits(theParams);
-		
 		IBundleProvider encounterBundle = searchQuery.getQueryResults(theParams, dao, translator, searchQueryInclude);
 		
 		if (!encounterBundle.isEmpty() && !visitBundle.isEmpty()) {

--- a/api/src/main/java/org/openmrs/module/fhir2/api/impl/FhirEncounterServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/impl/FhirEncounterServiceImpl.java
@@ -184,8 +184,10 @@ public class FhirEncounterServiceImpl extends BaseFhirService<Encounter, org.ope
 		if (tokenAndListParam != null && tokenAndListParam.getValuesAsQueryTokens() != null) {
 			tokenAndListParam.getValuesAsQueryTokens().forEach(tokenOrListParam -> {
 				tokenOrListParam.getValuesAsQueryTokens().forEach(tokenParam -> {
-					if (tokenParam.getSystem().equals(FhirConstants.OPENMRS_FHIR_EXT_ENCOUNTER_TAG)) {
-						tagsToInclude.add(tokenParam.getValue());
+					if (tokenParam != null && tokenParam.getSystem() != null && tokenParam.getValue() != null) {
+						if (tokenParam.getSystem().equals(FhirConstants.OPENMRS_FHIR_EXT_ENCOUNTER_TAG)) {
+							tagsToInclude.add(tokenParam.getValue());
+						}
 					}
 				});
 			});

--- a/api/src/main/java/org/openmrs/module/fhir2/api/impl/FhirEncounterServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/impl/FhirEncounterServiceImpl.java
@@ -17,6 +17,7 @@ import ca.uhn.fhir.model.api.Include;
 import ca.uhn.fhir.rest.api.SortSpec;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.HasAndListParam;
 import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.TokenAndListParam;
 import ca.uhn.fhir.rest.param.TokenParam;
@@ -146,7 +147,8 @@ public class FhirEncounterServiceImpl extends BaseFhirService<Encounter, org.ope
 	public IBundleProvider searchForEncounters(DateRangeParam date, ReferenceAndListParam location,
 	        ReferenceAndListParam participant, ReferenceAndListParam subject, TokenAndListParam encounterType,
 	        TokenAndListParam id, DateRangeParam lastUpdated, SortSpec sort, HashSet<Include> includes,
-	        HashSet<Include> revIncludes) {
+	        HashSet<Include> revIncludes, HasAndListParam hasAndListParam) {
+		
 		SearchParameterMap theParams = new SearchParameterMap().addParameter(FhirConstants.DATE_RANGE_SEARCH_HANDLER, date)
 		        .addParameter(FhirConstants.LOCATION_REFERENCE_SEARCH_HANDLER, location)
 		        .addParameter(FhirConstants.PARTICIPANT_REFERENCE_SEARCH_HANDLER, participant)
@@ -155,9 +157,11 @@ public class FhirEncounterServiceImpl extends BaseFhirService<Encounter, org.ope
 		        .addParameter(FhirConstants.COMMON_SEARCH_HANDLER, FhirConstants.ID_PROPERTY, id)
 		        .addParameter(FhirConstants.COMMON_SEARCH_HANDLER, FhirConstants.LAST_UPDATED_PROPERTY, lastUpdated)
 		        .addParameter(FhirConstants.INCLUDE_SEARCH_HANDLER, includes)
-		        .addParameter(FhirConstants.REVERSE_INCLUDE_SEARCH_HANDLER, revIncludes).setSortSpec(sort);
+		        .addParameter(FhirConstants.REVERSE_INCLUDE_SEARCH_HANDLER, revIncludes)
+		        .addParameter(FhirConstants.HAS_SEARCH_HANDLER, hasAndListParam).setSortSpec(sort);
 		
 		IBundleProvider visitBundle = visitService.searchForVisits(theParams);
+		
 		IBundleProvider encounterBundle = searchQuery.getQueryResults(theParams, dao, translator, searchQueryInclude);
 		
 		if (!encounterBundle.isEmpty() && !visitBundle.isEmpty()) {

--- a/api/src/main/java/org/openmrs/module/fhir2/api/search/SearchQueryInclude.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/search/SearchQueryInclude.java
@@ -207,7 +207,8 @@ public class SearchQueryInclude<U extends IBaseResource> {
 				return locationService.searchForLocations(null, null, null, null, null, null, params, null, null, null, null,
 				    null);
 			case FhirConstants.ENCOUNTER:
-				return encounterService.searchForEncounters(null, params, null, null, null, null, null, null, null, null);
+				return encounterService.searchForEncounters(null, params, null, null, null, null, null, null, null, null,
+				    null);
 		}
 		
 		return null;
@@ -229,7 +230,8 @@ public class SearchQueryInclude<U extends IBaseResource> {
 	private IBundleProvider handlePractitionerReverseInclude(ReferenceAndListParam params, String targetType) {
 		switch (targetType) {
 			case FhirConstants.ENCOUNTER:
-				return encounterService.searchForEncounters(null, null, params, null, null, null, null, null, null, null);
+				return encounterService.searchForEncounters(null, null, params, null, null, null, null, null, null, null,
+				    null);
 			case FhirConstants.MEDICATION_REQUEST:
 				return medicationRequestService.searchForMedicationRequests(null, null, null, params, null, null, null,
 				    null);
@@ -282,7 +284,8 @@ public class SearchQueryInclude<U extends IBaseResource> {
 				return allergyIntoleranceService.searchForAllergies(params, null, null, null, null, null, null, null, null,
 				    null);
 			case FhirConstants.ENCOUNTER:
-				return encounterService.searchForEncounters(null, null, null, params, null, null, null, null, null, null);
+				return encounterService.searchForEncounters(null, null, null, params, null, null, null, null, null, null,
+				    null);
 			case FhirConstants.MEDICATION_REQUEST:
 				return medicationRequestService.searchForMedicationRequests(params, null, null, null, null, null, null,
 				    null);

--- a/api/src/main/java/org/openmrs/module/fhir2/api/search/SearchQueryInclude.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/search/SearchQueryInclude.java
@@ -47,6 +47,7 @@ import org.openmrs.module.fhir2.api.FhirObservationService;
 import org.openmrs.module.fhir2.api.FhirPatientService;
 import org.openmrs.module.fhir2.api.FhirPractitionerService;
 import org.openmrs.module.fhir2.api.FhirServiceRequestService;
+import org.openmrs.module.fhir2.api.search.param.EncounterSearchParams;
 import org.openmrs.module.fhir2.api.search.param.PropParam;
 import org.openmrs.module.fhir2.api.search.param.SearchParameterMap;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -207,8 +208,9 @@ public class SearchQueryInclude<U extends IBaseResource> {
 				return locationService.searchForLocations(null, null, null, null, null, null, params, null, null, null, null,
 				    null);
 			case FhirConstants.ENCOUNTER:
-				return encounterService.searchForEncounters(null, params, null, null, null, null, null, null, null, null,
-				    null);
+				EncounterSearchParams encounterSearchParams = new EncounterSearchParams();
+				encounterSearchParams.setLocation(params);
+				return encounterService.searchForEncounters(encounterSearchParams);
 		}
 		
 		return null;
@@ -230,8 +232,9 @@ public class SearchQueryInclude<U extends IBaseResource> {
 	private IBundleProvider handlePractitionerReverseInclude(ReferenceAndListParam params, String targetType) {
 		switch (targetType) {
 			case FhirConstants.ENCOUNTER:
-				return encounterService.searchForEncounters(null, null, params, null, null, null, null, null, null, null,
-				    null);
+				EncounterSearchParams encounterSearchParams = new EncounterSearchParams();
+				encounterSearchParams.setParticipant(params);
+				return encounterService.searchForEncounters(encounterSearchParams);
 			case FhirConstants.MEDICATION_REQUEST:
 				return medicationRequestService.searchForMedicationRequests(null, null, null, params, null, null, null,
 				    null);
@@ -284,8 +287,9 @@ public class SearchQueryInclude<U extends IBaseResource> {
 				return allergyIntoleranceService.searchForAllergies(params, null, null, null, null, null, null, null, null,
 				    null);
 			case FhirConstants.ENCOUNTER:
-				return encounterService.searchForEncounters(null, null, null, params, null, null, null, null, null, null,
-				    null);
+				EncounterSearchParams encounterSearchParams = new EncounterSearchParams();
+				encounterSearchParams.setSubject(params);
+				return encounterService.searchForEncounters(encounterSearchParams);
 			case FhirConstants.MEDICATION_REQUEST:
 				return medicationRequestService.searchForMedicationRequests(params, null, null, null, null, null, null,
 				    null);

--- a/api/src/main/java/org/openmrs/module/fhir2/api/search/param/EncounterSearchParams.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/search/param/EncounterSearchParams.java
@@ -1,0 +1,53 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.fhir2.api.search.param;
+
+import java.io.Serializable;
+import java.util.HashSet;
+
+import ca.uhn.fhir.model.api.Include;
+import ca.uhn.fhir.rest.api.SortSpec;
+import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.HasAndListParam;
+import ca.uhn.fhir.rest.param.ReferenceAndListParam;
+import ca.uhn.fhir.rest.param.TokenAndListParam;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class EncounterSearchParams implements Serializable {
+	
+	private DateRangeParam date;
+	
+	private ReferenceAndListParam location;
+	
+	private ReferenceAndListParam participant;
+	
+	private ReferenceAndListParam subject;
+	
+	private TokenAndListParam encounterType;
+	
+	private TokenAndListParam id;
+	
+	private DateRangeParam lastUpdated;
+	
+	private SortSpec sort;
+	
+	private HashSet<Include> includes;
+	
+	private HashSet<Include> revIncludes;
+	
+	private HasAndListParam hasAndListParam;
+	
+	private TokenAndListParam tag;
+}

--- a/api/src/main/java/org/openmrs/module/fhir2/api/search/param/EncounterSearchParams.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/search/param/EncounterSearchParams.java
@@ -19,12 +19,14 @@ import ca.uhn.fhir.rest.param.HasAndListParam;
 import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.TokenAndListParam;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class EncounterSearchParams implements Serializable {
 	
 	private DateRangeParam date;
@@ -41,13 +43,13 @@ public class EncounterSearchParams implements Serializable {
 	
 	private DateRangeParam lastUpdated;
 	
+	private TokenAndListParam tag;
+	
+	private HasAndListParam hasAndListParam;
+	
 	private SortSpec sort;
 	
 	private HashSet<Include> includes;
 	
 	private HashSet<Include> revIncludes;
-	
-	private HasAndListParam hasAndListParam;
-	
-	private TokenAndListParam tag;
 }

--- a/api/src/main/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProvider.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProvider.java
@@ -54,6 +54,7 @@ import org.openmrs.module.fhir2.FhirConstants;
 import org.openmrs.module.fhir2.api.FhirEncounterService;
 import org.openmrs.module.fhir2.api.annotations.R3Provider;
 import org.openmrs.module.fhir2.api.search.SearchQueryBundleProviderR3Wrapper;
+import org.openmrs.module.fhir2.api.search.param.EncounterSearchParams;
 import org.openmrs.module.fhir2.providers.util.FhirProviderUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -124,6 +125,7 @@ public class EncounterFhirResourceProvider implements IResourceProvider {
 	                Patient.SP_FAMILY, Patient.SP_NAME }, targetTypes = Patient.class) ReferenceAndListParam patientParam,
 	        @OptionalParam(name = Encounter.SP_TYPE) TokenAndListParam encounterType,
 	        @OptionalParam(name = Encounter.SP_RES_ID) TokenAndListParam id,
+	        @OptionalParam(name = "_tag") TokenAndListParam tag,
 	        @OptionalParam(name = "_lastUpdated") DateRangeParam lastUpdated, @Sort SortSpec sort,
 	        @OptionalParam(name = FhirConstants.HAS_SEARCH_HANDLER) HasAndListParam hasAndListParam,
 	        @IncludeParam(allow = { "Encounter:" + Encounter.SP_LOCATION, "Encounter:" + Encounter.SP_PATIENT,
@@ -143,9 +145,9 @@ public class EncounterFhirResourceProvider implements IResourceProvider {
 			revIncludes = null;
 		}
 		
-		return new SearchQueryBundleProviderR3Wrapper(
-		        encounterService.searchForEncounters(date, location, participantReference, subjectReference, encounterType,
-		            id, lastUpdated, sort, includes, revIncludes, hasAndListParam));
+		return new SearchQueryBundleProviderR3Wrapper(encounterService
+		        .searchForEncounters(new EncounterSearchParams(date, location, participantReference, subjectReference,
+		                encounterType, id, lastUpdated, sort, includes, revIncludes, hasAndListParam, tag)));
 	}
 	
 }

--- a/api/src/main/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProvider.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProvider.java
@@ -30,6 +30,7 @@ import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.api.SortSpec;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.HasAndListParam;
 import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.TokenAndListParam;
 import ca.uhn.fhir.rest.server.IResourceProvider;
@@ -49,6 +50,7 @@ import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.dstu3.model.Practitioner;
 import org.hl7.fhir.dstu3.model.ProcedureRequest;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.openmrs.module.fhir2.FhirConstants;
 import org.openmrs.module.fhir2.api.FhirEncounterService;
 import org.openmrs.module.fhir2.api.annotations.R3Provider;
 import org.openmrs.module.fhir2.api.search.SearchQueryBundleProviderR3Wrapper;
@@ -123,6 +125,7 @@ public class EncounterFhirResourceProvider implements IResourceProvider {
 	        @OptionalParam(name = Encounter.SP_TYPE) TokenAndListParam encounterType,
 	        @OptionalParam(name = Encounter.SP_RES_ID) TokenAndListParam id,
 	        @OptionalParam(name = "_lastUpdated") DateRangeParam lastUpdated, @Sort SortSpec sort,
+	        @OptionalParam(name = FhirConstants.HAS_SEARCH_HANDLER) HasAndListParam hasAndListParam,
 	        @IncludeParam(allow = { "Encounter:" + Encounter.SP_LOCATION, "Encounter:" + Encounter.SP_PATIENT,
 	                "Encounter:" + Encounter.SP_PARTICIPANT }) HashSet<Include> includes,
 	        @IncludeParam(reverse = true, allow = { "Observation:" + Observation.SP_ENCOUNTER,
@@ -140,8 +143,9 @@ public class EncounterFhirResourceProvider implements IResourceProvider {
 			revIncludes = null;
 		}
 		
-		return new SearchQueryBundleProviderR3Wrapper(encounterService.searchForEncounters(date, location,
-		    participantReference, subjectReference, encounterType, id, lastUpdated, sort, includes, revIncludes));
+		return new SearchQueryBundleProviderR3Wrapper(
+		        encounterService.searchForEncounters(date, location, participantReference, subjectReference, encounterType,
+		            id, lastUpdated, sort, includes, revIncludes, hasAndListParam));
 	}
 	
 }

--- a/api/src/main/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProvider.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProvider.java
@@ -147,7 +147,7 @@ public class EncounterFhirResourceProvider implements IResourceProvider {
 		
 		return new SearchQueryBundleProviderR3Wrapper(encounterService
 		        .searchForEncounters(new EncounterSearchParams(date, location, participantReference, subjectReference,
-		                encounterType, id, lastUpdated, sort, includes, revIncludes, hasAndListParam, tag)));
+		                encounterType, id, lastUpdated, tag, hasAndListParam, sort, includes, revIncludes)));
 	}
 	
 }

--- a/api/src/main/java/org/openmrs/module/fhir2/providers/r4/EncounterFhirResourceProvider.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/providers/r4/EncounterFhirResourceProvider.java
@@ -55,6 +55,7 @@ import org.hl7.fhir.r4.model.ServiceRequest;
 import org.openmrs.module.fhir2.FhirConstants;
 import org.openmrs.module.fhir2.api.FhirEncounterService;
 import org.openmrs.module.fhir2.api.annotations.R4Provider;
+import org.openmrs.module.fhir2.api.search.param.EncounterSearchParams;
 import org.openmrs.module.fhir2.providers.util.FhirProviderUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -119,6 +120,7 @@ public class EncounterFhirResourceProvider implements IResourceProvider {
 	                Patient.SP_FAMILY, Patient.SP_NAME }, targetTypes = Patient.class) ReferenceAndListParam patientParam,
 	        @OptionalParam(name = Encounter.SP_TYPE) TokenAndListParam encounterType,
 	        @OptionalParam(name = Encounter.SP_RES_ID) TokenAndListParam id,
+	        @OptionalParam(name = "_tag") TokenAndListParam tag,
 	        @OptionalParam(name = "_lastUpdated") DateRangeParam lastUpdated, @Sort SortSpec sort,
 	        @OptionalParam(name = FhirConstants.HAS_SEARCH_HANDLER) HasAndListParam hasAndListParam,
 	        @IncludeParam(allow = { "Encounter:" + Encounter.SP_LOCATION, "Encounter:" + Encounter.SP_PATIENT,
@@ -139,8 +141,8 @@ public class EncounterFhirResourceProvider implements IResourceProvider {
 			revIncludes = null;
 		}
 		
-		return encounterService.searchForEncounters(date, location, participantReference, subjectReference, encounterType,
-		    id, lastUpdated, sort, includes, revIncludes, hasAndListParam);
+		return encounterService.searchForEncounters(new EncounterSearchParams(date, location, participantReference,
+		        subjectReference, encounterType, id, lastUpdated, sort, includes, revIncludes, hasAndListParam, tag));
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/module/fhir2/providers/r4/EncounterFhirResourceProvider.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/providers/r4/EncounterFhirResourceProvider.java
@@ -32,6 +32,7 @@ import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.api.SortSpec;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.HasAndListParam;
 import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.TokenAndListParam;
 import ca.uhn.fhir.rest.param.TokenParam;
@@ -51,6 +52,7 @@ import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Practitioner;
 import org.hl7.fhir.r4.model.ServiceRequest;
+import org.openmrs.module.fhir2.FhirConstants;
 import org.openmrs.module.fhir2.api.FhirEncounterService;
 import org.openmrs.module.fhir2.api.annotations.R4Provider;
 import org.openmrs.module.fhir2.providers.util.FhirProviderUtils;
@@ -118,6 +120,7 @@ public class EncounterFhirResourceProvider implements IResourceProvider {
 	        @OptionalParam(name = Encounter.SP_TYPE) TokenAndListParam encounterType,
 	        @OptionalParam(name = Encounter.SP_RES_ID) TokenAndListParam id,
 	        @OptionalParam(name = "_lastUpdated") DateRangeParam lastUpdated, @Sort SortSpec sort,
+	        @OptionalParam(name = FhirConstants.HAS_SEARCH_HANDLER) HasAndListParam hasAndListParam,
 	        @IncludeParam(allow = { "Encounter:" + Encounter.SP_LOCATION, "Encounter:" + Encounter.SP_PATIENT,
 	                "Encounter:" + Encounter.SP_PARTICIPANT }) HashSet<Include> includes,
 	        @IncludeParam(reverse = true, allow = { "Observation:" + Observation.SP_ENCOUNTER,
@@ -137,7 +140,7 @@ public class EncounterFhirResourceProvider implements IResourceProvider {
 		}
 		
 		return encounterService.searchForEncounters(date, location, participantReference, subjectReference, encounterType,
-		    id, lastUpdated, sort, includes, revIncludes);
+		    id, lastUpdated, sort, includes, revIncludes, hasAndListParam);
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/module/fhir2/providers/r4/EncounterFhirResourceProvider.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/providers/r4/EncounterFhirResourceProvider.java
@@ -142,7 +142,7 @@ public class EncounterFhirResourceProvider implements IResourceProvider {
 		}
 		
 		return encounterService.searchForEncounters(new EncounterSearchParams(date, location, participantReference,
-		        subjectReference, encounterType, id, lastUpdated, sort, includes, revIncludes, hasAndListParam, tag));
+		        subjectReference, encounterType, id, lastUpdated, tag, hasAndListParam, sort, includes, revIncludes));
 	}
 	
 	/**

--- a/api/src/test/java/org/openmrs/module/fhir2/api/dao/impl/FhirEncounterDaoImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/dao/impl/FhirEncounterDaoImplTest.java
@@ -95,7 +95,7 @@ public class FhirEncounterDaoImplTest extends BaseModuleContextSensitiveTest {
 		}
 		
 		HasOrListParam hasOrListParam = new HasOrListParam();
-		hasOrListParam.add(new HasParam("MedicationRequest", "encounter", "meta:tag:code", "Encounter"));
+		hasOrListParam.add(new HasParam("MedicationRequest", "encounter", "intent", "order"));
 		HasAndListParam hasAndListParam = new HasAndListParam();
 		hasAndListParam.addAnd(hasOrListParam);
 		SearchParameterMap theParams = new SearchParameterMap().addParameter(FhirConstants.HAS_SEARCH_HANDLER,

--- a/api/src/test/java/org/openmrs/module/fhir2/api/dao/impl/FhirEncounterDaoImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/dao/impl/FhirEncounterDaoImplTest.java
@@ -82,7 +82,7 @@ public class FhirEncounterDaoImplTest extends BaseModuleContextSensitiveTest {
 	}
 	
 	@Test
-	public void shouldOnlyReturnEncountersThatHaveAtLeastOneHasParamResource() {
+	public void shouldOnlyReturnEncountersThatHaveAssociatedMedicationRequests() {
 		Encounter withNoDrugOrders = dao.get(ENCOUNTER_WITH_NO_DRUG_ORDERS);
 		assertThat(withNoDrugOrders, notNullValue());
 		assertThat("Orders is empty", withNoDrugOrders.getOrders().isEmpty());

--- a/api/src/test/java/org/openmrs/module/fhir2/api/dao/impl/FhirEncounterDaoImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/dao/impl/FhirEncounterDaoImplTest.java
@@ -53,13 +53,6 @@ public class FhirEncounterDaoImplTest extends BaseModuleContextSensitiveTest {
 	
 	private FhirEncounterDaoImpl dao;
 	
-	@Override
-	public Properties getRuntimeProperties() {
-		Properties p = super.getRuntimeProperties();
-		//p.put("hibernate.show_sql", "true");
-		return p;
-	}
-	
 	@Before
 	public void setUp() throws Exception {
 		dao = new FhirEncounterDaoImpl();

--- a/api/src/test/java/org/openmrs/module/fhir2/api/dao/impl/FhirEncounterDaoImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/dao/impl/FhirEncounterDaoImplTest.java
@@ -9,20 +9,30 @@
  */
 package org.openmrs.module.fhir2.api.dao.impl;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-
+import ca.uhn.fhir.rest.param.HasAndListParam;
+import ca.uhn.fhir.rest.param.HasOrListParam;
+import ca.uhn.fhir.rest.param.HasParam;
 import org.hibernate.SessionFactory;
 import org.junit.Before;
 import org.junit.Test;
+import org.openmrs.DrugOrder;
 import org.openmrs.Encounter;
+import org.openmrs.Order;
+import org.openmrs.module.fhir2.FhirConstants;
 import org.openmrs.module.fhir2.TestFhirSpringConfiguration;
+import org.openmrs.module.fhir2.api.search.param.SearchParameterMap;
 import org.openmrs.test.BaseModuleContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.context.ContextConfiguration;
+
+import java.util.List;
+import java.util.Properties;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @ContextConfiguration(classes = TestFhirSpringConfiguration.class, inheritLocations = false)
 public class FhirEncounterDaoImplTest extends BaseModuleContextSensitiveTest {
@@ -31,6 +41,10 @@ public class FhirEncounterDaoImplTest extends BaseModuleContextSensitiveTest {
 	
 	private static final String UNKNOWN_ENCOUNTER_UUID = "xx923xx-3423kk-2323-232jk23";
 	
+	private static final String ENCOUNTER_WITH_DRUG_ORDERS = "6519d653-393b-4118-9c83-a3715b82d4ac"; // 3 in standard test dataset
+	
+	private static final String ENCOUNTER_WITH_NO_DRUG_ORDERS = "eec646cb-c847-45a7-98bc-91c8c4f70add"; // 4 in standard test dataset
+	
 	private static final String ENCOUNTER_INITIAL_DATA_XML = "org/openmrs/module/fhir2/api/dao/impl/FhirEncounterDaoImplTest_initial_data.xml";
 	
 	@Autowired
@@ -38,6 +52,13 @@ public class FhirEncounterDaoImplTest extends BaseModuleContextSensitiveTest {
 	private SessionFactory sessionFactory;
 	
 	private FhirEncounterDaoImpl dao;
+	
+	@Override
+	public Properties getRuntimeProperties() {
+		Properties p = super.getRuntimeProperties();
+		//p.put("hibernate.show_sql", "true");
+		return p;
+	}
 	
 	@Before
 	public void setUp() throws Exception {
@@ -58,5 +79,35 @@ public class FhirEncounterDaoImplTest extends BaseModuleContextSensitiveTest {
 	public void shouldReturnNullWithUnknownEncounterUuid() {
 		Encounter encounter = dao.get(UNKNOWN_ENCOUNTER_UUID);
 		assertThat(encounter, nullValue());
+	}
+	
+	@Test
+	public void shouldOnlyReturnEncountersThatHaveAtLeastOneHasParamResource() {
+		Encounter withNoDrugOrders = dao.get(ENCOUNTER_WITH_NO_DRUG_ORDERS);
+		assertThat(withNoDrugOrders, notNullValue());
+		assertThat("Orders is empty", withNoDrugOrders.getOrders().isEmpty());
+		
+		Encounter withDrugOrders = dao.get(ENCOUNTER_WITH_DRUG_ORDERS);
+		assertThat(withDrugOrders, notNullValue());
+		assertThat("Orders is not empty", !withDrugOrders.getOrders().isEmpty());
+		for (Order order : withDrugOrders.getOrders()) {
+			assertThat(order.getClass(), equalTo(DrugOrder.class));
+		}
+		
+		HasOrListParam hasOrListParam = new HasOrListParam();
+		hasOrListParam.add(new HasParam(
+				"MedicationRequest",
+				"encounter",
+				"meta:tag:code",
+				"Encounter")
+		);
+		HasAndListParam hasAndListParam = new HasAndListParam();
+		hasAndListParam.addAnd(hasOrListParam);
+		SearchParameterMap theParams = new SearchParameterMap()
+				.addParameter(FhirConstants.HAS_SEARCH_HANDLER, hasAndListParam);
+		
+		List<String> matchingUuids = dao.getSearchResultUuids(theParams);
+		assertThat("Encounter with Drug Orders is returned", matchingUuids.contains(ENCOUNTER_WITH_DRUG_ORDERS));
+		assertThat("Encounter without Drug Orders is not returned", !matchingUuids.contains(ENCOUNTER_WITH_NO_DRUG_ORDERS));
 	}
 }

--- a/api/src/test/java/org/openmrs/module/fhir2/api/dao/impl/FhirEncounterDaoImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/dao/impl/FhirEncounterDaoImplTest.java
@@ -9,6 +9,14 @@
  */
 package org.openmrs.module.fhir2.api.dao.impl;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.List;
+import java.util.Properties;
+
 import ca.uhn.fhir.rest.param.HasAndListParam;
 import ca.uhn.fhir.rest.param.HasOrListParam;
 import ca.uhn.fhir.rest.param.HasParam;
@@ -25,14 +33,6 @@ import org.openmrs.test.BaseModuleContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.context.ContextConfiguration;
-
-import java.util.List;
-import java.util.Properties;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 @ContextConfiguration(classes = TestFhirSpringConfiguration.class, inheritLocations = false)
 public class FhirEncounterDaoImplTest extends BaseModuleContextSensitiveTest {
@@ -95,16 +95,11 @@ public class FhirEncounterDaoImplTest extends BaseModuleContextSensitiveTest {
 		}
 		
 		HasOrListParam hasOrListParam = new HasOrListParam();
-		hasOrListParam.add(new HasParam(
-				"MedicationRequest",
-				"encounter",
-				"meta:tag:code",
-				"Encounter")
-		);
+		hasOrListParam.add(new HasParam("MedicationRequest", "encounter", "meta:tag:code", "Encounter"));
 		HasAndListParam hasAndListParam = new HasAndListParam();
 		hasAndListParam.addAnd(hasOrListParam);
-		SearchParameterMap theParams = new SearchParameterMap()
-				.addParameter(FhirConstants.HAS_SEARCH_HANDLER, hasAndListParam);
+		SearchParameterMap theParams = new SearchParameterMap().addParameter(FhirConstants.HAS_SEARCH_HANDLER,
+		    hasAndListParam);
 		
 		List<String> matchingUuids = dao.getSearchResultUuids(theParams);
 		assertThat("Encounter with Drug Orders is returned", matchingUuids.contains(ENCOUNTER_WITH_DRUG_ORDERS));

--- a/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirEncounterServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirEncounterServiceImplTest.java
@@ -608,9 +608,9 @@ public class FhirEncounterServiceImplTest {
 	}
 	
 	@Test
-	public void searchForEncounter_shouldOnlyReturnEncountersThatHaveAtLeastOneHasParamResourceIfNoValueIsSpecified() {
+	public void searchForEncounter_shouldOnlyReturnEncountersThatHaveAtLeastOneHasParamResource() {
 		HasOrListParam hasOrListParam = new HasOrListParam();
-		hasOrListParam.add(new HasParam("MedicationRequest", "encounter", null, null));
+		hasOrListParam.add(new HasParam("MedicationRequest", "encounter", "intent", "order"));
 		HasAndListParam hasAndListParam = new HasAndListParam();
 		hasAndListParam.addAnd(hasOrListParam);
 		SearchParameterMap theParams = new SearchParameterMap().addParameter(FhirConstants.HAS_SEARCH_HANDLER,

--- a/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirEncounterServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirEncounterServiceImplTest.java
@@ -608,7 +608,7 @@ public class FhirEncounterServiceImplTest {
 	}
 	
 	@Test
-	public void searchForEncounter_shouldOnlyReturnEncountersThatHaveAtLeastOneHasParamResource() {
+	public void searchForEncounter_shouldOnlyReturnEncountersThatHaveAssociatedMedicationRequests() {
 		HasOrListParam hasOrListParam = new HasOrListParam();
 		hasOrListParam.add(new HasParam("MedicationRequest", "encounter", "intent", "order"));
 		HasAndListParam hasAndListParam = new HasAndListParam();

--- a/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirEncounterServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirEncounterServiceImplTest.java
@@ -31,6 +31,9 @@ import ca.uhn.fhir.model.api.Include;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
 import ca.uhn.fhir.rest.param.DateParam;
 import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.HasAndListParam;
+import ca.uhn.fhir.rest.param.HasOrListParam;
+import ca.uhn.fhir.rest.param.HasParam;
 import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.ReferenceOrListParam;
 import ca.uhn.fhir.rest.param.ReferenceParam;
@@ -308,7 +311,7 @@ public class FhirEncounterServiceImplTest {
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
 		IBundleProvider results = encounterService.searchForEncounters(dateRangeParam, null, null, null, null, null, null,
-		    null, null, null);
+		    null, null, null, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -339,7 +342,7 @@ public class FhirEncounterServiceImplTest {
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
 		IBundleProvider results = encounterService.searchForEncounters(null, location, null, null, null, null, null, null,
-		    null, null);
+		    null, null, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -373,7 +376,7 @@ public class FhirEncounterServiceImplTest {
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
 		IBundleProvider results = encounterService.searchForEncounters(null, null, participant, null, null, null, null, null,
-		    null, null);
+		    null, null, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -407,7 +410,7 @@ public class FhirEncounterServiceImplTest {
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
 		IBundleProvider results = encounterService.searchForEncounters(null, null, null, subject, null, null, null, null,
-		    null, null);
+		    null, null, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -433,7 +436,7 @@ public class FhirEncounterServiceImplTest {
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
 		IBundleProvider results = encounterService.searchForEncounters(null, null, null, null, null, uuid, null, null, null,
-		    null);
+		    null, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -463,7 +466,7 @@ public class FhirEncounterServiceImplTest {
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
 		IBundleProvider results = encounterService.searchForEncounters(null, null, null, null, typeUuid, null, null, null,
-		    null, null);
+		    null, null, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -489,7 +492,7 @@ public class FhirEncounterServiceImplTest {
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
 		IBundleProvider results = encounterService.searchForEncounters(null, null, null, null, null, null, lastUpdated, null,
-		    null, null);
+		    null, null, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -515,7 +518,7 @@ public class FhirEncounterServiceImplTest {
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
 		IBundleProvider results = encounterService.searchForEncounters(null, null, null, null, null, null, null, null,
-		    includes, null);
+		    includes, null, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -541,7 +544,7 @@ public class FhirEncounterServiceImplTest {
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
 		IBundleProvider results = encounterService.searchForEncounters(null, null, null, null, null, null, null, null,
-		    includes, null);
+		    includes, null, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -568,7 +571,7 @@ public class FhirEncounterServiceImplTest {
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
 		IBundleProvider results = encounterService.searchForEncounters(null, null, null, null, null, null, null, null, null,
-		    revIncludes);
+		    revIncludes, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -595,7 +598,35 @@ public class FhirEncounterServiceImplTest {
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
 		IBundleProvider results = encounterService.searchForEncounters(null, null, null, null, null, null, null, null, null,
-		    revIncludes);
+		    revIncludes, null);
+		
+		List<IBaseResource> resultList = get(results);
+		
+		assertThat(results, notNullValue());
+		assertThat(resultList, not(empty()));
+		assertThat(resultList, hasSize(greaterThanOrEqualTo(1)));
+	}
+	
+	@Test
+	public void searchForEncounter_shouldOnlyReturnEncountersThatHaveAtLeastOneHasParamResourceIfNoValueIsSpecified() {
+		HasOrListParam hasOrListParam = new HasOrListParam();
+		hasOrListParam.add(new HasParam("MedicationRequest", "encounter", null, null));
+		HasAndListParam hasAndListParam = new HasAndListParam();
+		hasAndListParam.addAnd(hasOrListParam);
+		SearchParameterMap theParams = new SearchParameterMap().addParameter(FhirConstants.HAS_SEARCH_HANDLER,
+		    hasAndListParam);
+		
+		when(dao.getSearchResults(any(), any())).thenReturn(Collections.singletonList(openMrsEncounter));
+		when(dao.getSearchResultUuids(any())).thenReturn(Collections.singletonList(ENCOUNTER_UUID));
+		when(encounterTranslator.toFhirResource(openMrsEncounter)).thenReturn(fhirEncounter);
+		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
+		    new SearchQueryBundleProvider<>(theParams, dao, encounterTranslator, globalPropertyService, searchQueryInclude));
+		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
+		
+		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
+		
+		IBundleProvider results = encounterService.searchForEncounters(null, null, null, null, null, null, null, null, null,
+		    null, hasAndListParam);
 		
 		List<IBaseResource> resultList = get(results);
 		

--- a/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirEncounterServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirEncounterServiceImplTest.java
@@ -38,6 +38,7 @@ import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.ReferenceOrListParam;
 import ca.uhn.fhir.rest.param.ReferenceParam;
 import ca.uhn.fhir.rest.param.TokenAndListParam;
+import ca.uhn.fhir.rest.param.TokenOrListParam;
 import ca.uhn.fhir.rest.param.TokenParam;
 import ca.uhn.fhir.rest.server.SimpleBundleProvider;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
@@ -61,8 +62,10 @@ import org.openmrs.module.fhir2.api.dao.FhirEncounterDao;
 import org.openmrs.module.fhir2.api.search.SearchQuery;
 import org.openmrs.module.fhir2.api.search.SearchQueryBundleProvider;
 import org.openmrs.module.fhir2.api.search.SearchQueryInclude;
+import org.openmrs.module.fhir2.api.search.param.EncounterSearchParams;
 import org.openmrs.module.fhir2.api.search.param.SearchParameterMap;
 import org.openmrs.module.fhir2.api.translators.EncounterTranslator;
+import org.openmrs.module.fhir2.providers.r3.MockIBundleProvider;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FhirEncounterServiceImplTest {
@@ -310,8 +313,9 @@ public class FhirEncounterServiceImplTest {
 		
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
-		IBundleProvider results = encounterService.searchForEncounters(dateRangeParam, null, null, null, null, null, null,
-		    null, null, null, null);
+		EncounterSearchParams encounterSearchParams = new EncounterSearchParams();
+		encounterSearchParams.setDate(dateRangeParam);
+		IBundleProvider results = encounterService.searchForEncounters(encounterSearchParams);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -341,8 +345,9 @@ public class FhirEncounterServiceImplTest {
 		
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
-		IBundleProvider results = encounterService.searchForEncounters(null, location, null, null, null, null, null, null,
-		    null, null, null);
+		EncounterSearchParams encounterSearchParams = new EncounterSearchParams();
+		encounterSearchParams.setLocation(location);
+		IBundleProvider results = encounterService.searchForEncounters(encounterSearchParams);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -375,8 +380,9 @@ public class FhirEncounterServiceImplTest {
 		
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
-		IBundleProvider results = encounterService.searchForEncounters(null, null, participant, null, null, null, null, null,
-		    null, null, null);
+		EncounterSearchParams encounterSearchParams = new EncounterSearchParams();
+		encounterSearchParams.setParticipant(participant);
+		IBundleProvider results = encounterService.searchForEncounters(encounterSearchParams);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -409,8 +415,9 @@ public class FhirEncounterServiceImplTest {
 		
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
-		IBundleProvider results = encounterService.searchForEncounters(null, null, null, subject, null, null, null, null,
-		    null, null, null);
+		EncounterSearchParams encounterSearchParams = new EncounterSearchParams();
+		encounterSearchParams.setSubject(subject);
+		IBundleProvider results = encounterService.searchForEncounters(encounterSearchParams);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -435,8 +442,9 @@ public class FhirEncounterServiceImplTest {
 		
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
-		IBundleProvider results = encounterService.searchForEncounters(null, null, null, null, null, uuid, null, null, null,
-		    null, null);
+		EncounterSearchParams encounterSearchParams = new EncounterSearchParams();
+		encounterSearchParams.setId(uuid);
+		IBundleProvider results = encounterService.searchForEncounters(encounterSearchParams);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -465,8 +473,9 @@ public class FhirEncounterServiceImplTest {
 		
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
-		IBundleProvider results = encounterService.searchForEncounters(null, null, null, null, typeUuid, null, null, null,
-		    null, null, null);
+		EncounterSearchParams encounterSearchParams = new EncounterSearchParams();
+		encounterSearchParams.setEncounterType(typeUuid);
+		IBundleProvider results = encounterService.searchForEncounters(encounterSearchParams);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -491,8 +500,9 @@ public class FhirEncounterServiceImplTest {
 		
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
-		IBundleProvider results = encounterService.searchForEncounters(null, null, null, null, null, null, lastUpdated, null,
-		    null, null, null);
+		EncounterSearchParams encounterSearchParams = new EncounterSearchParams();
+		encounterSearchParams.setLastUpdated(lastUpdated);
+		IBundleProvider results = encounterService.searchForEncounters(encounterSearchParams);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -517,8 +527,9 @@ public class FhirEncounterServiceImplTest {
 		
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
-		IBundleProvider results = encounterService.searchForEncounters(null, null, null, null, null, null, null, null,
-		    includes, null, null);
+		EncounterSearchParams encounterSearchParams = new EncounterSearchParams();
+		encounterSearchParams.setIncludes(includes);
+		IBundleProvider results = encounterService.searchForEncounters(encounterSearchParams);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -543,8 +554,9 @@ public class FhirEncounterServiceImplTest {
 		
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
-		IBundleProvider results = encounterService.searchForEncounters(null, null, null, null, null, null, null, null,
-		    includes, null, null);
+		EncounterSearchParams encounterSearchParams = new EncounterSearchParams();
+		encounterSearchParams.setIncludes(includes);
+		IBundleProvider results = encounterService.searchForEncounters(encounterSearchParams);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -570,8 +582,9 @@ public class FhirEncounterServiceImplTest {
 		
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
-		IBundleProvider results = encounterService.searchForEncounters(null, null, null, null, null, null, null, null, null,
-		    revIncludes, null);
+		EncounterSearchParams encounterSearchParams = new EncounterSearchParams();
+		encounterSearchParams.setRevIncludes(revIncludes);
+		IBundleProvider results = encounterService.searchForEncounters(encounterSearchParams);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -597,8 +610,9 @@ public class FhirEncounterServiceImplTest {
 		
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
-		IBundleProvider results = encounterService.searchForEncounters(null, null, null, null, null, null, null, null, null,
-		    revIncludes, null);
+		EncounterSearchParams encounterSearchParams = new EncounterSearchParams();
+		encounterSearchParams.setRevIncludes(revIncludes);
+		IBundleProvider results = encounterService.searchForEncounters(encounterSearchParams);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -625,14 +639,93 @@ public class FhirEncounterServiceImplTest {
 		
 		when(visitService.searchForVisits(any())).thenReturn(new SimpleBundleProvider());
 		
-		IBundleProvider results = encounterService.searchForEncounters(null, null, null, null, null, null, null, null, null,
-		    null, hasAndListParam);
+		EncounterSearchParams encounterSearchParams = new EncounterSearchParams();
+		encounterSearchParams.setHasAndListParam(hasAndListParam);
+		IBundleProvider results = encounterService.searchForEncounters(encounterSearchParams);
 		
 		List<IBaseResource> resultList = get(results);
 		
 		assertThat(results, notNullValue());
 		assertThat(resultList, not(empty()));
 		assertThat(resultList, hasSize(greaterThanOrEqualTo(1)));
+	}
+	
+	@Test
+	public void searchEncounters_shouldIncludeAddResourcesThatMatchTagParam() {
+		
+		int numEncounters = 9;
+		List<org.hl7.fhir.r4.model.Encounter> fhirEncounters = new ArrayList<>();
+		for (int i = 0; i < numEncounters; i++) {
+			fhirEncounters.add(new org.hl7.fhir.r4.model.Encounter());
+		}
+		when(searchQuery.getQueryResults(any(), any(), any(), any()))
+		        .thenReturn(new MockIBundleProvider<>(fhirEncounters, 10, 1));
+		
+		int numVisits = 5;
+		List<org.hl7.fhir.r4.model.Encounter> fhirVisits = new ArrayList<>();
+		for (int i = 0; i < numVisits; i++) {
+			fhirVisits.add(new org.hl7.fhir.r4.model.Encounter());
+		}
+		when(visitService.searchForVisits(any())).thenReturn(new MockIBundleProvider<>(fhirVisits, 10, 1));
+		
+		{
+			IBundleProvider results = encounterService.searchForEncounters(new EncounterSearchParams());
+			List<IBaseResource> resultList = get(results);
+			assertThat(results, notNullValue());
+			assertThat(resultList, not(empty()));
+			assertThat(resultList, hasSize(numEncounters + numVisits));
+		}
+		
+		{
+			TokenAndListParam tokenAndListParam = new TokenAndListParam();
+			tokenAndListParam.addAnd(new TokenParam(FhirConstants.OPENMRS_FHIR_EXT_ENCOUNTER_TAG, "encounter"));
+			SearchParameterMap theParams = new SearchParameterMap();
+			theParams.addParameter(FhirConstants.TAG_SEARCH_HANDLER, tokenAndListParam);
+			EncounterSearchParams encounterSearchParams = new EncounterSearchParams();
+			encounterSearchParams.setTag(tokenAndListParam);
+			IBundleProvider results = encounterService.searchForEncounters(encounterSearchParams);
+			
+			List<IBaseResource> resultList = get(results);
+			
+			assertThat(results, notNullValue());
+			assertThat(resultList, not(empty()));
+			assertThat(resultList, hasSize(numEncounters));
+		}
+		
+		{
+			TokenAndListParam tokenAndListParam = new TokenAndListParam();
+			tokenAndListParam.addAnd(new TokenParam(FhirConstants.OPENMRS_FHIR_EXT_ENCOUNTER_TAG, "visit"));
+			SearchParameterMap theParams = new SearchParameterMap();
+			theParams.addParameter(FhirConstants.TAG_SEARCH_HANDLER, tokenAndListParam);
+			EncounterSearchParams encounterSearchParams = new EncounterSearchParams();
+			encounterSearchParams.setTag(tokenAndListParam);
+			IBundleProvider results = encounterService.searchForEncounters(encounterSearchParams);
+			
+			List<IBaseResource> resultList = get(results);
+			
+			assertThat(results, notNullValue());
+			assertThat(resultList, not(empty()));
+			assertThat(resultList, hasSize(numVisits));
+		}
+		
+		{
+			TokenAndListParam tokenAndListParam = new TokenAndListParam();
+			TokenOrListParam tokenOrListParam = new TokenOrListParam();
+			tokenOrListParam.add(FhirConstants.OPENMRS_FHIR_EXT_ENCOUNTER_TAG, "encounter");
+			tokenOrListParam.add(FhirConstants.OPENMRS_FHIR_EXT_ENCOUNTER_TAG, "visit");
+			tokenAndListParam.addAnd(tokenOrListParam);
+			SearchParameterMap theParams = new SearchParameterMap();
+			theParams.addParameter(FhirConstants.TAG_SEARCH_HANDLER, tokenAndListParam);
+			EncounterSearchParams encounterSearchParams = new EncounterSearchParams();
+			encounterSearchParams.setTag(tokenAndListParam);
+			IBundleProvider results = encounterService.searchForEncounters(encounterSearchParams);
+			
+			List<IBaseResource> resultList = get(results);
+			
+			assertThat(results, notNullValue());
+			assertThat(resultList, not(empty()));
+			assertThat(resultList, hasSize(numEncounters + numVisits));
+		}
 	}
 	
 	@Test

--- a/api/src/test/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProviderTest.java
@@ -30,6 +30,9 @@ import java.util.stream.Collectors;
 import ca.uhn.fhir.model.api.Include;
 import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.rest.param.HasAndListParam;
+import ca.uhn.fhir.rest.param.HasOrListParam;
+import ca.uhn.fhir.rest.param.HasParam;
 import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.ReferenceOrListParam;
 import ca.uhn.fhir.rest.param.ReferenceParam;
@@ -229,6 +232,27 @@ public class EncounterFhirResourceProviderTest extends BaseFhirR3ProvenanceResou
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
 		    null, null, revIncludes);
+		
+		List<IBaseResource> resultList = results.getResources(START_INDEX, END_INDEX);
+		
+		assertThat(results, notNullValue());
+		assertThat(resultList.size(), equalTo(1));
+		assertThat(resultList.get(0).fhirType(), equalTo(FhirConstants.ENCOUNTER));
+		assertThat(((Encounter) resultList.iterator().next()).getId(), equalTo(ENCOUNTER_UUID));
+	}
+	
+	@Test
+	public void searchEncounters_shouldIncludeAddResourcesThatMatchHasAndListParam() {
+		HasOrListParam hasOrListParam = new HasOrListParam();
+		hasOrListParam.add(new HasParam("MedicationRequest", "encounter", "intent", "order"));
+		HasAndListParam hasAndListParam = new HasAndListParam();
+		hasAndListParam.addAnd(hasOrListParam);
+		
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+		    any())).thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
+		
+		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
+		    hasAndListParam, null, null);
 		
 		List<IBaseResource> resultList = results.getResources(START_INDEX, END_INDEX);
 		

--- a/api/src/test/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProviderTest.java
@@ -123,14 +123,14 @@ public class EncounterFhirResourceProviderTest extends BaseFhirR3ProvenanceResou
 	public void searchEncounters_shouldReturnMatchingEncounters() {
 		List<org.hl7.fhir.r4.model.Encounter> encounters = new ArrayList<>();
 		encounters.add(encounter);
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
-		        .thenReturn(new MockIBundleProvider<>(encounters, PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+		    any())).thenReturn(new MockIBundleProvider<>(encounters, PREFERRED_SIZE, COUNT));
 		
 		ReferenceAndListParam subjectReference = new ReferenceAndListParam();
 		subjectReference.addValue(new ReferenceOrListParam().add(new ReferenceParam().setChain(Patient.SP_NAME)));
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, subjectReference, null, null, null,
-		    null, null, null, null);
+		    null, null, null, null, null);
 		
 		List<Encounter> resultList = get(results);
 		
@@ -144,14 +144,14 @@ public class EncounterFhirResourceProviderTest extends BaseFhirR3ProvenanceResou
 	public void searchEncounters_shouldReturnMatchingEncountersWhenPatientParamIsSpecified() {
 		List<org.hl7.fhir.r4.model.Encounter> encounters = new ArrayList<>();
 		encounters.add(encounter);
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
-		        .thenReturn(new MockIBundleProvider<>(encounters, PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+		    any())).thenReturn(new MockIBundleProvider<>(encounters, PREFERRED_SIZE, COUNT));
 		
 		ReferenceAndListParam patientParam = new ReferenceAndListParam();
 		patientParam.addValue(new ReferenceOrListParam().add(new ReferenceParam().setChain(Patient.SP_NAME)));
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, patientParam, null, null, null,
-		    null, null, null);
+		    null, null, null, null);
 		
 		List<Encounter> resultList = get(results);
 		
@@ -163,14 +163,14 @@ public class EncounterFhirResourceProviderTest extends BaseFhirR3ProvenanceResou
 	
 	@Test
 	public void searchEncounters_shouldAddRelatedResourcesForInclude() {
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
-		        .thenReturn(new MockIBundleProvider<>(Arrays.asList(encounter, new Patient()), PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+		    any())).thenReturn(new MockIBundleProvider<>(Arrays.asList(encounter, new Patient()), PREFERRED_SIZE, COUNT));
 		
 		HashSet<Include> includes = new HashSet<>();
 		includes.add(new Include("Encounter:patient"));
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
-		    includes, null);
+		    null, includes, null);
 		
 		List<IBaseResource> resultList = results.getResources(START_INDEX, END_INDEX);
 		
@@ -183,13 +183,13 @@ public class EncounterFhirResourceProviderTest extends BaseFhirR3ProvenanceResou
 	
 	@Test
 	public void searchEncounters_shouldNotAddResourcesForEmptyInclude() {
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), isNull(), any()))
-		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), isNull(), any(),
+		    any())).thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
 		
 		HashSet<Include> includes = new HashSet<>();
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
-		    includes, null);
+		    null, includes, null);
 		
 		List<IBaseResource> resultList = results.getResources(START_INDEX, END_INDEX);
 		
@@ -201,14 +201,15 @@ public class EncounterFhirResourceProviderTest extends BaseFhirR3ProvenanceResou
 	
 	@Test
 	public void searchEncounters_shouldAddRelatedResourcesForRevInclude() {
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
-		        .thenReturn(new MockIBundleProvider<>(Arrays.asList(encounter, new Observation()), PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+		    any())).thenReturn(
+		        new MockIBundleProvider<>(Arrays.asList(encounter, new Observation()), PREFERRED_SIZE, COUNT));
 		
 		HashSet<Include> revIncludes = new HashSet<>();
 		revIncludes.add(new Include("Observation:encounter"));
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
-		    null, revIncludes);
+		    null, null, revIncludes);
 		
 		List<IBaseResource> resultList = results.getResources(START_INDEX, END_INDEX);
 		
@@ -221,13 +222,13 @@ public class EncounterFhirResourceProviderTest extends BaseFhirR3ProvenanceResou
 	
 	@Test
 	public void searchEncounters_shouldNotAddResourcesForEmptyRevInclude() {
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), isNull()))
-		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), isNull(),
+		    any())).thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
 		
 		HashSet<Include> revIncludes = new HashSet<>();
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
-		    null, revIncludes);
+		    null, null, revIncludes);
 		
 		List<IBaseResource> resultList = results.getResources(START_INDEX, END_INDEX);
 		

--- a/api/src/test/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProviderTest.java
@@ -17,7 +17,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -36,6 +36,8 @@ import ca.uhn.fhir.rest.param.HasParam;
 import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.ReferenceOrListParam;
 import ca.uhn.fhir.rest.param.ReferenceParam;
+import ca.uhn.fhir.rest.param.TokenAndListParam;
+import ca.uhn.fhir.rest.param.TokenParam;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.MethodNotAllowedException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
@@ -49,10 +51,13 @@ import org.hl7.fhir.r4.model.Observation;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.openmrs.module.fhir2.FhirConstants;
 import org.openmrs.module.fhir2.api.FhirEncounterService;
+import org.openmrs.module.fhir2.api.search.param.EncounterSearchParams;
 import org.openmrs.module.fhir2.providers.r4.MockIBundleProvider;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -76,6 +81,9 @@ public class EncounterFhirResourceProviderTest extends BaseFhirR3ProvenanceResou
 	private EncounterFhirResourceProvider resourceProvider;
 	
 	private org.hl7.fhir.r4.model.Encounter encounter;
+	
+	@Captor
+	private ArgumentCaptor<EncounterSearchParams> paramCaptor;
 	
 	@Before
 	public void setup() {
@@ -126,14 +134,14 @@ public class EncounterFhirResourceProviderTest extends BaseFhirR3ProvenanceResou
 	public void searchEncounters_shouldReturnMatchingEncounters() {
 		List<org.hl7.fhir.r4.model.Encounter> encounters = new ArrayList<>();
 		encounters.add(encounter);
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
-		    any())).thenReturn(new MockIBundleProvider<>(encounters, PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any()))
+		        .thenReturn(new MockIBundleProvider<>(encounters, PREFERRED_SIZE, COUNT));
 		
 		ReferenceAndListParam subjectReference = new ReferenceAndListParam();
 		subjectReference.addValue(new ReferenceOrListParam().add(new ReferenceParam().setChain(Patient.SP_NAME)));
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, subjectReference, null, null, null,
-		    null, null, null, null, null);
+		    null, null, null, null, null, null);
 		
 		List<Encounter> resultList = get(results);
 		
@@ -147,14 +155,14 @@ public class EncounterFhirResourceProviderTest extends BaseFhirR3ProvenanceResou
 	public void searchEncounters_shouldReturnMatchingEncountersWhenPatientParamIsSpecified() {
 		List<org.hl7.fhir.r4.model.Encounter> encounters = new ArrayList<>();
 		encounters.add(encounter);
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
-		    any())).thenReturn(new MockIBundleProvider<>(encounters, PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any()))
+		        .thenReturn(new MockIBundleProvider<>(encounters, PREFERRED_SIZE, COUNT));
 		
 		ReferenceAndListParam patientParam = new ReferenceAndListParam();
 		patientParam.addValue(new ReferenceOrListParam().add(new ReferenceParam().setChain(Patient.SP_NAME)));
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, patientParam, null, null, null,
-		    null, null, null, null);
+		    null, null, null, null, null);
 		
 		List<Encounter> resultList = get(results);
 		
@@ -166,14 +174,14 @@ public class EncounterFhirResourceProviderTest extends BaseFhirR3ProvenanceResou
 	
 	@Test
 	public void searchEncounters_shouldAddRelatedResourcesForInclude() {
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
-		    any())).thenReturn(new MockIBundleProvider<>(Arrays.asList(encounter, new Patient()), PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any()))
+		        .thenReturn(new MockIBundleProvider<>(Arrays.asList(encounter, new Patient()), PREFERRED_SIZE, COUNT));
 		
 		HashSet<Include> includes = new HashSet<>();
 		includes.add(new Include("Encounter:patient"));
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
-		    null, includes, null);
+		    null, null, includes, null);
 		
 		List<IBaseResource> resultList = results.getResources(START_INDEX, END_INDEX);
 		
@@ -186,13 +194,13 @@ public class EncounterFhirResourceProviderTest extends BaseFhirR3ProvenanceResou
 	
 	@Test
 	public void searchEncounters_shouldNotAddResourcesForEmptyInclude() {
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), isNull(), any(),
-		    any())).thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any()))
+		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
 		
 		HashSet<Include> includes = new HashSet<>();
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
-		    null, includes, null);
+		    null, null, includes, null);
 		
 		List<IBaseResource> resultList = results.getResources(START_INDEX, END_INDEX);
 		
@@ -204,15 +212,14 @@ public class EncounterFhirResourceProviderTest extends BaseFhirR3ProvenanceResou
 	
 	@Test
 	public void searchEncounters_shouldAddRelatedResourcesForRevInclude() {
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
-		    any())).thenReturn(
-		        new MockIBundleProvider<>(Arrays.asList(encounter, new Observation()), PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any()))
+		        .thenReturn(new MockIBundleProvider<>(Arrays.asList(encounter, new Observation()), PREFERRED_SIZE, COUNT));
 		
 		HashSet<Include> revIncludes = new HashSet<>();
 		revIncludes.add(new Include("Observation:encounter"));
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
-		    null, null, revIncludes);
+		    null, null, null, revIncludes);
 		
 		List<IBaseResource> resultList = results.getResources(START_INDEX, END_INDEX);
 		
@@ -225,13 +232,13 @@ public class EncounterFhirResourceProviderTest extends BaseFhirR3ProvenanceResou
 	
 	@Test
 	public void searchEncounters_shouldNotAddResourcesForEmptyRevInclude() {
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), isNull(),
-		    any())).thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any()))
+		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
 		
 		HashSet<Include> revIncludes = new HashSet<>();
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
-		    null, null, revIncludes);
+		    null, null, null, revIncludes);
 		
 		List<IBaseResource> resultList = results.getResources(START_INDEX, END_INDEX);
 		
@@ -248,11 +255,11 @@ public class EncounterFhirResourceProviderTest extends BaseFhirR3ProvenanceResou
 		HasAndListParam hasAndListParam = new HasAndListParam();
 		hasAndListParam.addAnd(hasOrListParam);
 		
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
-		    any())).thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any()))
+		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
-		    hasAndListParam, null, null);
+		    null, hasAndListParam, null, null);
 		
 		List<IBaseResource> resultList = results.getResources(START_INDEX, END_INDEX);
 		
@@ -260,6 +267,24 @@ public class EncounterFhirResourceProviderTest extends BaseFhirR3ProvenanceResou
 		assertThat(resultList.size(), equalTo(1));
 		assertThat(resultList.get(0).fhirType(), equalTo(FhirConstants.ENCOUNTER));
 		assertThat(((Encounter) resultList.iterator().next()).getId(), equalTo(ENCOUNTER_UUID));
+	}
+	
+	@Test
+	public void searchEncounters_shouldIncludeAddResourcesThatMatchTagParam() {
+		TokenAndListParam tokenAndListParam = new TokenAndListParam();
+		tokenAndListParam.addAnd(new TokenParam(FhirConstants.OPENMRS_FHIR_EXT_ENCOUNTER_TAG, "encounter"));
+		
+		when(encounterService.searchForEncounters(any()))
+		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), 10, 1));
+		
+		resourceProvider.searchEncounter(null, null, null, null, null, null, null, tokenAndListParam, null, null, null, null,
+		    null);
+		
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
+		
+		TokenAndListParam tagParam = paramCaptor.getValue().getTag();
+		assertThat(tagParam, notNullValue());
+		assertThat(tagParam, equalTo(tokenAndListParam));
 	}
 	
 	@Test

--- a/api/src/test/java/org/openmrs/module/fhir2/providers/r4/EncounterFhirResourceProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/providers/r4/EncounterFhirResourceProviderTest.java
@@ -17,7 +17,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -35,6 +35,8 @@ import ca.uhn.fhir.rest.param.HasParam;
 import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.ReferenceOrListParam;
 import ca.uhn.fhir.rest.param.ReferenceParam;
+import ca.uhn.fhir.rest.param.TokenAndListParam;
+import ca.uhn.fhir.rest.param.TokenParam;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.MethodNotAllowedException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
@@ -47,10 +49,13 @@ import org.hl7.fhir.r4.model.Patient;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.openmrs.module.fhir2.FhirConstants;
 import org.openmrs.module.fhir2.api.FhirEncounterService;
+import org.openmrs.module.fhir2.api.search.param.EncounterSearchParams;
 import org.openmrs.module.fhir2.providers.BaseFhirProvenanceResourceTest;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -70,6 +75,9 @@ public class EncounterFhirResourceProviderTest extends BaseFhirProvenanceResourc
 	
 	@Mock
 	private FhirEncounterService encounterService;
+	
+	@Captor
+	private ArgumentCaptor<EncounterSearchParams> paramCaptor;
 	
 	private EncounterFhirResourceProvider resourceProvider;
 	
@@ -123,14 +131,14 @@ public class EncounterFhirResourceProviderTest extends BaseFhirProvenanceResourc
 	public void searchEncounters_shouldReturnMatchingEncounters() {
 		List<Encounter> encounters = new ArrayList<>();
 		encounters.add(encounter);
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
-		    any())).thenReturn(new MockIBundleProvider<>(encounters, PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any()))
+		        .thenReturn(new MockIBundleProvider<>(encounters, PREFERRED_SIZE, COUNT));
 		
 		ReferenceAndListParam subjectReference = new ReferenceAndListParam();
 		subjectReference.addValue(new ReferenceOrListParam().add(new ReferenceParam().setChain(Patient.SP_NAME)));
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, subjectReference, null, null, null,
-		    null, null, null, null, null);
+		    null, null, null, null, null, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -144,14 +152,14 @@ public class EncounterFhirResourceProviderTest extends BaseFhirProvenanceResourc
 	public void searchEncounters_shouldReturnMatchingEncountersWhenPatientParamIsSpecified() {
 		List<Encounter> encounters = new ArrayList<>();
 		encounters.add(encounter);
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
-		    any())).thenReturn(new MockIBundleProvider<>(encounters, PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any()))
+		        .thenReturn(new MockIBundleProvider<>(encounters, PREFERRED_SIZE, COUNT));
 		
 		ReferenceAndListParam patientParam = new ReferenceAndListParam();
 		patientParam.addValue(new ReferenceOrListParam().add(new ReferenceParam().setChain(Patient.SP_NAME)));
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, patientParam, null, null, null,
-		    null, null, null, null);
+		    null, null, null, null, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -163,14 +171,14 @@ public class EncounterFhirResourceProviderTest extends BaseFhirProvenanceResourc
 	
 	@Test
 	public void searchEncounters_shouldAddRelatedResourcesForInclude() {
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
-		    any())).thenReturn(new MockIBundleProvider<>(Arrays.asList(encounter, new Patient()), PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any()))
+		        .thenReturn(new MockIBundleProvider<>(Arrays.asList(encounter, new Patient()), PREFERRED_SIZE, COUNT));
 		
 		HashSet<Include> includes = new HashSet<>();
 		includes.add(new Include("Encounter:patient"));
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
-		    null, includes, null);
+		    null, null, includes, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -183,13 +191,13 @@ public class EncounterFhirResourceProviderTest extends BaseFhirProvenanceResourc
 	
 	@Test
 	public void searchEncounters_shouldNotAddResourcesForEmptyInclude() {
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), isNull(), any(),
-		    any())).thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any()))
+		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
 		
 		HashSet<Include> includes = new HashSet<>();
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
-		    null, includes, null);
+		    null, null, includes, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -201,15 +209,14 @@ public class EncounterFhirResourceProviderTest extends BaseFhirProvenanceResourc
 	
 	@Test
 	public void searchEncounters_shouldAddRelatedResourcesForRevInclude() {
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
-		    any())).thenReturn(
-		        new MockIBundleProvider<>(Arrays.asList(encounter, new Observation()), PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any()))
+		        .thenReturn(new MockIBundleProvider<>(Arrays.asList(encounter, new Observation()), PREFERRED_SIZE, COUNT));
 		
 		HashSet<Include> revIncludes = new HashSet<>();
 		revIncludes.add(new Include("Observation:encounter"));
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
-		    null, null, revIncludes);
+		    null, null, null, revIncludes);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -222,13 +229,13 @@ public class EncounterFhirResourceProviderTest extends BaseFhirProvenanceResourc
 	
 	@Test
 	public void searchEncounters_shouldNotAddResourcesForEmptyRevInclude() {
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), isNull(),
-		    any())).thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any()))
+		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
 		
 		HashSet<Include> revIncludes = new HashSet<>();
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
-		    null, null, revIncludes);
+		    null, null, null, revIncludes);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -245,11 +252,11 @@ public class EncounterFhirResourceProviderTest extends BaseFhirProvenanceResourc
 		HasAndListParam hasAndListParam = new HasAndListParam();
 		hasAndListParam.addAnd(hasOrListParam);
 		
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
-		    any())).thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any()))
+		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
-		    hasAndListParam, null, null);
+		    null, hasAndListParam, null, null);
 		
 		List<IBaseResource> resultList = results.getResources(START_INDEX, END_INDEX);
 		
@@ -257,6 +264,24 @@ public class EncounterFhirResourceProviderTest extends BaseFhirProvenanceResourc
 		assertThat(resultList.size(), equalTo(1));
 		assertThat(resultList.get(0).fhirType(), equalTo(FhirConstants.ENCOUNTER));
 		assertThat(((Encounter) resultList.iterator().next()).getId(), equalTo(ENCOUNTER_UUID));
+	}
+	
+	@Test
+	public void searchEncounters_shouldIncludeAddResourcesThatMatchTagParam() {
+		TokenAndListParam tokenAndListParam = new TokenAndListParam();
+		tokenAndListParam.addAnd(new TokenParam(FhirConstants.OPENMRS_FHIR_EXT_ENCOUNTER_TAG, "encounter"));
+		
+		when(encounterService.searchForEncounters(any()))
+		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), 10, 1));
+		
+		resourceProvider.searchEncounter(null, null, null, null, null, null, null, tokenAndListParam, null, null, null, null,
+		    null);
+		
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
+		
+		TokenAndListParam tagParam = paramCaptor.getValue().getTag();
+		assertThat(tagParam, notNullValue());
+		assertThat(tagParam, equalTo(tokenAndListParam));
 	}
 	
 	@Test

--- a/api/src/test/java/org/openmrs/module/fhir2/providers/r4/EncounterFhirResourceProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/providers/r4/EncounterFhirResourceProviderTest.java
@@ -120,14 +120,14 @@ public class EncounterFhirResourceProviderTest extends BaseFhirProvenanceResourc
 	public void searchEncounters_shouldReturnMatchingEncounters() {
 		List<Encounter> encounters = new ArrayList<>();
 		encounters.add(encounter);
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
-		        .thenReturn(new MockIBundleProvider<>(encounters, PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+		    any())).thenReturn(new MockIBundleProvider<>(encounters, PREFERRED_SIZE, COUNT));
 		
 		ReferenceAndListParam subjectReference = new ReferenceAndListParam();
 		subjectReference.addValue(new ReferenceOrListParam().add(new ReferenceParam().setChain(Patient.SP_NAME)));
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, subjectReference, null, null, null,
-		    null, null, null, null);
+		    null, null, null, null, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -141,14 +141,14 @@ public class EncounterFhirResourceProviderTest extends BaseFhirProvenanceResourc
 	public void searchEncounters_shouldReturnMatchingEncountersWhenPatientParamIsSpecified() {
 		List<Encounter> encounters = new ArrayList<>();
 		encounters.add(encounter);
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
-		        .thenReturn(new MockIBundleProvider<>(encounters, PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+		    any())).thenReturn(new MockIBundleProvider<>(encounters, PREFERRED_SIZE, COUNT));
 		
 		ReferenceAndListParam patientParam = new ReferenceAndListParam();
 		patientParam.addValue(new ReferenceOrListParam().add(new ReferenceParam().setChain(Patient.SP_NAME)));
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, patientParam, null, null, null,
-		    null, null, null);
+		    null, null, null, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -160,14 +160,14 @@ public class EncounterFhirResourceProviderTest extends BaseFhirProvenanceResourc
 	
 	@Test
 	public void searchEncounters_shouldAddRelatedResourcesForInclude() {
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
-		        .thenReturn(new MockIBundleProvider<>(Arrays.asList(encounter, new Patient()), PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+		    any())).thenReturn(new MockIBundleProvider<>(Arrays.asList(encounter, new Patient()), PREFERRED_SIZE, COUNT));
 		
 		HashSet<Include> includes = new HashSet<>();
 		includes.add(new Include("Encounter:patient"));
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
-		    includes, null);
+		    null, includes, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -180,13 +180,13 @@ public class EncounterFhirResourceProviderTest extends BaseFhirProvenanceResourc
 	
 	@Test
 	public void searchEncounters_shouldNotAddResourcesForEmptyInclude() {
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), isNull(), any()))
-		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), isNull(), any(),
+		    any())).thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
 		
 		HashSet<Include> includes = new HashSet<>();
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
-		    includes, null);
+		    null, includes, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -198,14 +198,15 @@ public class EncounterFhirResourceProviderTest extends BaseFhirProvenanceResourc
 	
 	@Test
 	public void searchEncounters_shouldAddRelatedResourcesForRevInclude() {
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
-		        .thenReturn(new MockIBundleProvider<>(Arrays.asList(encounter, new Observation()), PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+		    any())).thenReturn(
+		        new MockIBundleProvider<>(Arrays.asList(encounter, new Observation()), PREFERRED_SIZE, COUNT));
 		
 		HashSet<Include> revIncludes = new HashSet<>();
 		revIncludes.add(new Include("Observation:encounter"));
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
-		    null, revIncludes);
+		    null, null, revIncludes);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -218,13 +219,13 @@ public class EncounterFhirResourceProviderTest extends BaseFhirProvenanceResourc
 	
 	@Test
 	public void searchEncounters_shouldNotAddResourcesForEmptyRevInclude() {
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), isNull()))
-		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), isNull(),
+		    any())).thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
 		
 		HashSet<Include> revIncludes = new HashSet<>();
 		
 		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
-		    null, revIncludes);
+		    null, null, revIncludes);
 		
 		List<IBaseResource> resultList = get(results);
 		

--- a/api/src/test/java/org/openmrs/module/fhir2/providers/r4/EncounterFhirResourceProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/providers/r4/EncounterFhirResourceProviderTest.java
@@ -29,6 +29,9 @@ import java.util.List;
 import ca.uhn.fhir.model.api.Include;
 import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.rest.param.HasAndListParam;
+import ca.uhn.fhir.rest.param.HasOrListParam;
+import ca.uhn.fhir.rest.param.HasParam;
 import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.ReferenceOrListParam;
 import ca.uhn.fhir.rest.param.ReferenceParam;
@@ -228,6 +231,27 @@ public class EncounterFhirResourceProviderTest extends BaseFhirProvenanceResourc
 		    null, null, revIncludes);
 		
 		List<IBaseResource> resultList = get(results);
+		
+		assertThat(results, notNullValue());
+		assertThat(resultList.size(), equalTo(1));
+		assertThat(resultList.get(0).fhirType(), equalTo(FhirConstants.ENCOUNTER));
+		assertThat(((Encounter) resultList.iterator().next()).getId(), equalTo(ENCOUNTER_UUID));
+	}
+	
+	@Test
+	public void searchEncounters_shouldIncludeAddResourcesThatMatchHasAndListParam() {
+		HasOrListParam hasOrListParam = new HasOrListParam();
+		hasOrListParam.add(new HasParam("MedicationRequest", "encounter", "intent", "order"));
+		HasAndListParam hasAndListParam = new HasAndListParam();
+		hasAndListParam.addAnd(hasOrListParam);
+		
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+		    any())).thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), PREFERRED_SIZE, COUNT));
+		
+		IBundleProvider results = resourceProvider.searchEncounter(null, null, null, null, null, null, null, null, null,
+		    hasAndListParam, null, null);
+		
+		List<IBaseResource> resultList = results.getResources(START_INDEX, END_INDEX);
 		
 		assertThat(results, notNullValue());
 		assertThat(resultList.size(), equalTo(1));

--- a/api/src/test/resources/log4j.xml
+++ b/api/src/test/resources/log4j.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+-->
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<!-- ######################################################
+     #                                                    #
+     # This log4j file is only used by the unit tests.    #
+     # The /metadata/api/log4j/log4j.xml file is put into #
+     # the api jar and war files.                         #
+     #                                                    #
+     ###################################################### -->
+ 
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+
+	<appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+		<layout class="org.apache.log4j.PatternLayout">
+			<param name="ConversionPattern"
+				value="%p - %C{1}.%M(%L) |%d{ISO8601}| %m%n" />
+		</layout>
+	</appender>
+
+	<!-- Hide unnecessary errors logged by Hibernate during unit testing -->
+	<logger name="org.hibernate.tool.hbm2ddl.SchemaExport">
+		<level value="FATAL" />
+	</logger>
+
+	<!-- 
+		This controls the LoggingAdvice class that wraps around the OpenMRS services 
+		WARN == don't log anything special for the services
+		INFO == log all setters
+		DEBUG == log all setters & getters &  execution time
+	-->
+	<logger name="org.openmrs.api">
+		<level value="WARN" />
+	</logger>
+	
+	<logger name="org.openmrs.test">
+		<level value="INFO" />
+	</logger>
+	
+	<logger name="org.hibernate.SQL">
+		<level value="ERROR" />
+	</logger>
+
+	<logger name="org.hibernate.type">
+		<level value="ERROR" />
+	</logger>
+
+    <root>
+		<level value="ERROR" />
+		<appender-ref ref="CONSOLE" />
+	</root>
+
+</log4j:configuration>

--- a/omod/src/test/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProviderWebTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProviderWebTest.java
@@ -21,7 +21,6 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -33,11 +32,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 
-import ca.uhn.fhir.model.api.Include;
 import ca.uhn.fhir.rest.param.DateRangeParam;
 import ca.uhn.fhir.rest.param.HasAndListParam;
 import ca.uhn.fhir.rest.param.HasOrListParam;
@@ -45,6 +42,8 @@ import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.ReferenceOrListParam;
 import ca.uhn.fhir.rest.param.ReferenceParam;
 import ca.uhn.fhir.rest.param.TokenAndListParam;
+import ca.uhn.fhir.rest.param.TokenOrListParam;
+import ca.uhn.fhir.rest.param.TokenParam;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -61,6 +60,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.openmrs.module.fhir2.FhirConstants;
 import org.openmrs.module.fhir2.api.FhirEncounterService;
+import org.openmrs.module.fhir2.api.search.param.EncounterSearchParams;
 import org.openmrs.module.fhir2.providers.r4.MockIBundleProvider;
 import org.springframework.mock.web.MockHttpServletResponse;
 
@@ -112,25 +112,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 	private EncounterFhirResourceProvider resourceProvider;
 	
 	@Captor
-	private ArgumentCaptor<ReferenceAndListParam> locationCaptor;
-	
-	@Captor
-	private ArgumentCaptor<ReferenceAndListParam> participantCaptor;
-	
-	@Captor
-	private ArgumentCaptor<ReferenceAndListParam> subjectCaptor;
-	
-	@Captor
-	private ArgumentCaptor<DateRangeParam> dateRangeCaptor;
-	
-	@Captor
-	private ArgumentCaptor<TokenAndListParam> tokenAndListParamArgumentCaptor;
-	
-	@Captor
-	private ArgumentCaptor<HashSet<Include>> includeArgumentCaptor;
-	
-	@Captor
-	private ArgumentCaptor<HasAndListParam> hasAndListParamArgumentCaptor;
+	private ArgumentCaptor<EncounterSearchParams> paramCaptor;
 	
 	@Before
 	@Override
@@ -165,134 +147,128 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 	@Test
 	public void shouldGetEncountersBySubjectUuid() throws Exception {
 		verifyUri(String.format("/Encounter?subject:Patient=%s", PATIENT_UUID));
-		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), subjectCaptor.capture(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
-		assertThat(subjectCaptor.getValue(), notNullValue());
-		assertThat(subjectCaptor.getAllValues().iterator().next().getValuesAsQueryTokens().iterator().next()
-		        .getValuesAsQueryTokens().iterator().next().getIdPart(),
-		    equalTo(PATIENT_UUID));
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
+		ReferenceAndListParam p = paramCaptor.getValue().getSubject();
+		assertThat(p, notNullValue());
+		assertThat(p.getValuesAsQueryTokens().get(0).getValuesAsQueryTokens().get(0).getIdPart(), equalTo(PATIENT_UUID));
 	}
 	
 	@Test
 	public void shouldGetEncountersByDate() throws Exception {
 		verifyUri("/Encounter/?date=ge1975-02-02");
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		verify(encounterService).searchForEncounters(dateRangeCaptor.capture(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
-		assertThat(dateRangeCaptor.getValue(), notNullValue());
+		DateRangeParam p = paramCaptor.getValue().getDate();
+		assertThat(p, notNullValue());
 		
 		Calendar calendar = Calendar.getInstance();
 		calendar.set(1975, Calendar.FEBRUARY, 2);
 		
-		assertThat(dateRangeCaptor.getValue().getLowerBound().getValue(),
-		    equalTo(DateUtils.truncate(calendar.getTime(), Calendar.DATE)));
-		assertThat(dateRangeCaptor.getValue().getUpperBound(), nullValue());
+		assertThat(p.getLowerBound().getValue(), equalTo(DateUtils.truncate(calendar.getTime(), Calendar.DATE)));
+		assertThat(p.getUpperBound(), nullValue());
 	}
 	
 	@Test
 	public void shouldGetEncountersByLocationCityVillage() throws Exception {
 		verifyUri(String.format("/Encounter/?location.address-city=%s", ENCOUNTER_ADDRESS_CITY));
 		
-		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
-		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
-		
-		assertThat(locationCaptor.getValue(), notNullValue());
-		assertThat(referenceParam.getChain(), equalTo("address-city"));
-		assertThat(referenceParam.getValue(), equalTo(ENCOUNTER_ADDRESS_CITY));
+		ReferenceAndListParam listParam = paramCaptor.getValue().getLocation();
+		assertThat(listParam, notNullValue());
+		ReferenceParam firstParam = listParam.getValuesAsQueryTokens().get(0).getValuesAsQueryTokens().get(0);
+		assertThat(firstParam.getChain(), equalTo("address-city"));
+		assertThat(firstParam.getValue(), equalTo(ENCOUNTER_ADDRESS_CITY));
 	}
 	
 	@Test
 	public void shouldGetEncountersByLocationState() throws Exception {
 		verifyUri(String.format("/Encounter/?location.address-state=%s", ENCOUNTER_ADDRESS_STATE));
 		
-		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
-		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
-		
-		assertThat(locationCaptor.getValue(), notNullValue());
-		assertThat(referenceParam.getChain(), equalTo("address-state"));
-		assertThat(referenceParam.getValue(), equalTo(ENCOUNTER_ADDRESS_STATE));
+		ReferenceAndListParam listParam = paramCaptor.getValue().getLocation();
+		assertThat(listParam, notNullValue());
+		ReferenceParam firstParam = listParam.getValuesAsQueryTokens().get(0).getValuesAsQueryTokens().get(0);
+		assertThat(firstParam.getChain(), equalTo("address-state"));
+		assertThat(firstParam.getValue(), equalTo(ENCOUNTER_ADDRESS_STATE));
 	}
 	
 	@Test
 	public void shouldGetEncountersByLocationPostalCode() throws Exception {
 		verifyUri(String.format("/Encounter/?location.address-postalcode=%s", ENCOUNTER_POSTALCODE));
 		
-		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
-		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
-		
-		assertThat(locationCaptor.getValue(), notNullValue());
-		assertThat(referenceParam.getChain(), equalTo("address-postalcode"));
-		assertThat(referenceParam.getValue(), equalTo(ENCOUNTER_POSTALCODE));
+		ReferenceAndListParam listParam = paramCaptor.getValue().getLocation();
+		assertThat(listParam, notNullValue());
+		ReferenceParam firstParam = listParam.getValuesAsQueryTokens().get(0).getValuesAsQueryTokens().get(0);
+		assertThat(firstParam.getChain(), equalTo("address-postalcode"));
+		assertThat(firstParam.getValue(), equalTo(ENCOUNTER_POSTALCODE));
 	}
 	
 	@Test
 	public void shouldGetEncountersByLocationCountry() throws Exception {
 		verifyUri(String.format("/Encounter/?location.address-country=%s", ENCOUNTER_ADDRESS_COUNTRY));
 		
-		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
-		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
-		
-		assertThat(locationCaptor.getValue(), notNullValue());
-		assertThat(referenceParam.getChain(), equalTo("address-country"));
-		assertThat(referenceParam.getValue(), equalTo(ENCOUNTER_ADDRESS_COUNTRY));
+		ReferenceAndListParam listParam = paramCaptor.getValue().getLocation();
+		assertThat(listParam, notNullValue());
+		ReferenceParam firstParam = listParam.getValuesAsQueryTokens().get(0).getValuesAsQueryTokens().get(0);
+		assertThat(firstParam.getChain(), equalTo("address-country"));
+		assertThat(firstParam.getValue(), equalTo(ENCOUNTER_ADDRESS_COUNTRY));
 	}
 	
 	@Test
 	public void shouldGetEncountersByLocationCountryWithOr() throws Exception {
 		verifyUri(String.format("/Encounter/?location.address-country=%s,%s", ENCOUNTER_ADDRESS_COUNTRY, "USA"));
 		
-		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
-		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
+		ReferenceAndListParam andParams = paramCaptor.getValue().getLocation();
+		assertThat(andParams, notNullValue());
+		assertThat(andParams.getValuesAsQueryTokens().size(), equalTo(1));
 		
-		assertThat(locationCaptor.getValue(), notNullValue());
-		assertThat(referenceParam.getChain(), equalTo("address-country"));
-		assertThat(referenceParam.getValue(), equalTo(ENCOUNTER_ADDRESS_COUNTRY));
-		assertThat(orListParams.get(0).getValuesAsQueryTokens().size(), equalTo(2));
+		List<ReferenceParam> orParams = andParams.getValuesAsQueryTokens().get(0).getValuesAsQueryTokens();
+		assertThat(orParams.size(), equalTo(2));
+		assertThat(orParams.get(0).getChain(), equalTo("address-country"));
+		assertThat(orParams.get(0).getValue(), equalTo(ENCOUNTER_ADDRESS_COUNTRY));
+		assertThat(orParams.get(1).getChain(), equalTo("address-country"));
+		assertThat(orParams.get(1).getValue(), equalTo("USA"));
 	}
 	
 	@Test
 	public void shouldGetEncountersByLocationCountryWithAnd() throws Exception {
 		verifyUri("/Encounter/?location.address-country=INDIA&location.address-country=USA");
 		
-		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
-		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
+		ReferenceAndListParam andParams = paramCaptor.getValue().getLocation();
+		assertThat(andParams, notNullValue());
+		assertThat(andParams.getValuesAsQueryTokens().size(), equalTo(2));
 		
-		assertThat(locationCaptor.getValue(), notNullValue());
-		assertThat(referenceParam.getChain(), equalTo("address-country"));
-		assertThat(referenceParam.getValue(), equalTo(ENCOUNTER_ADDRESS_COUNTRY));
-		assertThat(locationCaptor.getValue().getValuesAsQueryTokens().size(), equalTo(2));
+		ReferenceOrListParam param1 = andParams.getValuesAsQueryTokens().get(0);
+		assertThat(param1.getValuesAsQueryTokens().size(), equalTo(1));
+		assertThat(param1.getValuesAsQueryTokens().get(0).getChain(), equalTo("address-country"));
+		assertThat(param1.getValuesAsQueryTokens().get(0).getValue(), equalTo(ENCOUNTER_ADDRESS_COUNTRY));
+		
+		ReferenceOrListParam param2 = andParams.getValuesAsQueryTokens().get(1);
+		assertThat(param2.getValuesAsQueryTokens().size(), equalTo(1));
+		assertThat(param2.getValuesAsQueryTokens().get(0).getChain(), equalTo("address-country"));
+		assertThat(param2.getValuesAsQueryTokens().get(0).getValue(), equalTo("USA"));
 	}
 	
 	@Test
 	public void shouldGetEncountersByParticipantGivenName() throws Exception {
 		verifyUri(String.format("/Encounter/?participant:Practitioner.given=%s", PARTICIPANT_GIVEN_NAME));
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParams = paramCaptor.getValue().getParticipant().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
 		
-		assertThat(participantCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getParticipant(), notNullValue());
 		assertThat(referenceParam.getChain(), equalTo("given"));
 		assertThat(referenceParam.getValue(), equalTo(PARTICIPANT_GIVEN_NAME));
 	}
@@ -301,13 +277,12 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 	public void shouldGetEncountersByParticipantFamilyName() throws Exception {
 		verifyUri(String.format("/Encounter/?participant:Practitioner.family=%s", PARTICIPANT_FAMILY_NAME));
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParams = paramCaptor.getValue().getParticipant().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
 		
-		assertThat(participantCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getParticipant(), notNullValue());
 		assertThat(referenceParam.getChain(), equalTo("family"));
 		assertThat(referenceParam.getValue(), equalTo(PARTICIPANT_FAMILY_NAME));
 	}
@@ -316,13 +291,12 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 	public void shouldGetEncountersByParticipantFamilyNameWithOr() throws Exception {
 		verifyUri(String.format("/Encounter/?participant:Practitioner.family=%s,%s", PARTICIPANT_FAMILY_NAME, "Vox"));
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParams = paramCaptor.getValue().getParticipant().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
 		
-		assertThat(participantCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getParticipant(), notNullValue());
 		assertThat(referenceParam.getChain(), equalTo("family"));
 		assertThat(referenceParam.getValue(), equalTo(PARTICIPANT_FAMILY_NAME));
 		assertThat(orListParams.get(0).getValuesAsQueryTokens().size(), equalTo(2));
@@ -333,16 +307,15 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter/?participant:Practitioner.family=%s&participant:Practitioner.family=%s",
 		    PARTICIPANT_FAMILY_NAME, "Vox"));
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParams = paramCaptor.getValue().getParticipant().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
 		
-		assertThat(participantCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getParticipant(), notNullValue());
 		assertThat(referenceParam.getChain(), equalTo("family"));
 		assertThat(referenceParam.getValue(), equalTo(PARTICIPANT_FAMILY_NAME));
-		assertThat(participantCaptor.getValue().getValuesAsQueryTokens().size(), equalTo(2));
+		assertThat(paramCaptor.getValue().getParticipant().getValuesAsQueryTokens().size(), equalTo(2));
 	}
 	
 	@Test
@@ -350,13 +323,12 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter/?participant:Practitioner.identifier=%s,%s", PARTICIPANT_IDENTIFIER,
 		    "op87yh-34fd-34egs-56h34-34f7"));
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParams = paramCaptor.getValue().getParticipant().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
 		
-		assertThat(participantCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getParticipant(), notNullValue());
 		assertThat(referenceParam.getChain(), equalTo("identifier"));
 		assertThat(referenceParam.getValue(), equalTo(PARTICIPANT_IDENTIFIER));
 		assertThat(orListParams.get(0).getValuesAsQueryTokens().size(), equalTo(2));
@@ -366,13 +338,12 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 	public void shouldGetEncountersBySubjectGivenName() throws Exception {
 		verifyUri(String.format("/Encounter/?subject.given=%s", PATIENT_GIVEN_NAME));
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), subjectCaptor.capture(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParams = subjectCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParams = paramCaptor.getValue().getSubject().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
 		
-		assertThat(subjectCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getSubject(), notNullValue());
 		assertThat(referenceParam.getChain(), equalTo("given"));
 		assertThat(referenceParam.getValue(), equalTo(PATIENT_GIVEN_NAME));
 	}
@@ -381,13 +352,12 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 	public void shouldGetEncountersBySubjectFamilyName() throws Exception {
 		verifyUri(String.format("/Encounter?subject.family=%s", PATIENT_FAMILY_NAME));
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), subjectCaptor.capture(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParams = subjectCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParams = paramCaptor.getValue().getSubject().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
 		
-		assertThat(subjectCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getSubject(), notNullValue());
 		assertThat(referenceParam.getChain(), equalTo("family"));
 		assertThat(referenceParam.getValue(), equalTo(PATIENT_FAMILY_NAME));
 	}
@@ -396,13 +366,12 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 	public void shouldGetEncountersBySubjectIdentifier() throws Exception {
 		verifyUri(String.format("/Encounter?subject.identifier=%s", PATIENT_IDENTIFIER));
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), subjectCaptor.capture(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParams = subjectCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParams = paramCaptor.getValue().getSubject().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
 		
-		assertThat(subjectCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getSubject(), notNullValue());
 		assertThat(referenceParam.getChain(), equalTo("identifier"));
 		assertThat(referenceParam.getValue(), equalTo(PATIENT_IDENTIFIER));
 	}
@@ -411,19 +380,18 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 	public void shouldGetEncountersBySubjectGivenNameAndLocationPostalCode() throws Exception {
 		verifyUri("/Encounter?subject.given=Hannibal&location.address-postalcode=248001");
 		
-		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), subjectCaptor.capture(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParamsSubject = subjectCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParamsSubject = paramCaptor.getValue().getSubject().getValuesAsQueryTokens();
 		ReferenceParam referenceParamSubject = orListParamsSubject.get(0).getValuesAsQueryTokens().get(0);
 		
-		List<ReferenceOrListParam> orListParamsLocation = locationCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParamsLocation = paramCaptor.getValue().getLocation().getValuesAsQueryTokens();
 		ReferenceParam referenceParamLocation = orListParamsLocation.get(0).getValuesAsQueryTokens().get(0);
 		
-		assertThat(subjectCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getSubject(), notNullValue());
 		assertThat(referenceParamSubject.getChain(), equalTo("given"));
 		assertThat(referenceParamSubject.getValue(), equalTo(PATIENT_GIVEN_NAME));
-		assertThat(locationCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getLocation(), notNullValue());
 		assertThat(referenceParamLocation.getChain(), equalTo("address-postalcode"));
 		assertThat(referenceParamLocation.getValue(), equalTo(ENCOUNTER_POSTALCODE));
 	}
@@ -432,19 +400,18 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 	public void shouldGetEncountersBySubjectGivenNameAndLocationPostalCodeWithOr() throws Exception {
 		verifyUri("/Encounter?subject.given=Hannibal&location.address-postalcode=248001,854796");
 		
-		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), subjectCaptor.capture(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParamsSubject = subjectCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParamsSubject = paramCaptor.getValue().getSubject().getValuesAsQueryTokens();
 		ReferenceParam referenceParamSubject = orListParamsSubject.get(0).getValuesAsQueryTokens().get(0);
 		
-		List<ReferenceOrListParam> orListParamsLocation = locationCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParamsLocation = paramCaptor.getValue().getLocation().getValuesAsQueryTokens();
 		ReferenceParam referenceParamLocation = orListParamsLocation.get(0).getValuesAsQueryTokens().get(0);
 		
-		assertThat(subjectCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getSubject(), notNullValue());
 		assertThat(referenceParamSubject.getChain(), equalTo("given"));
 		assertThat(referenceParamSubject.getValue(), equalTo(PATIENT_GIVEN_NAME));
-		assertThat(locationCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getLocation(), notNullValue());
 		assertThat(referenceParamLocation.getChain(), equalTo("address-postalcode"));
 		assertThat(referenceParamLocation.getValue(), equalTo(ENCOUNTER_POSTALCODE));
 		assertThat(orListParamsLocation.get(0).getValuesAsQueryTokens().size(), equalTo(2));
@@ -454,41 +421,40 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 	public void shouldGetEncountersBySubjectGivenNameAndLocationPostalCodeWithAnd() throws Exception {
 		verifyUri("/Encounter?subject.given=Hannibal&location.address-postalcode=248001&location.address-postalcode=854796");
 		
-		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), subjectCaptor.capture(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParamsSubject = subjectCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParamsSubject = paramCaptor.getValue().getSubject().getValuesAsQueryTokens();
 		ReferenceParam referenceParamSubject = orListParamsSubject.get(0).getValuesAsQueryTokens().get(0);
 		
-		List<ReferenceOrListParam> orListParamsLocation = locationCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParamsLocation = paramCaptor.getValue().getLocation().getValuesAsQueryTokens();
 		ReferenceParam referenceParamLocation = orListParamsLocation.get(0).getValuesAsQueryTokens().get(0);
 		
-		assertThat(subjectCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getSubject(), notNullValue());
 		assertThat(referenceParamSubject.getChain(), equalTo("given"));
 		assertThat(referenceParamSubject.getValue(), equalTo(PATIENT_GIVEN_NAME));
-		assertThat(locationCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getLocation(), notNullValue());
 		assertThat(referenceParamLocation.getChain(), equalTo("address-postalcode"));
 		assertThat(referenceParamLocation.getValue(), equalTo(ENCOUNTER_POSTALCODE));
-		assertThat(locationCaptor.getValue().getValuesAsQueryTokens().size(), equalTo(2));
+		assertThat(paramCaptor.getValue().getLocation().getValuesAsQueryTokens().size(), equalTo(2));
 	}
 	
 	@Test
 	public void shouldGetEncountersByParticipantIdentifierAndLocationPostalCode() throws Exception {
 		verifyUri("/Encounter?participant:Practitioner.identifier=1000WF&location.address-postalcode=248001");
 		
-		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), participantCaptor.capture(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParamsParticipant = participantCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParamsParticipant = paramCaptor.getValue().getParticipant()
+		        .getValuesAsQueryTokens();
 		ReferenceParam referenceParamParticipant = orListParamsParticipant.get(0).getValuesAsQueryTokens().get(0);
 		
-		List<ReferenceOrListParam> orListParamsLocation = locationCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParamsLocation = paramCaptor.getValue().getLocation().getValuesAsQueryTokens();
 		ReferenceParam referenceParamLocation = orListParamsLocation.get(0).getValuesAsQueryTokens().get(0);
 		
-		assertThat(participantCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getParticipant(), notNullValue());
 		assertThat(referenceParamParticipant.getChain(), equalTo("identifier"));
 		assertThat(referenceParamParticipant.getValue(), equalTo(PARTICIPANT_IDENTIFIER));
-		assertThat(locationCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getLocation(), notNullValue());
 		assertThat(referenceParamLocation.getChain(), equalTo("address-postalcode"));
 		assertThat(referenceParamLocation.getValue(), equalTo(ENCOUNTER_POSTALCODE));
 	}
@@ -497,36 +463,34 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 	public void shouldGetEncountersByParticipantIdentifierAndDate() throws Exception {
 		verifyUri("/Encounter?participant:Practitioner.identifier=1000WF,670WD&date=ge1975-02-02");
 		
-		verify(encounterService).searchForEncounters(dateRangeCaptor.capture(), isNull(), participantCaptor.capture(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParamsParticipant = participantCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParamsParticipant = paramCaptor.getValue().getParticipant()
+		        .getValuesAsQueryTokens();
 		ReferenceParam referenceParamParticipant = orListParamsParticipant.get(0).getValuesAsQueryTokens().get(0);
 		
-		assertThat(participantCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getParticipant(), notNullValue());
 		assertThat(referenceParamParticipant.getChain(), equalTo("identifier"));
 		assertThat(referenceParamParticipant.getValue(), equalTo(PARTICIPANT_IDENTIFIER));
 		assertThat(orListParamsParticipant.get(0).getValuesAsQueryTokens().size(), equalTo(2));
 		
 		Calendar calendar = Calendar.getInstance();
 		calendar.set(1975, Calendar.FEBRUARY, 2);
-		assertThat(dateRangeCaptor.getValue(), notNullValue());
-		assertThat(dateRangeCaptor.getValue().getLowerBound().getValue(),
+		assertThat(paramCaptor.getValue().getDate(), notNullValue());
+		assertThat(paramCaptor.getValue().getDate().getLowerBound().getValue(),
 		    equalTo(DateUtils.truncate(calendar.getTime(), Calendar.DATE)));
-		assertThat(dateRangeCaptor.getValue().getUpperBound(), nullValue());
+		assertThat(paramCaptor.getValue().getDate().getUpperBound(), nullValue());
 	}
 	
 	@Test
 	public void shouldGetEncountersByUUID() throws Exception {
 		verifyUri(String.format("/Encounter?_id=%s", ENCOUNTER_UUID));
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(),
-		    tokenAndListParamArgumentCaptor.capture(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		assertThat(tokenAndListParamArgumentCaptor.getValue(), notNullValue());
-		assertThat(tokenAndListParamArgumentCaptor.getValue().getValuesAsQueryTokens(), not(empty()));
-		assertThat(tokenAndListParamArgumentCaptor.getValue().getValuesAsQueryTokens().get(0).getValuesAsQueryTokens().get(0)
-		        .getValue(),
+		assertThat(paramCaptor.getValue().getId(), notNullValue());
+		assertThat(paramCaptor.getValue().getId().getValuesAsQueryTokens(), not(empty()));
+		assertThat(paramCaptor.getValue().getId().getValuesAsQueryTokens().get(0).getValuesAsQueryTokens().get(0).getValue(),
 		    equalTo(ENCOUNTER_UUID));
 	}
 	
@@ -534,12 +498,11 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 	public void shouldGetEncountersByTypeUUID() throws Exception {
 		verifyUri(String.format("/Encounter?type=%s", ENCOUNTER_TYPE_UUID));
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(),
-		    tokenAndListParamArgumentCaptor.capture(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		assertThat(tokenAndListParamArgumentCaptor.getValue(), notNullValue());
-		assertThat(tokenAndListParamArgumentCaptor.getValue().getValuesAsQueryTokens(), not(empty()));
-		assertThat(tokenAndListParamArgumentCaptor.getValue().getValuesAsQueryTokens().get(0).getValuesAsQueryTokens().get(0)
+		assertThat(paramCaptor.getValue().getEncounterType(), notNullValue());
+		assertThat(paramCaptor.getValue().getEncounterType().getValuesAsQueryTokens(), not(empty()));
+		assertThat(paramCaptor.getValue().getEncounterType().getValuesAsQueryTokens().get(0).getValuesAsQueryTokens().get(0)
 		        .getValue(),
 		    equalTo(ENCOUNTER_TYPE_UUID));
 	}
@@ -548,17 +511,16 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 	public void shouldGetEncountersByLastUpdatedDate() throws Exception {
 		verifyUri(String.format("/Encounter?_lastUpdated=%s", LAST_UPDATED_DATE));
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    dateRangeCaptor.capture(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		assertThat(dateRangeCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getLastUpdated(), notNullValue());
 		
 		Calendar calendar = Calendar.getInstance();
 		calendar.set(2020, Calendar.SEPTEMBER, 3);
 		
-		assertThat(dateRangeCaptor.getValue().getLowerBound().getValue(),
+		assertThat(paramCaptor.getValue().getLastUpdated().getLowerBound().getValue(),
 		    equalTo(org.apache.commons.lang3.time.DateUtils.truncate(calendar.getTime(), Calendar.DATE)));
-		assertThat(dateRangeCaptor.getValue().getUpperBound().getValue(),
+		assertThat(paramCaptor.getValue().getLastUpdated().getUpperBound().getValue(),
 		    equalTo(org.apache.commons.lang3.time.DateUtils.truncate(calendar.getTime(), Calendar.DATE)));
 	}
 	
@@ -566,58 +528,54 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 	public void shouldAddPatientsWithReturnedEncounters() throws Exception {
 		verifyUri("/Encounter?_include=Encounter:patient");
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), includeArgumentCaptor.capture(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		assertThat(includeArgumentCaptor.getValue(), notNullValue());
-		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
-		assertThat(includeArgumentCaptor.getValue().iterator().next().getParamName(),
+		assertThat(paramCaptor.getValue().getIncludes(), notNullValue());
+		assertThat(paramCaptor.getValue().getIncludes().size(), equalTo(1));
+		assertThat(paramCaptor.getValue().getIncludes().iterator().next().getParamName(),
 		    equalTo(FhirConstants.INCLUDE_PATIENT_PARAM));
-		assertThat(includeArgumentCaptor.getValue().iterator().next().getParamType(), equalTo(FhirConstants.ENCOUNTER));
+		assertThat(paramCaptor.getValue().getIncludes().iterator().next().getParamType(), equalTo(FhirConstants.ENCOUNTER));
 	}
 	
 	@Test
 	public void shouldAddLocationsWithReturnedEncounters() throws Exception {
 		verifyUri("/Encounter?_include=Encounter:location");
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), includeArgumentCaptor.capture(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		assertThat(includeArgumentCaptor.getValue(), notNullValue());
-		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
-		assertThat(includeArgumentCaptor.getValue().iterator().next().getParamName(),
+		assertThat(paramCaptor.getValue().getIncludes(), notNullValue());
+		assertThat(paramCaptor.getValue().getIncludes().size(), equalTo(1));
+		assertThat(paramCaptor.getValue().getIncludes().iterator().next().getParamName(),
 		    equalTo(FhirConstants.INCLUDE_LOCATION_PARAM));
-		assertThat(includeArgumentCaptor.getValue().iterator().next().getParamType(), equalTo(FhirConstants.ENCOUNTER));
+		assertThat(paramCaptor.getValue().getIncludes().iterator().next().getParamType(), equalTo(FhirConstants.ENCOUNTER));
 	}
 	
 	@Test
 	public void shouldAddParticipantsWithReturnedEncounters() throws Exception {
 		verifyUri("/Encounter?_include=Encounter:participant");
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), includeArgumentCaptor.capture(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		assertThat(includeArgumentCaptor.getValue(), notNullValue());
-		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
-		assertThat(includeArgumentCaptor.getValue().iterator().next().getParamName(),
+		assertThat(paramCaptor.getValue().getIncludes(), notNullValue());
+		assertThat(paramCaptor.getValue().getIncludes().size(), equalTo(1));
+		assertThat(paramCaptor.getValue().getIncludes().iterator().next().getParamName(),
 		    equalTo(FhirConstants.INCLUDE_PARTICIPANT_PARAM));
-		assertThat(includeArgumentCaptor.getValue().iterator().next().getParamType(), equalTo(FhirConstants.ENCOUNTER));
+		assertThat(paramCaptor.getValue().getIncludes().iterator().next().getParamType(), equalTo(FhirConstants.ENCOUNTER));
 	}
 	
 	@Test
 	public void shouldHandleMultipleIncludes() throws Exception {
 		verifyUri("/Encounter?_include=Encounter:participant&_include=Encounter:location");
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), includeArgumentCaptor.capture(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		assertThat(includeArgumentCaptor.getValue(), notNullValue());
-		assertThat(includeArgumentCaptor.getValue().size(), equalTo(2));
+		assertThat(paramCaptor.getValue().getIncludes(), notNullValue());
+		assertThat(paramCaptor.getValue().getIncludes().size(), equalTo(2));
 		
-		assertThat(includeArgumentCaptor.getValue(),
+		assertThat(paramCaptor.getValue().getIncludes(),
 		    hasItem(allOf(hasProperty("paramName", equalTo(FhirConstants.INCLUDE_LOCATION_PARAM)),
 		        hasProperty("paramType", equalTo(FhirConstants.ENCOUNTER)))));
-		assertThat(includeArgumentCaptor.getValue(),
+		assertThat(paramCaptor.getValue().getIncludes(),
 		    hasItem(allOf(hasProperty("paramName", equalTo(FhirConstants.INCLUDE_PARTICIPANT_PARAM)),
 		        hasProperty("paramType", equalTo(FhirConstants.ENCOUNTER)))));
 	}
@@ -626,28 +584,27 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 	public void shouldAddObservationsWithReturnedEncounters() throws Exception {
 		verifyUri("/Encounter?_revinclude=Observation:encounter");
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), includeArgumentCaptor.capture(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		assertThat(includeArgumentCaptor.getValue(), notNullValue());
-		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
-		assertThat(includeArgumentCaptor.getValue().iterator().next().getParamName(),
+		assertThat(paramCaptor.getValue().getRevIncludes(), notNullValue());
+		assertThat(paramCaptor.getValue().getRevIncludes().size(), equalTo(1));
+		assertThat(paramCaptor.getValue().getRevIncludes().iterator().next().getParamName(),
 		    equalTo(FhirConstants.INCLUDE_ENCOUNTER_PARAM));
-		assertThat(includeArgumentCaptor.getValue().iterator().next().getParamType(), equalTo(FhirConstants.OBSERVATION));
+		assertThat(paramCaptor.getValue().getRevIncludes().iterator().next().getParamType(),
+		    equalTo(FhirConstants.OBSERVATION));
 	}
 	
 	@Test
 	public void shouldAddDiagnosticReportsWithReturnedEncounters() throws Exception {
 		verifyUri("/Encounter?_revinclude=DiagnosticReport:encounter");
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), includeArgumentCaptor.capture(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		assertThat(includeArgumentCaptor.getValue(), notNullValue());
-		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
-		assertThat(includeArgumentCaptor.getValue().iterator().next().getParamName(),
+		assertThat(paramCaptor.getValue().getRevIncludes(), notNullValue());
+		assertThat(paramCaptor.getValue().getRevIncludes().size(), equalTo(1));
+		assertThat(paramCaptor.getValue().getRevIncludes().iterator().next().getParamName(),
 		    equalTo(FhirConstants.INCLUDE_ENCOUNTER_PARAM));
-		assertThat(includeArgumentCaptor.getValue().iterator().next().getParamType(),
+		assertThat(paramCaptor.getValue().getRevIncludes().iterator().next().getParamType(),
 		    equalTo(FhirConstants.DIAGNOSTIC_REPORT));
 	}
 	
@@ -655,14 +612,13 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 	public void shouldAddMedicationRequestsWithReturnedEncounters() throws Exception {
 		verifyUri("/Encounter?_revinclude=MedicationRequest:context");
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), includeArgumentCaptor.capture(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		assertThat(includeArgumentCaptor.getValue(), notNullValue());
-		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
-		assertThat(includeArgumentCaptor.getValue().iterator().next().getParamName(),
+		assertThat(paramCaptor.getValue().getRevIncludes(), notNullValue());
+		assertThat(paramCaptor.getValue().getRevIncludes().size(), equalTo(1));
+		assertThat(paramCaptor.getValue().getRevIncludes().iterator().next().getParamName(),
 		    equalTo(FhirConstants.INCLUDE_CONTEXT_PARAM));
-		assertThat(includeArgumentCaptor.getValue().iterator().next().getParamType(),
+		assertThat(paramCaptor.getValue().getRevIncludes().iterator().next().getParamType(),
 		    equalTo(FhirConstants.MEDICATION_REQUEST));
 	}
 	
@@ -670,14 +626,13 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 	public void shouldAddProcedureRequestsWithReturnedEncounters() throws Exception {
 		verifyUri("/Encounter?_revinclude=ProcedureRequest:encounter");
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), includeArgumentCaptor.capture(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		assertThat(includeArgumentCaptor.getValue(), notNullValue());
-		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
-		assertThat(includeArgumentCaptor.getValue().iterator().next().getParamName(),
+		assertThat(paramCaptor.getValue().getRevIncludes(), notNullValue());
+		assertThat(paramCaptor.getValue().getRevIncludes().size(), equalTo(1));
+		assertThat(paramCaptor.getValue().getRevIncludes().iterator().next().getParamName(),
 		    equalTo(FhirConstants.INCLUDE_ENCOUNTER_PARAM));
-		assertThat(includeArgumentCaptor.getValue().iterator().next().getParamType(),
+		assertThat(paramCaptor.getValue().getRevIncludes().iterator().next().getParamType(),
 		    equalTo(FhirConstants.PROCEDURE_REQUEST));
 	}
 	
@@ -685,16 +640,15 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 	public void shouldHandleMultipleReverseIncludes() throws Exception {
 		verifyUri("/Encounter?_revinclude=DiagnosticReport:encounter&_revinclude=Observation:encounter");
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), includeArgumentCaptor.capture(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		assertThat(includeArgumentCaptor.getValue(), notNullValue());
-		assertThat(includeArgumentCaptor.getValue().size(), equalTo(2));
+		assertThat(paramCaptor.getValue().getRevIncludes(), notNullValue());
+		assertThat(paramCaptor.getValue().getRevIncludes().size(), equalTo(2));
 		
-		assertThat(includeArgumentCaptor.getValue(),
+		assertThat(paramCaptor.getValue().getRevIncludes(),
 		    hasItem(allOf(hasProperty("paramName", equalTo(FhirConstants.INCLUDE_ENCOUNTER_PARAM)),
 		        hasProperty("paramType", equalTo(FhirConstants.OBSERVATION)))));
-		assertThat(includeArgumentCaptor.getValue(),
+		assertThat(paramCaptor.getValue().getRevIncludes(),
 		    hasItem(allOf(hasProperty("paramName", equalTo(FhirConstants.INCLUDE_ENCOUNTER_PARAM)),
 		        hasProperty("paramType", equalTo(FhirConstants.DIAGNOSTIC_REPORT)))));
 	}
@@ -704,12 +658,10 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(
 		    "/Encounter?_has:MedicationRequest:encounter:intent=order&_has:MedicationRequest:encounter:status=active,draft");
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), hasAndListParamArgumentCaptor.capture());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		assertThat(hasAndListParamArgumentCaptor.getValue(), notNullValue());
-		
-		HasAndListParam hasAndListParam = hasAndListParamArgumentCaptor.getValue();
+		HasAndListParam hasAndListParam = paramCaptor.getValue().getHasAndListParam();
+		assertThat(hasAndListParam, notNullValue());
 		assertThat(hasAndListParam.size(), equalTo(2));
 		
 		List<HasOrListParam> hasOrListParams = hasAndListParam.getValuesAsQueryTokens();
@@ -732,11 +684,28 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		assertThat(valuesFound.get(2), equalTo("status=draft"));
 	}
 	
+	@Test
+	public void shouldHandleTagParameter() throws Exception {
+		verifyUri("/Encounter?_tag=http://fhir.openmrs.org/ext/encounter-tag|encounter");
+		
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
+		
+		TokenAndListParam tagParam = paramCaptor.getValue().getTag();
+		assertThat(tagParam, notNullValue());
+		List<TokenOrListParam> tokenOrListParams = tagParam.getValuesAsQueryTokens();
+		assertThat(tokenOrListParams.size(), equalTo(1));
+		TokenOrListParam tokenOrListParam = tokenOrListParams.get(0);
+		assertThat(tokenOrListParam.getValuesAsQueryTokens().size(), equalTo(1));
+		TokenParam tokenParam = tokenOrListParam.getValuesAsQueryTokens().get(0);
+		assertThat(tokenParam.getSystem(), equalTo(FhirConstants.OPENMRS_FHIR_EXT_ENCOUNTER_TAG));
+		assertThat(tokenParam.getValue(), equalTo("encounter"));
+	}
+	
 	private void verifyUri(String uri) throws Exception {
 		Encounter encounter = new Encounter();
 		encounter.setId(ENCOUNTER_UUID);
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
-		    any())).thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), 10, 1));
+		when(encounterService.searchForEncounters(any()))
+		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), 10, 1));
 		
 		MockHttpServletResponse response = get(uri).accept(FhirMediaTypes.JSON).go();
 		

--- a/omod/src/test/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProviderWebTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProviderWebTest.java
@@ -161,7 +161,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter?subject:Patient=%s", PATIENT_UUID));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), subjectCaptor.capture(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		assertThat(subjectCaptor.getValue(), notNullValue());
 		assertThat(subjectCaptor.getAllValues().iterator().next().getValuesAsQueryTokens().iterator().next()
 		        .getValuesAsQueryTokens().iterator().next().getIdPart(),
@@ -173,7 +173,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter/?date=ge1975-02-02");
 		
 		verify(encounterService).searchForEncounters(dateRangeCaptor.capture(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		assertThat(dateRangeCaptor.getValue(), notNullValue());
 		
 		Calendar calendar = Calendar.getInstance();
@@ -189,7 +189,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter/?location.address-city=%s", ENCOUNTER_ADDRESS_CITY));
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -204,7 +204,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter/?location.address-state=%s", ENCOUNTER_ADDRESS_STATE));
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -219,7 +219,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter/?location.address-postalcode=%s", ENCOUNTER_POSTALCODE));
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -234,7 +234,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter/?location.address-country=%s", ENCOUNTER_ADDRESS_COUNTRY));
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -249,7 +249,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter/?location.address-country=%s,%s", ENCOUNTER_ADDRESS_COUNTRY, "USA"));
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -265,7 +265,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter/?location.address-country=INDIA&location.address-country=USA");
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -281,7 +281,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter/?participant:Practitioner.given=%s", PARTICIPANT_GIVEN_NAME));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -296,7 +296,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter/?participant:Practitioner.family=%s", PARTICIPANT_FAMILY_NAME));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -311,7 +311,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter/?participant:Practitioner.family=%s,%s", PARTICIPANT_FAMILY_NAME, "Vox"));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -328,7 +328,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		    PARTICIPANT_FAMILY_NAME, "Vox"));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -345,7 +345,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		    "op87yh-34fd-34egs-56h34-34f7"));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -361,7 +361,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter/?subject.given=%s", PATIENT_GIVEN_NAME));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), subjectCaptor.capture(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = subjectCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -376,7 +376,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter?subject.family=%s", PATIENT_FAMILY_NAME));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), subjectCaptor.capture(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = subjectCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -391,7 +391,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter?subject.identifier=%s", PATIENT_IDENTIFIER));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), subjectCaptor.capture(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = subjectCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -406,7 +406,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter?subject.given=Hannibal&location.address-postalcode=248001");
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), subjectCaptor.capture(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParamsSubject = subjectCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParamSubject = orListParamsSubject.get(0).getValuesAsQueryTokens().get(0);
@@ -427,7 +427,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter?subject.given=Hannibal&location.address-postalcode=248001,854796");
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), subjectCaptor.capture(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParamsSubject = subjectCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParamSubject = orListParamsSubject.get(0).getValuesAsQueryTokens().get(0);
@@ -449,7 +449,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter?subject.given=Hannibal&location.address-postalcode=248001&location.address-postalcode=854796");
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), subjectCaptor.capture(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParamsSubject = subjectCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParamSubject = orListParamsSubject.get(0).getValuesAsQueryTokens().get(0);
@@ -471,7 +471,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter?participant:Practitioner.identifier=1000WF&location.address-postalcode=248001");
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), participantCaptor.capture(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParamsParticipant = participantCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParamParticipant = orListParamsParticipant.get(0).getValuesAsQueryTokens().get(0);
@@ -492,7 +492,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter?participant:Practitioner.identifier=1000WF,670WD&date=ge1975-02-02");
 		
 		verify(encounterService).searchForEncounters(dateRangeCaptor.capture(), isNull(), participantCaptor.capture(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParamsParticipant = participantCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParamParticipant = orListParamsParticipant.get(0).getValuesAsQueryTokens().get(0);
@@ -515,7 +515,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter?_id=%s", ENCOUNTER_UUID));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(),
-		    tokenAndListParamArgumentCaptor.capture(), isNull(), isNull(), isNull(), isNull());
+		    tokenAndListParamArgumentCaptor.capture(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		assertThat(tokenAndListParamArgumentCaptor.getValue(), notNullValue());
 		assertThat(tokenAndListParamArgumentCaptor.getValue().getValuesAsQueryTokens(), not(empty()));
@@ -529,7 +529,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter?type=%s", ENCOUNTER_TYPE_UUID));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(),
-		    tokenAndListParamArgumentCaptor.capture(), isNull(), isNull(), isNull(), isNull(), isNull());
+		    tokenAndListParamArgumentCaptor.capture(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		assertThat(tokenAndListParamArgumentCaptor.getValue(), notNullValue());
 		assertThat(tokenAndListParamArgumentCaptor.getValue().getValuesAsQueryTokens(), not(empty()));
@@ -543,7 +543,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri(String.format("/Encounter?_lastUpdated=%s", LAST_UPDATED_DATE));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    dateRangeCaptor.capture(), isNull(), isNull(), isNull());
+		    dateRangeCaptor.capture(), isNull(), isNull(), isNull(), isNull());
 		
 		assertThat(dateRangeCaptor.getValue(), notNullValue());
 		
@@ -561,7 +561,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter?_include=Encounter:patient");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), includeArgumentCaptor.capture(), isNull());
+		    isNull(), includeArgumentCaptor.capture(), isNull(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
@@ -575,7 +575,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter?_include=Encounter:location");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), includeArgumentCaptor.capture(), isNull());
+		    isNull(), includeArgumentCaptor.capture(), isNull(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
@@ -589,7 +589,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter?_include=Encounter:participant");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), includeArgumentCaptor.capture(), isNull());
+		    isNull(), includeArgumentCaptor.capture(), isNull(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
@@ -603,7 +603,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter?_include=Encounter:participant&_include=Encounter:location");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), includeArgumentCaptor.capture(), isNull());
+		    isNull(), includeArgumentCaptor.capture(), isNull(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(2));
@@ -621,7 +621,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter?_revinclude=Observation:encounter");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), includeArgumentCaptor.capture());
+		    isNull(), isNull(), includeArgumentCaptor.capture(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
@@ -635,7 +635,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter?_revinclude=DiagnosticReport:encounter");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), includeArgumentCaptor.capture());
+		    isNull(), isNull(), includeArgumentCaptor.capture(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
@@ -650,7 +650,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter?_revinclude=MedicationRequest:context");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), includeArgumentCaptor.capture());
+		    isNull(), isNull(), includeArgumentCaptor.capture(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
@@ -665,7 +665,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter?_revinclude=ProcedureRequest:encounter");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), includeArgumentCaptor.capture());
+		    isNull(), isNull(), includeArgumentCaptor.capture(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
@@ -680,7 +680,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		verifyUri("/Encounter?_revinclude=DiagnosticReport:encounter&_revinclude=Observation:encounter");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), includeArgumentCaptor.capture());
+		    isNull(), isNull(), includeArgumentCaptor.capture(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(2));
@@ -696,8 +696,8 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 	private void verifyUri(String uri) throws Exception {
 		Encounter encounter = new Encounter();
 		encounter.setId(ENCOUNTER_UUID);
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
-		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), 10, 1));
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+		    any())).thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), 10, 1));
 		
 		MockHttpServletResponse response = get(uri).accept(FhirMediaTypes.JSON).go();
 		

--- a/omod/src/test/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProviderWebTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/providers/r3/EncounterFhirResourceProviderWebTest.java
@@ -30,6 +30,7 @@ import javax.servlet.ServletException;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.HashSet;
@@ -38,6 +39,8 @@ import java.util.Objects;
 
 import ca.uhn.fhir.model.api.Include;
 import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.HasAndListParam;
+import ca.uhn.fhir.rest.param.HasOrListParam;
 import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.ReferenceOrListParam;
 import ca.uhn.fhir.rest.param.ReferenceParam;
@@ -125,6 +128,9 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 	
 	@Captor
 	private ArgumentCaptor<HashSet<Include>> includeArgumentCaptor;
+	
+	@Captor
+	private ArgumentCaptor<HasAndListParam> hasAndListParamArgumentCaptor;
 	
 	@Before
 	@Override
@@ -691,6 +697,39 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR3ResourceProv
 		assertThat(includeArgumentCaptor.getValue(),
 		    hasItem(allOf(hasProperty("paramName", equalTo(FhirConstants.INCLUDE_ENCOUNTER_PARAM)),
 		        hasProperty("paramType", equalTo(FhirConstants.DIAGNOSTIC_REPORT)))));
+	}
+	
+	@Test
+	public void shouldHandleHasAndListParameter() throws Exception {
+		verifyUri(
+		    "/Encounter?_has:MedicationRequest:encounter:intent=order&_has:MedicationRequest:encounter:status=active,draft");
+		
+		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
+		    isNull(), isNull(), isNull(), hasAndListParamArgumentCaptor.capture());
+		
+		assertThat(hasAndListParamArgumentCaptor.getValue(), notNullValue());
+		
+		HasAndListParam hasAndListParam = hasAndListParamArgumentCaptor.getValue();
+		assertThat(hasAndListParam.size(), equalTo(2));
+		
+		List<HasOrListParam> hasOrListParams = hasAndListParam.getValuesAsQueryTokens();
+		assertThat(hasOrListParams.size(), equalTo(2));
+		
+		List<String> valuesFound = new ArrayList<>();
+		
+		for (HasOrListParam hasOrListParam : hasOrListParams) {
+			hasOrListParam.getValuesAsQueryTokens().forEach(hasParam -> {
+				assertThat(hasParam.getTargetResourceType(), equalTo(FhirConstants.MEDICATION_REQUEST));
+				assertThat(hasParam.getReferenceFieldName(), equalTo("encounter"));
+				valuesFound.add(hasParam.getParameterName() + "=" + hasParam.getParameterValue());
+			});
+		}
+		Collections.sort(valuesFound);
+		
+		assertThat(valuesFound.size(), equalTo(3));
+		assertThat(valuesFound.get(0), equalTo("intent=order"));
+		assertThat(valuesFound.get(1), equalTo("status=active"));
+		assertThat(valuesFound.get(2), equalTo("status=draft"));
 	}
 	
 	private void verifyUri(String uri) throws Exception {

--- a/omod/src/test/java/org/openmrs/module/fhir2/providers/r4/EncounterFhirResourceProviderWebTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/providers/r4/EncounterFhirResourceProviderWebTest.java
@@ -172,7 +172,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter?subject:Patient=%s", PATIENT_UUID));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), subjectCaptor.capture(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		assertThat(subjectCaptor.getValue(), notNullValue());
 		assertThat(subjectCaptor.getAllValues().iterator().next().getValuesAsQueryTokens().iterator().next()
 		        .getValuesAsQueryTokens().iterator().next().getIdPart(),
@@ -187,7 +187,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter/?date=ge1975-02-02");
 		
 		verify(encounterService).searchForEncounters(dateRangeCaptor.capture(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		assertThat(dateRangeCaptor.getValue(), notNullValue());
 		
 		Calendar calendar = Calendar.getInstance();
@@ -203,7 +203,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter/?location=%s", LOCATION_UUID));
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -218,7 +218,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter/?location.address-city=%s", ENCOUNTER_ADDRESS_CITY));
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -233,7 +233,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter/?location.address-state=%s", ENCOUNTER_ADDRESS_STATE));
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -248,7 +248,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter/?location.address-postalcode=%s", ENCOUNTER_POSTALCODE));
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -263,7 +263,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter/?location.address-country=%s", ENCOUNTER_ADDRESS_COUNTRY));
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -278,7 +278,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter/?location.address-country=%s,%s", ENCOUNTER_ADDRESS_COUNTRY, "USA"));
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -294,7 +294,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter/?location.address-country=INDIA&location.address-country=USA");
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -310,7 +310,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter/?participant:Practitioner=%s", PARTICIPANT_UUID));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -325,7 +325,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter/?participant:Practitioner.given=%s", PARTICIPANT_GIVEN_NAME));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -340,7 +340,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter/?participant:Practitioner.family=%s", PARTICIPANT_FAMILY_NAME));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -355,7 +355,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter/?participant:Practitioner.family=%s,%s", PARTICIPANT_FAMILY_NAME, "Vox"));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -372,7 +372,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		    PARTICIPANT_FAMILY_NAME, "Vox"));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -389,7 +389,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		    "op87yh-34fd-34egs-56h34-34f7"));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -405,7 +405,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter/?subject.given=%s", PATIENT_GIVEN_NAME));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), subjectCaptor.capture(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = subjectCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -420,7 +420,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter?subject.family=%s", PATIENT_FAMILY_NAME));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), subjectCaptor.capture(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = subjectCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -435,7 +435,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter?subject.identifier=%s", PATIENT_IDENTIFIER));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), subjectCaptor.capture(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParams = subjectCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
@@ -450,7 +450,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter?subject.given=Hannibal&location.address-postalcode=248001");
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), subjectCaptor.capture(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParamsSubject = subjectCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParamSubject = orListParamsSubject.get(0).getValuesAsQueryTokens().get(0);
@@ -471,7 +471,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter?subject.given=Hannibal&location.address-postalcode=248001,854796");
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), subjectCaptor.capture(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParamsSubject = subjectCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParamSubject = orListParamsSubject.get(0).getValuesAsQueryTokens().get(0);
@@ -493,7 +493,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter?subject.given=Hannibal&location.address-postalcode=248001&location.address-postalcode=854796");
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), subjectCaptor.capture(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParamsSubject = subjectCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParamSubject = orListParamsSubject.get(0).getValuesAsQueryTokens().get(0);
@@ -515,7 +515,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter?participant:Practitioner.identifier=1000WF&location.address-postalcode=248001");
 		
 		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), participantCaptor.capture(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParamsParticipant = participantCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParamParticipant = orListParamsParticipant.get(0).getValuesAsQueryTokens().get(0);
@@ -536,7 +536,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter?participant:Practitioner.identifier=1000WF,670WD&date=ge1975-02-02");
 		
 		verify(encounterService).searchForEncounters(dateRangeCaptor.capture(), isNull(), participantCaptor.capture(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		List<ReferenceOrListParam> orListParamsParticipant = participantCaptor.getValue().getValuesAsQueryTokens();
 		ReferenceParam referenceParamParticipant = orListParamsParticipant.get(0).getValuesAsQueryTokens().get(0);
@@ -559,7 +559,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter?_id=%s", ENCOUNTER_UUID));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(),
-		    tokenAndListParamArgumentCaptor.capture(), isNull(), isNull(), isNull(), isNull());
+		    tokenAndListParamArgumentCaptor.capture(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		assertThat(tokenAndListParamArgumentCaptor.getValue(), notNullValue());
 		assertThat(tokenAndListParamArgumentCaptor.getValue().getValuesAsQueryTokens(), not(empty()));
@@ -573,7 +573,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter?type=%s", ENCOUNTER_TYPE_UUID));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(),
-		    tokenAndListParamArgumentCaptor.capture(), isNull(), isNull(), isNull(), isNull(), isNull());
+		    tokenAndListParamArgumentCaptor.capture(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
 		
 		assertThat(tokenAndListParamArgumentCaptor.getValue(), notNullValue());
 		assertThat(tokenAndListParamArgumentCaptor.getValue().getValuesAsQueryTokens(), not(empty()));
@@ -587,7 +587,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter?_lastUpdated=%s", LAST_UPDATED_DATE));
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    dateRangeCaptor.capture(), isNull(), isNull(), isNull());
+		    dateRangeCaptor.capture(), isNull(), isNull(), isNull(), isNull());
 		
 		assertThat(dateRangeCaptor.getValue(), notNullValue());
 		
@@ -605,7 +605,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter?_include=Encounter:patient");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), includeArgumentCaptor.capture(), isNull());
+		    isNull(), includeArgumentCaptor.capture(), isNull(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
@@ -619,7 +619,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter?_include=Encounter:location");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), includeArgumentCaptor.capture(), isNull());
+		    isNull(), includeArgumentCaptor.capture(), isNull(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
@@ -633,7 +633,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter?_include=Encounter:participant");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), includeArgumentCaptor.capture(), isNull());
+		    isNull(), includeArgumentCaptor.capture(), isNull(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
@@ -647,7 +647,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter?_include=Encounter:participant&_include=Encounter:location");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), includeArgumentCaptor.capture(), isNull());
+		    isNull(), includeArgumentCaptor.capture(), isNull(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(2));
@@ -665,7 +665,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter?_revinclude=Observation:encounter");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), includeArgumentCaptor.capture());
+		    isNull(), isNull(), includeArgumentCaptor.capture(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
@@ -679,7 +679,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter?_revinclude=DiagnosticReport:encounter");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), includeArgumentCaptor.capture());
+		    isNull(), isNull(), includeArgumentCaptor.capture(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
@@ -694,7 +694,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter?_revinclude=MedicationRequest:encounter");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), includeArgumentCaptor.capture());
+		    isNull(), isNull(), includeArgumentCaptor.capture(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
@@ -709,7 +709,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter?_revinclude=ServiceRequest:encounter");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), includeArgumentCaptor.capture());
+		    isNull(), isNull(), includeArgumentCaptor.capture(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
@@ -724,7 +724,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri("/Encounter?_revinclude=DiagnosticReport:encounter&_revinclude=Observation:encounter");
 		
 		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), includeArgumentCaptor.capture());
+		    isNull(), isNull(), includeArgumentCaptor.capture(), isNull());
 		
 		assertThat(includeArgumentCaptor.getValue(), notNullValue());
 		assertThat(includeArgumentCaptor.getValue().size(), equalTo(2));
@@ -740,8 +740,8 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 	private void verifyUri(String uri) throws Exception {
 		Encounter encounter = new Encounter();
 		encounter.setId(ENCOUNTER_UUID);
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
-		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), 10, 1));
+		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+		    any())).thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), 10, 1));
 		
 		MockHttpServletResponse response = get(uri).accept(FhirMediaTypes.JSON).go();
 		

--- a/omod/src/test/java/org/openmrs/module/fhir2/providers/r4/EncounterFhirResourceProviderWebTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/providers/r4/EncounterFhirResourceProviderWebTest.java
@@ -21,7 +21,6 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -33,11 +32,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 
-import ca.uhn.fhir.model.api.Include;
 import ca.uhn.fhir.rest.param.DateRangeParam;
 import ca.uhn.fhir.rest.param.HasAndListParam;
 import ca.uhn.fhir.rest.param.HasOrListParam;
@@ -45,6 +42,7 @@ import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.ReferenceOrListParam;
 import ca.uhn.fhir.rest.param.ReferenceParam;
 import ca.uhn.fhir.rest.param.TokenAndListParam;
+import ca.uhn.fhir.rest.param.TokenOrListParam;
 import ca.uhn.fhir.rest.param.TokenParam;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import lombok.AccessLevel;
@@ -62,6 +60,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.openmrs.module.fhir2.FhirConstants;
 import org.openmrs.module.fhir2.api.FhirEncounterService;
+import org.openmrs.module.fhir2.api.search.param.EncounterSearchParams;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -116,25 +115,7 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 	private EncounterFhirResourceProvider resourceProvider;
 	
 	@Captor
-	private ArgumentCaptor<ReferenceAndListParam> locationCaptor;
-	
-	@Captor
-	private ArgumentCaptor<ReferenceAndListParam> participantCaptor;
-	
-	@Captor
-	private ArgumentCaptor<ReferenceAndListParam> subjectCaptor;
-	
-	@Captor
-	private ArgumentCaptor<DateRangeParam> dateRangeCaptor;
-	
-	@Captor
-	private ArgumentCaptor<TokenAndListParam> tokenAndListParamArgumentCaptor;
-	
-	@Captor
-	private ArgumentCaptor<HashSet<Include>> includeArgumentCaptor;
-	
-	@Captor
-	private ArgumentCaptor<HasAndListParam> hasAndListParamArgumentCaptor;
+	private ArgumentCaptor<EncounterSearchParams> paramCaptor;
 	
 	@Captor
 	private ArgumentCaptor<TokenParam> tokenCaptor;
@@ -176,45 +157,37 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 	@Test
 	public void shouldGetEncountersBySubjectUuid() throws Exception {
 		verifyUri(String.format("/Encounter?subject:Patient=%s", PATIENT_UUID));
-		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), subjectCaptor.capture(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
-		assertThat(subjectCaptor.getValue(), notNullValue());
-		assertThat(subjectCaptor.getAllValues().iterator().next().getValuesAsQueryTokens().iterator().next()
-		        .getValuesAsQueryTokens().iterator().next().getIdPart(),
-		    equalTo(PATIENT_UUID));
-		assertThat(subjectCaptor.getAllValues().iterator().next().getValuesAsQueryTokens().iterator().next()
-		        .getValuesAsQueryTokens().iterator().next().getChain(),
-		    equalTo(null));
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
+		ReferenceAndListParam p = paramCaptor.getValue().getSubject();
+		assertThat(p, notNullValue());
+		assertThat(p.getValuesAsQueryTokens().get(0).getValuesAsQueryTokens().get(0).getIdPart(), equalTo(PATIENT_UUID));
 	}
 	
 	@Test
 	public void shouldGetEncountersByDate() throws Exception {
 		verifyUri("/Encounter/?date=ge1975-02-02");
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		verify(encounterService).searchForEncounters(dateRangeCaptor.capture(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
-		assertThat(dateRangeCaptor.getValue(), notNullValue());
+		DateRangeParam p = paramCaptor.getValue().getDate();
+		assertThat(p, notNullValue());
 		
 		Calendar calendar = Calendar.getInstance();
 		calendar.set(1975, Calendar.FEBRUARY, 2);
 		
-		assertThat(dateRangeCaptor.getValue().getLowerBound().getValue(),
-		    equalTo(DateUtils.truncate(calendar.getTime(), Calendar.DATE)));
-		assertThat(dateRangeCaptor.getValue().getUpperBound(), nullValue());
+		assertThat(p.getLowerBound().getValue(), equalTo(DateUtils.truncate(calendar.getTime(), Calendar.DATE)));
+		assertThat(p.getUpperBound(), nullValue());
 	}
 	
 	@Test
 	public void shouldGetEncountersByLocationUUID() throws Exception {
 		verifyUri(String.format("/Encounter/?location=%s", LOCATION_UUID));
 		
-		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParams = paramCaptor.getValue().getLocation().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
 		
-		assertThat(locationCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getLocation(), notNullValue());
 		assertThat(referenceParam.getChain(), equalTo(null));
 		assertThat(referenceParam.getValue(), equalTo(LOCATION_UUID));
 	}
@@ -223,120 +196,103 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 	public void shouldGetEncountersByLocationCityVillage() throws Exception {
 		verifyUri(String.format("/Encounter/?location.address-city=%s", ENCOUNTER_ADDRESS_CITY));
 		
-		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
-		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
-		
-		assertThat(locationCaptor.getValue(), notNullValue());
-		assertThat(referenceParam.getChain(), equalTo("address-city"));
-		assertThat(referenceParam.getValue(), equalTo(ENCOUNTER_ADDRESS_CITY));
+		ReferenceAndListParam listParam = paramCaptor.getValue().getLocation();
+		assertThat(listParam, notNullValue());
+		ReferenceParam firstParam = listParam.getValuesAsQueryTokens().get(0).getValuesAsQueryTokens().get(0);
+		assertThat(firstParam.getChain(), equalTo("address-city"));
+		assertThat(firstParam.getValue(), equalTo(ENCOUNTER_ADDRESS_CITY));
 	}
 	
 	@Test
 	public void shouldGetEncountersByLocationState() throws Exception {
 		verifyUri(String.format("/Encounter/?location.address-state=%s", ENCOUNTER_ADDRESS_STATE));
 		
-		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
-		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
-		
-		assertThat(locationCaptor.getValue(), notNullValue());
-		assertThat(referenceParam.getChain(), equalTo("address-state"));
-		assertThat(referenceParam.getValue(), equalTo(ENCOUNTER_ADDRESS_STATE));
+		ReferenceAndListParam listParam = paramCaptor.getValue().getLocation();
+		assertThat(listParam, notNullValue());
+		ReferenceParam firstParam = listParam.getValuesAsQueryTokens().get(0).getValuesAsQueryTokens().get(0);
+		assertThat(firstParam.getChain(), equalTo("address-state"));
+		assertThat(firstParam.getValue(), equalTo(ENCOUNTER_ADDRESS_STATE));
 	}
 	
 	@Test
 	public void shouldGetEncountersByLocationPostalCode() throws Exception {
 		verifyUri(String.format("/Encounter/?location.address-postalcode=%s", ENCOUNTER_POSTALCODE));
 		
-		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
-		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
-		
-		assertThat(locationCaptor.getValue(), notNullValue());
-		assertThat(referenceParam.getChain(), equalTo("address-postalcode"));
-		assertThat(referenceParam.getValue(), equalTo(ENCOUNTER_POSTALCODE));
+		ReferenceAndListParam listParam = paramCaptor.getValue().getLocation();
+		assertThat(listParam, notNullValue());
+		ReferenceParam firstParam = listParam.getValuesAsQueryTokens().get(0).getValuesAsQueryTokens().get(0);
+		assertThat(firstParam.getChain(), equalTo("address-postalcode"));
+		assertThat(firstParam.getValue(), equalTo(ENCOUNTER_POSTALCODE));
 	}
 	
 	@Test
 	public void shouldGetEncountersByLocationCountry() throws Exception {
 		verifyUri(String.format("/Encounter/?location.address-country=%s", ENCOUNTER_ADDRESS_COUNTRY));
 		
-		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
-		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
-		
-		assertThat(locationCaptor.getValue(), notNullValue());
-		assertThat(referenceParam.getChain(), equalTo("address-country"));
-		assertThat(referenceParam.getValue(), equalTo(ENCOUNTER_ADDRESS_COUNTRY));
+		ReferenceAndListParam listParam = paramCaptor.getValue().getLocation();
+		assertThat(listParam, notNullValue());
+		ReferenceParam firstParam = listParam.getValuesAsQueryTokens().get(0).getValuesAsQueryTokens().get(0);
+		assertThat(firstParam.getChain(), equalTo("address-country"));
+		assertThat(firstParam.getValue(), equalTo(ENCOUNTER_ADDRESS_COUNTRY));
 	}
 	
 	@Test
 	public void shouldGetEncountersByLocationCountryWithOr() throws Exception {
 		verifyUri(String.format("/Encounter/?location.address-country=%s,%s", ENCOUNTER_ADDRESS_COUNTRY, "USA"));
 		
-		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
-		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
+		ReferenceAndListParam andParams = paramCaptor.getValue().getLocation();
+		assertThat(andParams, notNullValue());
+		assertThat(andParams.getValuesAsQueryTokens().size(), equalTo(1));
 		
-		assertThat(locationCaptor.getValue(), notNullValue());
-		assertThat(referenceParam.getChain(), equalTo("address-country"));
-		assertThat(referenceParam.getValue(), equalTo(ENCOUNTER_ADDRESS_COUNTRY));
-		assertThat(orListParams.get(0).getValuesAsQueryTokens().size(), equalTo(2));
+		List<ReferenceParam> orParams = andParams.getValuesAsQueryTokens().get(0).getValuesAsQueryTokens();
+		assertThat(orParams.size(), equalTo(2));
+		assertThat(orParams.get(0).getChain(), equalTo("address-country"));
+		assertThat(orParams.get(0).getValue(), equalTo(ENCOUNTER_ADDRESS_COUNTRY));
+		assertThat(orParams.get(1).getChain(), equalTo("address-country"));
+		assertThat(orParams.get(1).getValue(), equalTo("USA"));
 	}
 	
 	@Test
 	public void shouldGetEncountersByLocationCountryWithAnd() throws Exception {
 		verifyUri("/Encounter/?location.address-country=INDIA&location.address-country=USA");
 		
-		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParams = locationCaptor.getValue().getValuesAsQueryTokens();
-		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
+		ReferenceAndListParam andParams = paramCaptor.getValue().getLocation();
+		assertThat(andParams, notNullValue());
+		assertThat(andParams.getValuesAsQueryTokens().size(), equalTo(2));
 		
-		assertThat(locationCaptor.getValue(), notNullValue());
-		assertThat(referenceParam.getChain(), equalTo("address-country"));
-		assertThat(referenceParam.getValue(), equalTo(ENCOUNTER_ADDRESS_COUNTRY));
-		assertThat(locationCaptor.getValue().getValuesAsQueryTokens().size(), equalTo(2));
-	}
-	
-	@Test
-	public void shouldGetEncountersByParticipantUUID() throws Exception {
-		verifyUri(String.format("/Encounter/?participant:Practitioner=%s", PARTICIPANT_UUID));
+		ReferenceOrListParam param1 = andParams.getValuesAsQueryTokens().get(0);
+		assertThat(param1.getValuesAsQueryTokens().size(), equalTo(1));
+		assertThat(param1.getValuesAsQueryTokens().get(0).getChain(), equalTo("address-country"));
+		assertThat(param1.getValuesAsQueryTokens().get(0).getValue(), equalTo(ENCOUNTER_ADDRESS_COUNTRY));
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
-		
-		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
-		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
-		
-		assertThat(participantCaptor.getValue(), notNullValue());
-		assertThat(referenceParam.getChain(), equalTo(null));
-		assertThat(referenceParam.getValue(), equalTo(PARTICIPANT_UUID));
+		ReferenceOrListParam param2 = andParams.getValuesAsQueryTokens().get(1);
+		assertThat(param2.getValuesAsQueryTokens().size(), equalTo(1));
+		assertThat(param2.getValuesAsQueryTokens().get(0).getChain(), equalTo("address-country"));
+		assertThat(param2.getValuesAsQueryTokens().get(0).getValue(), equalTo("USA"));
 	}
 	
 	@Test
 	public void shouldGetEncountersByParticipantGivenName() throws Exception {
 		verifyUri(String.format("/Encounter/?participant:Practitioner.given=%s", PARTICIPANT_GIVEN_NAME));
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParams = paramCaptor.getValue().getParticipant().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
 		
-		assertThat(participantCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getParticipant(), notNullValue());
 		assertThat(referenceParam.getChain(), equalTo("given"));
 		assertThat(referenceParam.getValue(), equalTo(PARTICIPANT_GIVEN_NAME));
 	}
@@ -345,13 +301,12 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 	public void shouldGetEncountersByParticipantFamilyName() throws Exception {
 		verifyUri(String.format("/Encounter/?participant:Practitioner.family=%s", PARTICIPANT_FAMILY_NAME));
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParams = paramCaptor.getValue().getParticipant().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
 		
-		assertThat(participantCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getParticipant(), notNullValue());
 		assertThat(referenceParam.getChain(), equalTo("family"));
 		assertThat(referenceParam.getValue(), equalTo(PARTICIPANT_FAMILY_NAME));
 	}
@@ -360,13 +315,12 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 	public void shouldGetEncountersByParticipantFamilyNameWithOr() throws Exception {
 		verifyUri(String.format("/Encounter/?participant:Practitioner.family=%s,%s", PARTICIPANT_FAMILY_NAME, "Vox"));
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParams = paramCaptor.getValue().getParticipant().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
 		
-		assertThat(participantCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getParticipant(), notNullValue());
 		assertThat(referenceParam.getChain(), equalTo("family"));
 		assertThat(referenceParam.getValue(), equalTo(PARTICIPANT_FAMILY_NAME));
 		assertThat(orListParams.get(0).getValuesAsQueryTokens().size(), equalTo(2));
@@ -377,16 +331,15 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter/?participant:Practitioner.family=%s&participant:Practitioner.family=%s",
 		    PARTICIPANT_FAMILY_NAME, "Vox"));
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParams = paramCaptor.getValue().getParticipant().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
 		
-		assertThat(participantCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getParticipant(), notNullValue());
 		assertThat(referenceParam.getChain(), equalTo("family"));
 		assertThat(referenceParam.getValue(), equalTo(PARTICIPANT_FAMILY_NAME));
-		assertThat(participantCaptor.getValue().getValuesAsQueryTokens().size(), equalTo(2));
+		assertThat(paramCaptor.getValue().getParticipant().getValuesAsQueryTokens().size(), equalTo(2));
 	}
 	
 	@Test
@@ -394,13 +347,12 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(String.format("/Encounter/?participant:Practitioner.identifier=%s,%s", PARTICIPANT_IDENTIFIER,
 		    "op87yh-34fd-34egs-56h34-34f7"));
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), participantCaptor.capture(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParams = participantCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParams = paramCaptor.getValue().getParticipant().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
 		
-		assertThat(participantCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getParticipant(), notNullValue());
 		assertThat(referenceParam.getChain(), equalTo("identifier"));
 		assertThat(referenceParam.getValue(), equalTo(PARTICIPANT_IDENTIFIER));
 		assertThat(orListParams.get(0).getValuesAsQueryTokens().size(), equalTo(2));
@@ -410,13 +362,12 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 	public void shouldGetEncountersBySubjectGivenName() throws Exception {
 		verifyUri(String.format("/Encounter/?subject.given=%s", PATIENT_GIVEN_NAME));
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), subjectCaptor.capture(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParams = subjectCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParams = paramCaptor.getValue().getSubject().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
 		
-		assertThat(subjectCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getSubject(), notNullValue());
 		assertThat(referenceParam.getChain(), equalTo("given"));
 		assertThat(referenceParam.getValue(), equalTo(PATIENT_GIVEN_NAME));
 	}
@@ -425,13 +376,12 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 	public void shouldGetEncountersBySubjectFamilyName() throws Exception {
 		verifyUri(String.format("/Encounter?subject.family=%s", PATIENT_FAMILY_NAME));
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), subjectCaptor.capture(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParams = subjectCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParams = paramCaptor.getValue().getSubject().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
 		
-		assertThat(subjectCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getSubject(), notNullValue());
 		assertThat(referenceParam.getChain(), equalTo("family"));
 		assertThat(referenceParam.getValue(), equalTo(PATIENT_FAMILY_NAME));
 	}
@@ -440,13 +390,12 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 	public void shouldGetEncountersBySubjectIdentifier() throws Exception {
 		verifyUri(String.format("/Encounter?subject.identifier=%s", PATIENT_IDENTIFIER));
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), subjectCaptor.capture(), isNull(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParams = subjectCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParams = paramCaptor.getValue().getSubject().getValuesAsQueryTokens();
 		ReferenceParam referenceParam = orListParams.get(0).getValuesAsQueryTokens().get(0);
 		
-		assertThat(subjectCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getSubject(), notNullValue());
 		assertThat(referenceParam.getChain(), equalTo("identifier"));
 		assertThat(referenceParam.getValue(), equalTo(PATIENT_IDENTIFIER));
 	}
@@ -455,19 +404,18 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 	public void shouldGetEncountersBySubjectGivenNameAndLocationPostalCode() throws Exception {
 		verifyUri("/Encounter?subject.given=Hannibal&location.address-postalcode=248001");
 		
-		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), subjectCaptor.capture(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParamsSubject = subjectCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParamsSubject = paramCaptor.getValue().getSubject().getValuesAsQueryTokens();
 		ReferenceParam referenceParamSubject = orListParamsSubject.get(0).getValuesAsQueryTokens().get(0);
 		
-		List<ReferenceOrListParam> orListParamsLocation = locationCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParamsLocation = paramCaptor.getValue().getLocation().getValuesAsQueryTokens();
 		ReferenceParam referenceParamLocation = orListParamsLocation.get(0).getValuesAsQueryTokens().get(0);
 		
-		assertThat(subjectCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getSubject(), notNullValue());
 		assertThat(referenceParamSubject.getChain(), equalTo("given"));
 		assertThat(referenceParamSubject.getValue(), equalTo(PATIENT_GIVEN_NAME));
-		assertThat(locationCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getLocation(), notNullValue());
 		assertThat(referenceParamLocation.getChain(), equalTo("address-postalcode"));
 		assertThat(referenceParamLocation.getValue(), equalTo(ENCOUNTER_POSTALCODE));
 	}
@@ -476,19 +424,18 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 	public void shouldGetEncountersBySubjectGivenNameAndLocationPostalCodeWithOr() throws Exception {
 		verifyUri("/Encounter?subject.given=Hannibal&location.address-postalcode=248001,854796");
 		
-		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), subjectCaptor.capture(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParamsSubject = subjectCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParamsSubject = paramCaptor.getValue().getSubject().getValuesAsQueryTokens();
 		ReferenceParam referenceParamSubject = orListParamsSubject.get(0).getValuesAsQueryTokens().get(0);
 		
-		List<ReferenceOrListParam> orListParamsLocation = locationCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParamsLocation = paramCaptor.getValue().getLocation().getValuesAsQueryTokens();
 		ReferenceParam referenceParamLocation = orListParamsLocation.get(0).getValuesAsQueryTokens().get(0);
 		
-		assertThat(subjectCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getSubject(), notNullValue());
 		assertThat(referenceParamSubject.getChain(), equalTo("given"));
 		assertThat(referenceParamSubject.getValue(), equalTo(PATIENT_GIVEN_NAME));
-		assertThat(locationCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getLocation(), notNullValue());
 		assertThat(referenceParamLocation.getChain(), equalTo("address-postalcode"));
 		assertThat(referenceParamLocation.getValue(), equalTo(ENCOUNTER_POSTALCODE));
 		assertThat(orListParamsLocation.get(0).getValuesAsQueryTokens().size(), equalTo(2));
@@ -498,41 +445,40 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 	public void shouldGetEncountersBySubjectGivenNameAndLocationPostalCodeWithAnd() throws Exception {
 		verifyUri("/Encounter?subject.given=Hannibal&location.address-postalcode=248001&location.address-postalcode=854796");
 		
-		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), isNull(), subjectCaptor.capture(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParamsSubject = subjectCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParamsSubject = paramCaptor.getValue().getSubject().getValuesAsQueryTokens();
 		ReferenceParam referenceParamSubject = orListParamsSubject.get(0).getValuesAsQueryTokens().get(0);
 		
-		List<ReferenceOrListParam> orListParamsLocation = locationCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParamsLocation = paramCaptor.getValue().getLocation().getValuesAsQueryTokens();
 		ReferenceParam referenceParamLocation = orListParamsLocation.get(0).getValuesAsQueryTokens().get(0);
 		
-		assertThat(subjectCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getSubject(), notNullValue());
 		assertThat(referenceParamSubject.getChain(), equalTo("given"));
 		assertThat(referenceParamSubject.getValue(), equalTo(PATIENT_GIVEN_NAME));
-		assertThat(locationCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getLocation(), notNullValue());
 		assertThat(referenceParamLocation.getChain(), equalTo("address-postalcode"));
 		assertThat(referenceParamLocation.getValue(), equalTo(ENCOUNTER_POSTALCODE));
-		assertThat(locationCaptor.getValue().getValuesAsQueryTokens().size(), equalTo(2));
+		assertThat(paramCaptor.getValue().getLocation().getValuesAsQueryTokens().size(), equalTo(2));
 	}
 	
 	@Test
 	public void shouldGetEncountersByParticipantIdentifierAndLocationPostalCode() throws Exception {
 		verifyUri("/Encounter?participant:Practitioner.identifier=1000WF&location.address-postalcode=248001");
 		
-		verify(encounterService).searchForEncounters(isNull(), locationCaptor.capture(), participantCaptor.capture(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParamsParticipant = participantCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParamsParticipant = paramCaptor.getValue().getParticipant()
+		        .getValuesAsQueryTokens();
 		ReferenceParam referenceParamParticipant = orListParamsParticipant.get(0).getValuesAsQueryTokens().get(0);
 		
-		List<ReferenceOrListParam> orListParamsLocation = locationCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParamsLocation = paramCaptor.getValue().getLocation().getValuesAsQueryTokens();
 		ReferenceParam referenceParamLocation = orListParamsLocation.get(0).getValuesAsQueryTokens().get(0);
 		
-		assertThat(participantCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getParticipant(), notNullValue());
 		assertThat(referenceParamParticipant.getChain(), equalTo("identifier"));
 		assertThat(referenceParamParticipant.getValue(), equalTo(PARTICIPANT_IDENTIFIER));
-		assertThat(locationCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getLocation(), notNullValue());
 		assertThat(referenceParamLocation.getChain(), equalTo("address-postalcode"));
 		assertThat(referenceParamLocation.getValue(), equalTo(ENCOUNTER_POSTALCODE));
 	}
@@ -541,36 +487,34 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 	public void shouldGetEncountersByParticipantIdentifierAndDate() throws Exception {
 		verifyUri("/Encounter?participant:Practitioner.identifier=1000WF,670WD&date=ge1975-02-02");
 		
-		verify(encounterService).searchForEncounters(dateRangeCaptor.capture(), isNull(), participantCaptor.capture(),
-		    isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		List<ReferenceOrListParam> orListParamsParticipant = participantCaptor.getValue().getValuesAsQueryTokens();
+		List<ReferenceOrListParam> orListParamsParticipant = paramCaptor.getValue().getParticipant()
+		        .getValuesAsQueryTokens();
 		ReferenceParam referenceParamParticipant = orListParamsParticipant.get(0).getValuesAsQueryTokens().get(0);
 		
-		assertThat(participantCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getParticipant(), notNullValue());
 		assertThat(referenceParamParticipant.getChain(), equalTo("identifier"));
 		assertThat(referenceParamParticipant.getValue(), equalTo(PARTICIPANT_IDENTIFIER));
 		assertThat(orListParamsParticipant.get(0).getValuesAsQueryTokens().size(), equalTo(2));
 		
 		Calendar calendar = Calendar.getInstance();
 		calendar.set(1975, Calendar.FEBRUARY, 2);
-		assertThat(dateRangeCaptor.getValue(), notNullValue());
-		assertThat(dateRangeCaptor.getValue().getLowerBound().getValue(),
+		assertThat(paramCaptor.getValue().getDate(), notNullValue());
+		assertThat(paramCaptor.getValue().getDate().getLowerBound().getValue(),
 		    equalTo(DateUtils.truncate(calendar.getTime(), Calendar.DATE)));
-		assertThat(dateRangeCaptor.getValue().getUpperBound(), nullValue());
+		assertThat(paramCaptor.getValue().getDate().getUpperBound(), nullValue());
 	}
 	
 	@Test
 	public void shouldGetEncountersByUUID() throws Exception {
 		verifyUri(String.format("/Encounter?_id=%s", ENCOUNTER_UUID));
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(),
-		    tokenAndListParamArgumentCaptor.capture(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		assertThat(tokenAndListParamArgumentCaptor.getValue(), notNullValue());
-		assertThat(tokenAndListParamArgumentCaptor.getValue().getValuesAsQueryTokens(), not(empty()));
-		assertThat(tokenAndListParamArgumentCaptor.getValue().getValuesAsQueryTokens().get(0).getValuesAsQueryTokens().get(0)
-		        .getValue(),
+		assertThat(paramCaptor.getValue().getId(), notNullValue());
+		assertThat(paramCaptor.getValue().getId().getValuesAsQueryTokens(), not(empty()));
+		assertThat(paramCaptor.getValue().getId().getValuesAsQueryTokens().get(0).getValuesAsQueryTokens().get(0).getValue(),
 		    equalTo(ENCOUNTER_UUID));
 	}
 	
@@ -578,12 +522,11 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 	public void shouldGetEncountersByTypeUUID() throws Exception {
 		verifyUri(String.format("/Encounter?type=%s", ENCOUNTER_TYPE_UUID));
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(),
-		    tokenAndListParamArgumentCaptor.capture(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		assertThat(tokenAndListParamArgumentCaptor.getValue(), notNullValue());
-		assertThat(tokenAndListParamArgumentCaptor.getValue().getValuesAsQueryTokens(), not(empty()));
-		assertThat(tokenAndListParamArgumentCaptor.getValue().getValuesAsQueryTokens().get(0).getValuesAsQueryTokens().get(0)
+		assertThat(paramCaptor.getValue().getEncounterType(), notNullValue());
+		assertThat(paramCaptor.getValue().getEncounterType().getValuesAsQueryTokens(), not(empty()));
+		assertThat(paramCaptor.getValue().getEncounterType().getValuesAsQueryTokens().get(0).getValuesAsQueryTokens().get(0)
 		        .getValue(),
 		    equalTo(ENCOUNTER_TYPE_UUID));
 	}
@@ -592,76 +535,71 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 	public void shouldGetEncountersByLastUpdatedDate() throws Exception {
 		verifyUri(String.format("/Encounter?_lastUpdated=%s", LAST_UPDATED_DATE));
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    dateRangeCaptor.capture(), isNull(), isNull(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		assertThat(dateRangeCaptor.getValue(), notNullValue());
+		assertThat(paramCaptor.getValue().getLastUpdated(), notNullValue());
 		
 		Calendar calendar = Calendar.getInstance();
 		calendar.set(2020, Calendar.SEPTEMBER, 3);
 		
-		assertThat(dateRangeCaptor.getValue().getLowerBound().getValue(),
-		    equalTo(DateUtils.truncate(calendar.getTime(), Calendar.DATE)));
-		assertThat(dateRangeCaptor.getValue().getUpperBound().getValue(),
-		    equalTo(DateUtils.truncate(calendar.getTime(), Calendar.DATE)));
+		assertThat(paramCaptor.getValue().getLastUpdated().getLowerBound().getValue(),
+		    equalTo(org.apache.commons.lang3.time.DateUtils.truncate(calendar.getTime(), Calendar.DATE)));
+		assertThat(paramCaptor.getValue().getLastUpdated().getUpperBound().getValue(),
+		    equalTo(org.apache.commons.lang3.time.DateUtils.truncate(calendar.getTime(), Calendar.DATE)));
 	}
 	
 	@Test
 	public void shouldAddPatientsWithReturnedEncounters() throws Exception {
 		verifyUri("/Encounter?_include=Encounter:patient");
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), includeArgumentCaptor.capture(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		assertThat(includeArgumentCaptor.getValue(), notNullValue());
-		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
-		assertThat(includeArgumentCaptor.getValue().iterator().next().getParamName(),
+		assertThat(paramCaptor.getValue().getIncludes(), notNullValue());
+		assertThat(paramCaptor.getValue().getIncludes().size(), equalTo(1));
+		assertThat(paramCaptor.getValue().getIncludes().iterator().next().getParamName(),
 		    equalTo(FhirConstants.INCLUDE_PATIENT_PARAM));
-		assertThat(includeArgumentCaptor.getValue().iterator().next().getParamType(), equalTo(FhirConstants.ENCOUNTER));
+		assertThat(paramCaptor.getValue().getIncludes().iterator().next().getParamType(), equalTo(FhirConstants.ENCOUNTER));
 	}
 	
 	@Test
 	public void shouldAddLocationsWithReturnedEncounters() throws Exception {
 		verifyUri("/Encounter?_include=Encounter:location");
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), includeArgumentCaptor.capture(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		assertThat(includeArgumentCaptor.getValue(), notNullValue());
-		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
-		assertThat(includeArgumentCaptor.getValue().iterator().next().getParamName(),
+		assertThat(paramCaptor.getValue().getIncludes(), notNullValue());
+		assertThat(paramCaptor.getValue().getIncludes().size(), equalTo(1));
+		assertThat(paramCaptor.getValue().getIncludes().iterator().next().getParamName(),
 		    equalTo(FhirConstants.INCLUDE_LOCATION_PARAM));
-		assertThat(includeArgumentCaptor.getValue().iterator().next().getParamType(), equalTo(FhirConstants.ENCOUNTER));
+		assertThat(paramCaptor.getValue().getIncludes().iterator().next().getParamType(), equalTo(FhirConstants.ENCOUNTER));
 	}
 	
 	@Test
 	public void shouldAddParticipantsWithReturnedEncounters() throws Exception {
 		verifyUri("/Encounter?_include=Encounter:participant");
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), includeArgumentCaptor.capture(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		assertThat(includeArgumentCaptor.getValue(), notNullValue());
-		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
-		assertThat(includeArgumentCaptor.getValue().iterator().next().getParamName(),
+		assertThat(paramCaptor.getValue().getIncludes(), notNullValue());
+		assertThat(paramCaptor.getValue().getIncludes().size(), equalTo(1));
+		assertThat(paramCaptor.getValue().getIncludes().iterator().next().getParamName(),
 		    equalTo(FhirConstants.INCLUDE_PARTICIPANT_PARAM));
-		assertThat(includeArgumentCaptor.getValue().iterator().next().getParamType(), equalTo(FhirConstants.ENCOUNTER));
+		assertThat(paramCaptor.getValue().getIncludes().iterator().next().getParamType(), equalTo(FhirConstants.ENCOUNTER));
 	}
 	
 	@Test
 	public void shouldHandleMultipleIncludes() throws Exception {
 		verifyUri("/Encounter?_include=Encounter:participant&_include=Encounter:location");
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), includeArgumentCaptor.capture(), isNull(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		assertThat(includeArgumentCaptor.getValue(), notNullValue());
-		assertThat(includeArgumentCaptor.getValue().size(), equalTo(2));
+		assertThat(paramCaptor.getValue().getIncludes(), notNullValue());
+		assertThat(paramCaptor.getValue().getIncludes().size(), equalTo(2));
 		
-		assertThat(includeArgumentCaptor.getValue(),
+		assertThat(paramCaptor.getValue().getIncludes(),
 		    hasItem(allOf(hasProperty("paramName", equalTo(FhirConstants.INCLUDE_LOCATION_PARAM)),
 		        hasProperty("paramType", equalTo(FhirConstants.ENCOUNTER)))));
-		assertThat(includeArgumentCaptor.getValue(),
+		assertThat(paramCaptor.getValue().getIncludes(),
 		    hasItem(allOf(hasProperty("paramName", equalTo(FhirConstants.INCLUDE_PARTICIPANT_PARAM)),
 		        hasProperty("paramType", equalTo(FhirConstants.ENCOUNTER)))));
 	}
@@ -670,28 +608,27 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 	public void shouldAddObservationsWithReturnedEncounters() throws Exception {
 		verifyUri("/Encounter?_revinclude=Observation:encounter");
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), includeArgumentCaptor.capture(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		assertThat(includeArgumentCaptor.getValue(), notNullValue());
-		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
-		assertThat(includeArgumentCaptor.getValue().iterator().next().getParamName(),
+		assertThat(paramCaptor.getValue().getRevIncludes(), notNullValue());
+		assertThat(paramCaptor.getValue().getRevIncludes().size(), equalTo(1));
+		assertThat(paramCaptor.getValue().getRevIncludes().iterator().next().getParamName(),
 		    equalTo(FhirConstants.INCLUDE_ENCOUNTER_PARAM));
-		assertThat(includeArgumentCaptor.getValue().iterator().next().getParamType(), equalTo(FhirConstants.OBSERVATION));
+		assertThat(paramCaptor.getValue().getRevIncludes().iterator().next().getParamType(),
+		    equalTo(FhirConstants.OBSERVATION));
 	}
 	
 	@Test
 	public void shouldAddDiagnosticReportsWithReturnedEncounters() throws Exception {
 		verifyUri("/Encounter?_revinclude=DiagnosticReport:encounter");
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), includeArgumentCaptor.capture(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		assertThat(includeArgumentCaptor.getValue(), notNullValue());
-		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
-		assertThat(includeArgumentCaptor.getValue().iterator().next().getParamName(),
+		assertThat(paramCaptor.getValue().getRevIncludes(), notNullValue());
+		assertThat(paramCaptor.getValue().getRevIncludes().size(), equalTo(1));
+		assertThat(paramCaptor.getValue().getRevIncludes().iterator().next().getParamName(),
 		    equalTo(FhirConstants.INCLUDE_ENCOUNTER_PARAM));
-		assertThat(includeArgumentCaptor.getValue().iterator().next().getParamType(),
+		assertThat(paramCaptor.getValue().getRevIncludes().iterator().next().getParamType(),
 		    equalTo(FhirConstants.DIAGNOSTIC_REPORT));
 	}
 	
@@ -699,14 +636,13 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 	public void shouldAddMedicationRequestsWithReturnedEncounters() throws Exception {
 		verifyUri("/Encounter?_revinclude=MedicationRequest:encounter");
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), includeArgumentCaptor.capture(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		assertThat(includeArgumentCaptor.getValue(), notNullValue());
-		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
-		assertThat(includeArgumentCaptor.getValue().iterator().next().getParamName(),
+		assertThat(paramCaptor.getValue().getRevIncludes(), notNullValue());
+		assertThat(paramCaptor.getValue().getRevIncludes().size(), equalTo(1));
+		assertThat(paramCaptor.getValue().getRevIncludes().iterator().next().getParamName(),
 		    equalTo(FhirConstants.INCLUDE_ENCOUNTER_PARAM));
-		assertThat(includeArgumentCaptor.getValue().iterator().next().getParamType(),
+		assertThat(paramCaptor.getValue().getRevIncludes().iterator().next().getParamType(),
 		    equalTo(FhirConstants.MEDICATION_REQUEST));
 	}
 	
@@ -714,14 +650,13 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 	public void shouldAddServiceRequestsWithReturnedEncounters() throws Exception {
 		verifyUri("/Encounter?_revinclude=ServiceRequest:encounter");
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), includeArgumentCaptor.capture(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		assertThat(includeArgumentCaptor.getValue(), notNullValue());
-		assertThat(includeArgumentCaptor.getValue().size(), equalTo(1));
-		assertThat(includeArgumentCaptor.getValue().iterator().next().getParamName(),
+		assertThat(paramCaptor.getValue().getRevIncludes(), notNullValue());
+		assertThat(paramCaptor.getValue().getRevIncludes().size(), equalTo(1));
+		assertThat(paramCaptor.getValue().getRevIncludes().iterator().next().getParamName(),
 		    equalTo(FhirConstants.INCLUDE_ENCOUNTER_PARAM));
-		assertThat(includeArgumentCaptor.getValue().iterator().next().getParamType(),
+		assertThat(paramCaptor.getValue().getRevIncludes().iterator().next().getParamType(),
 		    equalTo(FhirConstants.SERVICE_REQUEST));
 	}
 	
@@ -729,16 +664,15 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 	public void shouldHandleMultipleReverseIncludes() throws Exception {
 		verifyUri("/Encounter?_revinclude=DiagnosticReport:encounter&_revinclude=Observation:encounter");
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), includeArgumentCaptor.capture(), isNull());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		assertThat(includeArgumentCaptor.getValue(), notNullValue());
-		assertThat(includeArgumentCaptor.getValue().size(), equalTo(2));
+		assertThat(paramCaptor.getValue().getRevIncludes(), notNullValue());
+		assertThat(paramCaptor.getValue().getRevIncludes().size(), equalTo(2));
 		
-		assertThat(includeArgumentCaptor.getValue(),
+		assertThat(paramCaptor.getValue().getRevIncludes(),
 		    hasItem(allOf(hasProperty("paramName", equalTo(FhirConstants.INCLUDE_ENCOUNTER_PARAM)),
 		        hasProperty("paramType", equalTo(FhirConstants.OBSERVATION)))));
-		assertThat(includeArgumentCaptor.getValue(),
+		assertThat(paramCaptor.getValue().getRevIncludes(),
 		    hasItem(allOf(hasProperty("paramName", equalTo(FhirConstants.INCLUDE_ENCOUNTER_PARAM)),
 		        hasProperty("paramType", equalTo(FhirConstants.DIAGNOSTIC_REPORT)))));
 	}
@@ -748,12 +682,10 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		verifyUri(
 		    "/Encounter?_has:MedicationRequest:encounter:intent=order&_has:MedicationRequest:encounter:status=active,draft");
 		
-		verify(encounterService).searchForEncounters(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(),
-		    isNull(), isNull(), isNull(), hasAndListParamArgumentCaptor.capture());
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
 		
-		assertThat(hasAndListParamArgumentCaptor.getValue(), notNullValue());
-		
-		HasAndListParam hasAndListParam = hasAndListParamArgumentCaptor.getValue();
+		HasAndListParam hasAndListParam = paramCaptor.getValue().getHasAndListParam();
+		assertThat(hasAndListParam, notNullValue());
 		assertThat(hasAndListParam.size(), equalTo(2));
 		
 		List<HasOrListParam> hasOrListParams = hasAndListParam.getValuesAsQueryTokens();
@@ -776,11 +708,28 @@ public class EncounterFhirResourceProviderWebTest extends BaseFhirR4ResourceProv
 		assertThat(valuesFound.get(2), equalTo("status=draft"));
 	}
 	
+	@Test
+	public void shouldHandleTagParameter() throws Exception {
+		verifyUri("/Encounter?_tag=http://fhir.openmrs.org/ext/encounter-tag|encounter");
+		
+		verify(encounterService).searchForEncounters(paramCaptor.capture());
+		
+		TokenAndListParam tagParam = paramCaptor.getValue().getTag();
+		assertThat(tagParam, notNullValue());
+		List<TokenOrListParam> tokenOrListParams = tagParam.getValuesAsQueryTokens();
+		assertThat(tokenOrListParams.size(), equalTo(1));
+		TokenOrListParam tokenOrListParam = tokenOrListParams.get(0);
+		assertThat(tokenOrListParam.getValuesAsQueryTokens().size(), equalTo(1));
+		TokenParam tokenParam = tokenOrListParam.getValuesAsQueryTokens().get(0);
+		assertThat(tokenParam.getSystem(), equalTo(FhirConstants.OPENMRS_FHIR_EXT_ENCOUNTER_TAG));
+		assertThat(tokenParam.getValue(), equalTo("encounter"));
+	}
+	
 	private void verifyUri(String uri) throws Exception {
 		Encounter encounter = new Encounter();
 		encounter.setId(ENCOUNTER_UUID);
-		when(encounterService.searchForEncounters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
-		    any())).thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), 10, 1));
+		when(encounterService.searchForEncounters(any()))
+		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(encounter), 10, 1));
 		
 		MockHttpServletResponse response = get(uri).accept(FhirMediaTypes.JSON).go();
 		


### PR DESCRIPTION
Both FM2-477 and FM2-478 are written with a common goal - to be able to return encounters (only encounters, not visits) that contain medication requests.  Those 2 tickets break this down into supporting the _has:MedicationRequest:encounter parameter on the Encounter resource (FM2-477), and in supporting the _tag=http://fhir.openmrs.org/ext/encounter-tag|encounter on the Encounter resource.

See:  https://issues.openmrs.org/browse/FM2-477
See:  https://issues.openmrs.org/browse/FM2-478

Both of these tickets hit the same blocks of code, and both benefited from some refactoring I did as a part of this on the FhirEncounterService and associated unit tests, so I bundled these together so as not to have to deal with a mess of merge issues.