### PR TITLE
FM2-587: Add Support for JSON patching operations — MedicationDispense Resource

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhir2/providers/r4/MedicationDispenseFhirResourceProvider.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/providers/r4/MedicationDispenseFhirResourceProvider.java
@@ -21,14 +21,17 @@ import ca.uhn.fhir.rest.annotation.Delete;
 import ca.uhn.fhir.rest.annotation.IdParam;
 import ca.uhn.fhir.rest.annotation.IncludeParam;
 import ca.uhn.fhir.rest.annotation.OptionalParam;
+import ca.uhn.fhir.rest.annotation.Patch;
 import ca.uhn.fhir.rest.annotation.Read;
 import ca.uhn.fhir.rest.annotation.ResourceParam;
 import ca.uhn.fhir.rest.annotation.Search;
 import ca.uhn.fhir.rest.annotation.Sort;
 import ca.uhn.fhir.rest.annotation.Update;
 import ca.uhn.fhir.rest.api.MethodOutcome;
+import ca.uhn.fhir.rest.api.PatchTypeEnum;
 import ca.uhn.fhir.rest.api.SortSpec;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.param.DateRangeParam;
 import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.TokenAndListParam;
@@ -88,6 +91,19 @@ public class MedicationDispenseFhirResourceProvider implements IResourceProvider
 		mDispense.setId(id.getIdPart());
 		MedicationDispense medicationDispense = fhirMedicationDispenseService.update(id.getIdPart(), mDispense);
 		return FhirProviderUtils.buildUpdate(medicationDispense);
+	}
+	
+	@Patch
+	public MethodOutcome patchMedicationDispense(@IdParam IdType id, PatchTypeEnum patchType, @ResourceParam String body,
+	        RequestDetails requestDetails) {
+		if (id == null || id.getIdPart() == null) {
+			throw new InvalidRequestException("id must be specified to update medication Dispense resource");
+		}
+		
+		MedicationDispense medicationDispense = fhirMedicationDispenseService.patch(id.getIdPart(), patchType, body,
+		    requestDetails);
+		
+		return FhirProviderUtils.buildPatch(medicationDispense);
 	}
 	
 	@Delete

