### PR TITLE
FM2-635: ValueSetTranslatorImplTest unit test failure fix

### DIFF
--- a/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/ValueSetTranslatorImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/ValueSetTranslatorImplTest.java
@@ -33,6 +33,7 @@ import org.openmrs.ConceptName;
 import org.openmrs.ConceptReferenceTerm;
 import org.openmrs.ConceptSet;
 import org.openmrs.ConceptSource;
+import org.openmrs.ConceptMapType;
 import org.openmrs.module.fhir2.FhirTestConstants;
 import org.openmrs.module.fhir2.TestFhirSpringConfiguration;
 import org.openmrs.module.fhir2.api.FhirConceptSourceService;
@@ -75,8 +76,10 @@ public class ValueSetTranslatorImplTest extends BaseModuleContextSensitiveTest {
 		ConceptMap conceptMap = mock(ConceptMap.class);
 		ConceptReferenceTerm conceptReferenceTerm = mock(ConceptReferenceTerm.class);
 		ConceptSource conceptSource = mock(ConceptSource.class);
+		ConceptMapType conceptMapType=mock(ConceptMapType.class);
 		
 		when(conceptMap.getConceptReferenceTerm()).thenReturn(conceptReferenceTerm);
+		when(conceptMap.getConceptMapType()).thenReturn(conceptMapType);
 		when(conceptReferenceTerm.getConceptSource()).thenReturn(conceptSource);
 		when(conceptReferenceTerm.getCode()).thenReturn("1000-1");
 		when(conceptSource.getName()).thenReturn("LOINC");


### PR DESCRIPTION
## Description of what I changed

Added a mock of `ConceptMapType` in `ValueSetTranslatorImplTest` to resolve an issue where the `conceptMap` object was looking for `defaultConceptMapType` without it.

## Issue I worked on
see https://issues.openmrs.org/browse/FM2-635

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.