### PR TITLE
Add additional display text to concept and medication resources

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/BaseReferenceHandlingTranslator.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/BaseReferenceHandlingTranslator.java
@@ -57,7 +57,7 @@ public abstract class BaseReferenceHandlingTranslator {
 	
 	protected Reference createMedicationReference(@Nonnull Drug drug) {
 		return new Reference().setReference(FhirConstants.MEDICATION + "/" + drug.getUuid())
-		        .setType(FhirConstants.MEDICATION);
+		        .setType(FhirConstants.MEDICATION).setDisplay(drug.getDisplayName());
 	}
 	
 	protected Reference createObservationReference(@Nonnull Obs obs) {

--- a/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/ConceptTranslatorImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/ConceptTranslatorImpl.java
@@ -48,6 +48,7 @@ public class ConceptTranslatorImpl implements ConceptTranslator {
 		}
 		
 		CodeableConcept codeableConcept = new CodeableConcept();
+		codeableConcept.setText(concept.getDisplayString());
 		addConceptCoding(codeableConcept.addCoding(), null, concept.getUuid(), concept);
 		
 		for (ConceptMap mapping : concept.getConceptMappings()) {

--- a/api/src/test/java/org/openmrs/module/fhir2/api/dao/impl/FhirEncounterDaoImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/dao/impl/FhirEncounterDaoImplTest.java
@@ -15,7 +15,6 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.List;
-import java.util.Properties;
 
 import ca.uhn.fhir.rest.param.HasAndListParam;
 import ca.uhn.fhir.rest.param.HasOrListParam;


### PR DESCRIPTION
Populates the "display" property on the Medication Reference, and the "text" property on the Codeable Concept reference, to better enable direct usage of these properties without requiring additional requests.