--- a/api/src/main/java/org/openmrs/module/fhir2/providers/r4/MedicationDispenseFhirResourceProvider.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/providers/r4/MedicationDispenseFhirResourceProvider.java
@@ -97,7 +97,7 @@ public class MedicationDispenseFhirResourceProvider implements IResourceProvider
 	public MethodOutcome patchMedicationDispense(@IdParam IdType id, PatchTypeEnum patchType, @ResourceParam String body,
 	        RequestDetails requestDetails) {
 		if (id == null || id.getIdPart() == null) {
-			throw new InvalidRequestException("id must be specified to update medication Dispense resource");
+			throw new InvalidRequestException("id must be specified to update MedicationDispense resource");
 		}
 		
 		MedicationDispense medicationDispense = fhirMedicationDispenseService.patch(id.getIdPart(), patchType, body,

--- a/integration-tests-2.6/src/test/java/org/openmrs/module/fhir2/provider/r4/MedicationDispenseFhirResourceProviderIntegrationTest.java
+++ b/integration-tests-2.6/src/test/java/org/openmrs/module/fhir2/provider/r4/MedicationDispenseFhirResourceProviderIntegrationTest.java
@@ -86,54 +86,6 @@ public class MedicationDispenseFhirResourceProviderIntegrationTest extends BaseF
 	}
 	
 	@Test
-	public void shouldPatchExistingMedicationDispenseViaJsonMergePatch() throws Exception {
-		String jsonMedicationDispensePatch;
-		try (InputStream is = this.getClass().getClassLoader().getResourceAsStream(JSON_MERGE_PATCH_DISPENSE_PATH)) {
-			Objects.requireNonNull(is);
-			jsonMedicationDispensePatch = inputStreamToString(is, UTF_8);
-		}
-		
-		MockHttpServletResponse response = patch("/MedicationDispense/" + EXISTING_DISPENSE_UUID)
-		        .jsonMergePatch(jsonMedicationDispensePatch).accept(FhirMediaTypes.JSON).go();
-		
-		assertThat(response, isOk());
-		assertThat(response.getContentType(), startsWith(FhirMediaTypes.JSON.toString()));
-		assertThat(response.getContentAsString(), notNullValue());
-		
-		MedicationDispense medicationDispense = readResponse(response);
-		
-		assertThat(medicationDispense, notNullValue());
-		assertThat(medicationDispense.getIdElement().getIdPart(), equalTo(EXISTING_DISPENSE_UUID));
-		assertThat(medicationDispense, validResource());
-		
-		assertThat(medicationDispense.getStatus(), is(MedicationDispense.MedicationDispenseStatus.COMPLETED));
-	}
-	
-	@Test
-	public void shouldPatchExistingMedicationDispenseViaJsonPatch() throws Exception {
-		String jsonMedicationDispensePatch;
-		try (InputStream is = this.getClass().getClassLoader().getResourceAsStream(JSON_PATCH_DISPENSE_PATH)) {
-			Objects.requireNonNull(is);
-			jsonMedicationDispensePatch = inputStreamToString(is, UTF_8);
-		}
-		
-		MockHttpServletResponse response = patch("/MedicationDispense/" + EXISTING_DISPENSE_UUID)
-		        .jsonPatch(jsonMedicationDispensePatch).accept(FhirMediaTypes.JSON).go();
-		
-		assertThat(response, isOk());
-		assertThat(response.getContentType(), startsWith(FhirMediaTypes.JSON.toString()));
-		assertThat(response.getContentAsString(), notNullValue());
-		
-		MedicationDispense medicationDispense = readResponse(response);
-		
-		assertThat(medicationDispense, notNullValue());
-		assertThat(medicationDispense.getIdElement().getIdPart(), equalTo(EXISTING_DISPENSE_UUID));
-		assertThat(medicationDispense, validResource());
-		
-		assertThat(medicationDispense.getStatus(), is(MedicationDispense.MedicationDispenseStatus.COMPLETED));
-	}
-	
-	@Test
 	public void shouldThrow404ForNonExistingMedicationDispenseAsJson() throws Exception {
 		MockHttpServletResponse response = get("/MedicationDispense/" + NEW_DISPENSE_UUID).accept(FhirMediaTypes.JSON).go();
 		
@@ -276,5 +228,53 @@ public class MedicationDispenseFhirResourceProviderIntegrationTest extends BaseF
 		assertThat(result, notNullValue());
 		assertThat(result.getType(), equalTo(Bundle.BundleType.SEARCHSET));
 		assertThat(result, hasProperty("total", equalTo(3)));
+	}
+	
+	@Test
+	public void shouldPatchExistingMedicationDispenseUsingJsonMergePatch() throws Exception {
+		String jsonMedicationDispensePatch;
+		try (InputStream is = this.getClass().getClassLoader().getResourceAsStream(JSON_MERGE_PATCH_DISPENSE_PATH)) {
+			Objects.requireNonNull(is);
+			jsonMedicationDispensePatch = inputStreamToString(is, UTF_8);
+		}
+		
+		MockHttpServletResponse response = patch("/MedicationDispense/" + EXISTING_DISPENSE_UUID)
+				.jsonMergePatch(jsonMedicationDispensePatch).accept(FhirMediaTypes.JSON).go();
+		
+		assertThat(response, isOk());
+		assertThat(response.getContentType(), startsWith(FhirMediaTypes.JSON.toString()));
+		assertThat(response.getContentAsString(), notNullValue());
+		
+		MedicationDispense medicationDispense = readResponse(response);
+		
+		assertThat(medicationDispense, notNullValue());
+		assertThat(medicationDispense.getIdElement().getIdPart(), equalTo(EXISTING_DISPENSE_UUID));
+		assertThat(medicationDispense, validResource());
+		
+		assertThat(medicationDispense.getStatus(), is(MedicationDispense.MedicationDispenseStatus.COMPLETED));
+	}
+	
+	@Test
+	public void shouldPatchExistingMedicationDispenseUsingJsonPatch() throws Exception {
+		String jsonMedicationDispensePatch;
+		try (InputStream is = this.getClass().getClassLoader().getResourceAsStream(JSON_PATCH_DISPENSE_PATH)) {
+			Objects.requireNonNull(is);
+			jsonMedicationDispensePatch = inputStreamToString(is, UTF_8);
+		}
+		
+		MockHttpServletResponse response = patch("/MedicationDispense/" + EXISTING_DISPENSE_UUID)
+				.jsonPatch(jsonMedicationDispensePatch).accept(FhirMediaTypes.JSON).go();
+		
+		assertThat(response, isOk());
+		assertThat(response.getContentType(), startsWith(FhirMediaTypes.JSON.toString()));
+		assertThat(response.getContentAsString(), notNullValue());
+		
+		MedicationDispense medicationDispense = readResponse(response);
+		
+		assertThat(medicationDispense, notNullValue());
+		assertThat(medicationDispense.getIdElement().getIdPart(), equalTo(EXISTING_DISPENSE_UUID));
+		assertThat(medicationDispense, validResource());
+		
+		assertThat(medicationDispense.getStatus(), is(MedicationDispense.MedicationDispenseStatus.COMPLETED));
 	}
 }

--- a/test-data/src/main/resources/org/openmrs/module/fhir2/providers/MedicationDispense_json_merge_patch.json
+++ b/test-data/src/main/resources/org/openmrs/module/fhir2/providers/MedicationDispense_json_merge_patch.json
@@ -1,0 +1,3 @@
+{
+  "status" : "completed"
+}

--- a/test-data/src/main/resources/org/openmrs/module/fhir2/providers/MedicationDispense_json_patch.json
+++ b/test-data/src/main/resources/org/openmrs/module/fhir2/providers/MedicationDispense_json_patch.json
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "replace",
+    "path": "/status",
+    "value": "completed"
+  }
+]


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'FM2-8: Implement the Person Resource' -->
<!--- 'FM2-JiraIssueNumber: JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
Ensure the MedicationDispense Resource Provider(R4) can support JSON_MERGE_PATCH and JSON_PATCH patch operations.
## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/FM2-587

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
