### PR TITLE
FM2-656: If the concept does not allow decimals, only use integers

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/ObservationReferenceRangeTranslatorImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/ObservationReferenceRangeTranslatorImpl.java
@@ -29,20 +29,22 @@ public class ObservationReferenceRangeTranslatorImpl implements ObservationRefer
 	@Override
 	public List<Observation.ObservationReferenceRangeComponent> toFhirResource(@Nonnull ConceptNumeric conceptNumeric) {
 		if (conceptNumeric != null) {
+			boolean allowDecimal = conceptNumeric.getAllowDecimal() != null ? conceptNumeric.getAllowDecimal() : true;
+			
 			List<Observation.ObservationReferenceRangeComponent> observationReferenceRangeComponentList = new ArrayList<>();
 			if (conceptNumeric.getHiNormal() != null || conceptNumeric.getLowNormal() != null) {
 				observationReferenceRangeComponentList.add(createObservationReferenceRange(conceptNumeric.getHiNormal(),
-				    conceptNumeric.getLowNormal(), FhirConstants.OBSERVATION_REFERENCE_NORMAL));
+				    conceptNumeric.getLowNormal(), FhirConstants.OBSERVATION_REFERENCE_NORMAL, allowDecimal));
 			}
 			
 			if (conceptNumeric.getHiCritical() != null || conceptNumeric.getLowCritical() != null) {
 				observationReferenceRangeComponentList.add(createObservationReferenceRange(conceptNumeric.getHiCritical(),
-				    conceptNumeric.getLowCritical(), FhirConstants.OBSERVATION_REFERENCE_TREATMENT));
+				    conceptNumeric.getLowCritical(), FhirConstants.OBSERVATION_REFERENCE_TREATMENT, allowDecimal));
 			}
 			
 			if (conceptNumeric.getHiAbsolute() != null || conceptNumeric.getLowAbsolute() != null) {
 				observationReferenceRangeComponentList.add(createObservationReferenceRange(conceptNumeric.getHiAbsolute(),
-				    conceptNumeric.getLowAbsolute(), FhirConstants.OBSERVATION_REFERENCE_ABSOLUTE));
+				    conceptNumeric.getLowAbsolute(), FhirConstants.OBSERVATION_REFERENCE_ABSOLUTE, allowDecimal));
 			}
 			
 			return observationReferenceRangeComponentList;
@@ -52,15 +54,23 @@ public class ObservationReferenceRangeTranslatorImpl implements ObservationRefer
 	}
 	
 	private Observation.ObservationReferenceRangeComponent createObservationReferenceRange(Double hiValue, Double lowValue,
-	        String code) {
+	        String code, boolean allowDecimal) {
 		Observation.ObservationReferenceRangeComponent component = new Observation.ObservationReferenceRangeComponent();
 		
 		if (hiValue != null) {
-			component.setHigh(new Quantity().setValue(hiValue));
+			if (allowDecimal) {
+				component.setHigh(new Quantity().setValue(hiValue));
+			} else {
+				component.setHigh(new Quantity().setValue(hiValue.longValue()));
+			}
 		}
 		
 		if (lowValue != null) {
-			component.setLow(new Quantity().setValue(lowValue));
+			if (allowDecimal) {
+				component.setLow(new Quantity().setValue(lowValue));
+			} else {
+				component.setLow(new Quantity().setValue(lowValue.longValue()));
+			}
 		}
 		
 		CodeableConcept referenceRangeType = new CodeableConcept();

--- a/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/ObservationValueTranslatorImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/ObservationValueTranslatorImpl.java
@@ -62,17 +62,27 @@ public class ObservationValueTranslatorImpl implements ObservationValueTranslato
 		} else if (obs.getValueDatetime() != null) {
 			return new DateTimeType(obs.getValueDatetime());
 		} else if (obs.getValueNumeric() != null) {
-			Quantity result = new Quantity(obs.getValueNumeric());
+			Double value = obs.getValueNumeric();
+			
+			Quantity result = new Quantity();
 			if (obs.getConcept() instanceof ConceptNumeric) {
 				ConceptNumeric cn = (ConceptNumeric) obs.getConcept();
+				if (cn.getAllowDecimal()) {
+					result.setValue(value);
+				} else {
+					result.setValue(value.longValue());
+				}
+				
 				result.setUnit(cn.getUnits());
 				
 				// only set the coding system if unit conforms to UCUM standard
 				Coding coding = quantityCodingTranslator.toFhirResource(cn);
-				if (coding.hasSystem() && coding.getSystem().equals(UCUM_SYSTEM_URI)) {
+				if (coding != null && coding.hasSystem() && coding.getSystem().equals(UCUM_SYSTEM_URI)) {
 					result.setCode(coding.getCode());
 					result.setSystem(coding.getSystem());
 				}
+			} else {
+				result.setValue(value);
 			}
 			
 			return result;

--- a/api/src/test/java/org/openmrs/module/fhir2/MockedGlobalPropertyServiceConfiguration.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/MockedGlobalPropertyServiceConfiguration.java
@@ -1,0 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */

--- a/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/ObservationReferenceRangeTranslatorImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/ObservationReferenceRangeTranslatorImplTest.java
@@ -28,17 +28,17 @@ import org.openmrs.module.fhir2.FhirConstants;
 
 public class ObservationReferenceRangeTranslatorImplTest {
 	
-	private static final Double LOW_NORMAL_VALUE = 1.0;
+	private static final BigDecimal LOW_NORMAL_VALUE = BigDecimal.valueOf(1L);
 	
-	private static final Double HIGH_NORMAL_VALUE = 2.0;
+	private static final BigDecimal HIGH_NORMAL_VALUE = BigDecimal.valueOf(2L);
 	
-	private static final Double LOW_ABSOLUTE_VALUE = 3.0;
+	private static final BigDecimal LOW_ABSOLUTE_VALUE = BigDecimal.valueOf(3L);
 	
-	private static final Double HIGH_ABSOLUTE_VALUE = 4.0;
+	private static final BigDecimal HIGH_ABSOLUTE_VALUE = BigDecimal.valueOf(4L);
 	
-	private static final Double LOW_CRITICAL_VALUE = 5.0;
+	private static final BigDecimal LOW_CRITICAL_VALUE = BigDecimal.valueOf(5L);
 	
-	private static final Double HIGH_CRITICAL_VALUE = 6.0;
+	private static final BigDecimal HIGH_CRITICAL_VALUE = BigDecimal.valueOf(6L);
 	
 	private static final String CONCEPT_UUID = "12345-abcdef-12345";
 	
@@ -50,11 +50,11 @@ public class ObservationReferenceRangeTranslatorImplTest {
 	}
 	
 	@Test
-	public void toFhirType_shouldMapHiAndLowNormalObservationReferenceRangeToExpected() {
+	public void toFhirType_shouldMapHighAndLowNormalObservationReferenceRangeToExpected() {
 		ConceptNumeric conceptNumeric = new ConceptNumeric();
 		conceptNumeric.setUuid(CONCEPT_UUID);
-		conceptNumeric.setLowNormal(LOW_NORMAL_VALUE);
-		conceptNumeric.setHiNormal(HIGH_NORMAL_VALUE);
+		conceptNumeric.setLowNormal(LOW_NORMAL_VALUE.doubleValue());
+		conceptNumeric.setHiNormal(HIGH_NORMAL_VALUE.doubleValue());
 		
 		List<Observation.ObservationReferenceRangeComponent> result = observationReferenceRangeTranslator
 		        .toFhirResource(conceptNumeric);
@@ -68,18 +68,18 @@ public class ObservationReferenceRangeTranslatorImplTest {
 		    equalTo(FhirConstants.OBSERVATION_REFERENCE_RANGE_SYSTEM_URI));
 		assertThat(component.getType().getCodingFirstRep().getCode(), equalTo(FhirConstants.OBSERVATION_REFERENCE_NORMAL));
 		assertThat(component.hasLow(), is(true));
-		assertThat(component.getLow().getValue(), equalTo(BigDecimal.valueOf(LOW_NORMAL_VALUE)));
+		assertThat(component.getLow().getValue(), equalTo(LOW_NORMAL_VALUE));
 		assertThat(component.hasHigh(), is(true));
-		assertThat(component.getHigh().getValue(), equalTo(BigDecimal.valueOf(HIGH_NORMAL_VALUE)));
+		assertThat(component.getHigh().getValue(), equalTo(HIGH_NORMAL_VALUE));
 	}
 	
 	@Test
-	public void toFhirType_shouldMapHiAndLowCriticalObservationReferenceRangeToExpected() {
+	public void toFhirType_shouldMapHighAndLowCriticalObservationReferenceRangeToExpected() {
 		ConceptNumeric conceptNumeric = new ConceptNumeric();
 		conceptNumeric.setUuid(CONCEPT_UUID);
 		
-		conceptNumeric.setLowCritical(LOW_CRITICAL_VALUE);
-		conceptNumeric.setHiCritical(HIGH_CRITICAL_VALUE);
+		conceptNumeric.setLowCritical(LOW_CRITICAL_VALUE.doubleValue());
+		conceptNumeric.setHiCritical(HIGH_CRITICAL_VALUE.doubleValue());
 		
 		List<Observation.ObservationReferenceRangeComponent> result = observationReferenceRangeTranslator
 		        .toFhirResource(conceptNumeric);
@@ -94,17 +94,17 @@ public class ObservationReferenceRangeTranslatorImplTest {
 		assertThat(component.getType().getCodingFirstRep().getCode(),
 		    equalTo(FhirConstants.OBSERVATION_REFERENCE_TREATMENT));
 		assertThat(component.hasLow(), is(true));
-		assertThat(component.getLow().getValue(), equalTo(BigDecimal.valueOf(LOW_CRITICAL_VALUE)));
+		assertThat(component.getLow().getValue(), equalTo(LOW_CRITICAL_VALUE));
 		assertThat(component.hasHigh(), is(true));
-		assertThat(component.getHigh().getValue(), equalTo(BigDecimal.valueOf(HIGH_CRITICAL_VALUE)));
+		assertThat(component.getHigh().getValue(), equalTo(HIGH_CRITICAL_VALUE));
 	}
 	
 	@Test
-	public void toFhirType_shouldMapHiAndLowAbsoluteObservationReferenceRangeToExpected() {
+	public void toFhirType_shouldMapHighAndLowAbsoluteObservationReferenceRangeToExpected() {
 		ConceptNumeric conceptNumeric = new ConceptNumeric();
 		conceptNumeric.setUuid(CONCEPT_UUID);
-		conceptNumeric.setLowAbsolute(LOW_ABSOLUTE_VALUE);
-		conceptNumeric.setHiAbsolute(HIGH_ABSOLUTE_VALUE);
+		conceptNumeric.setLowAbsolute(LOW_ABSOLUTE_VALUE.doubleValue());
+		conceptNumeric.setHiAbsolute(HIGH_ABSOLUTE_VALUE.doubleValue());
 		
 		List<Observation.ObservationReferenceRangeComponent> result = observationReferenceRangeTranslator
 		        .toFhirResource(conceptNumeric);
@@ -118,56 +118,98 @@ public class ObservationReferenceRangeTranslatorImplTest {
 		    equalTo(FhirConstants.OPENMRS_FHIR_EXT_OBSERVATION_REFERENCE_RANGE));
 		assertThat(component.getType().getCodingFirstRep().getCode(), equalTo(FhirConstants.OBSERVATION_REFERENCE_ABSOLUTE));
 		assertThat(component.hasLow(), is(true));
-		assertThat(component.getLow().getValue(), equalTo(BigDecimal.valueOf(LOW_ABSOLUTE_VALUE)));
+		assertThat(component.getLow().getValue(), equalTo(LOW_ABSOLUTE_VALUE));
 		assertThat(component.hasHigh(), is(true));
-		assertThat(component.getHigh().getValue(), equalTo(BigDecimal.valueOf(HIGH_ABSOLUTE_VALUE)));
+		assertThat(component.getHigh().getValue(), equalTo(HIGH_ABSOLUTE_VALUE));
 	}
 	
 	@Test
-	public void toFhirType_shouldMapHiAndLowAbsoluteToExpectedIfOneIsNull() {
+	public void toFhirType_shouldMapHighAndLowAbsoluteToExpectedIfLowIsNull() {
 		ConceptNumeric conceptNumeric = new ConceptNumeric();
 		conceptNumeric.setUuid(CONCEPT_UUID);
 		conceptNumeric.setLowAbsolute(null);
-		conceptNumeric.setHiAbsolute(HIGH_ABSOLUTE_VALUE);
+		conceptNumeric.setHiAbsolute(HIGH_ABSOLUTE_VALUE.doubleValue());
 		
 		List<Observation.ObservationReferenceRangeComponent> result = observationReferenceRangeTranslator
 		        .toFhirResource(conceptNumeric);
 		
 		assertThat(result, not(empty()));
 		assertThat(result.get(0).hasLow(), equalTo(false));
-		assertThat(result,
-		    hasItem(hasProperty("high", hasProperty("value", equalTo(BigDecimal.valueOf(HIGH_ABSOLUTE_VALUE))))));
+		assertThat(result, hasItem(hasProperty("high", hasProperty("value", equalTo(HIGH_ABSOLUTE_VALUE)))));
 	}
 	
 	@Test
-	public void toFhirType_shouldMapHiAndLowNormalToExpectedIfOneIsNull() {
+	public void toFhirType_shouldMapHighAndLowAbsoluteToExpectedIfHighIsNull() {
+		ConceptNumeric conceptNumeric = new ConceptNumeric();
+		conceptNumeric.setUuid(CONCEPT_UUID);
+		conceptNumeric.setLowAbsolute(LOW_ABSOLUTE_VALUE.doubleValue());
+		conceptNumeric.setHiAbsolute(null);
+		
+		List<Observation.ObservationReferenceRangeComponent> result = observationReferenceRangeTranslator
+		        .toFhirResource(conceptNumeric);
+		
+		assertThat(result, not(empty()));
+		assertThat(result.get(0).hasHigh(), equalTo(false));
+		assertThat(result, hasItem(hasProperty("low", hasProperty("value", equalTo(LOW_ABSOLUTE_VALUE)))));
+	}
+	
+	@Test
+	public void toFhirType_shouldMapHighAndLowNormalToExpectedIfLowIsNull() {
 		ConceptNumeric conceptNumeric = new ConceptNumeric();
 		conceptNumeric.setUuid(CONCEPT_UUID);
 		conceptNumeric.setLowNormal(null);
-		conceptNumeric.setHiNormal(HIGH_NORMAL_VALUE);
+		conceptNumeric.setHiNormal(HIGH_NORMAL_VALUE.doubleValue());
 		
 		List<Observation.ObservationReferenceRangeComponent> result = observationReferenceRangeTranslator
 		        .toFhirResource(conceptNumeric);
 		
 		assertThat(result, not(empty()));
 		assertThat(result.get(0).hasLow(), equalTo(false));
-		assertThat(result,
-		    hasItem(hasProperty("high", hasProperty("value", equalTo(BigDecimal.valueOf(HIGH_NORMAL_VALUE))))));
+		assertThat(result, hasItem(hasProperty("high", hasProperty("value", equalTo(HIGH_NORMAL_VALUE)))));
 	}
 	
 	@Test
-	public void toFhirType_shouldMapHiAndLowCriticalToExpectedIfOneIsNull() {
+	public void toFhirType_shouldMapHighAndLowNormalToExpectedIfHighIsNull() {
+		ConceptNumeric conceptNumeric = new ConceptNumeric();
+		conceptNumeric.setUuid(CONCEPT_UUID);
+		conceptNumeric.setLowNormal(LOW_NORMAL_VALUE.doubleValue());
+		conceptNumeric.setHiNormal(null);
+		
+		List<Observation.ObservationReferenceRangeComponent> result = observationReferenceRangeTranslator
+		        .toFhirResource(conceptNumeric);
+		
+		assertThat(result, not(empty()));
+		assertThat(result.get(0).hasHigh(), equalTo(false));
+		assertThat(result, hasItem(hasProperty("low", hasProperty("value", equalTo(LOW_NORMAL_VALUE)))));
+	}
+	
+	@Test
+	public void toFhirType_shouldMapHighAndLowCriticalToExpectedIfLowIsNull() {
 		ConceptNumeric conceptNumeric = new ConceptNumeric();
 		conceptNumeric.setUuid(CONCEPT_UUID);
 		conceptNumeric.setLowCritical(null);
-		conceptNumeric.setHiCritical(HIGH_CRITICAL_VALUE);
+		conceptNumeric.setHiCritical(HIGH_CRITICAL_VALUE.doubleValue());
 		
 		List<Observation.ObservationReferenceRangeComponent> result = observationReferenceRangeTranslator
 		        .toFhirResource(conceptNumeric);
 		
 		assertThat(result, not(empty()));
 		assertThat(result.get(0).hasLow(), equalTo(false));
-		assertThat(result,
-		    hasItem(hasProperty("high", hasProperty("value", equalTo(BigDecimal.valueOf(HIGH_CRITICAL_VALUE))))));
+		assertThat(result, hasItem(hasProperty("high", hasProperty("value", equalTo(HIGH_CRITICAL_VALUE)))));
+	}
+	
+	@Test
+	public void toFhirType_shouldMapHighAndLowCriticalToExpectedIHighIsNull() {
+		ConceptNumeric conceptNumeric = new ConceptNumeric();
+		conceptNumeric.setUuid(CONCEPT_UUID);
+		conceptNumeric.setLowCritical(LOW_CRITICAL_VALUE.doubleValue());
+		conceptNumeric.setHiCritical(null);
+		
+		List<Observation.ObservationReferenceRangeComponent> result = observationReferenceRangeTranslator
+		        .toFhirResource(conceptNumeric);
+		
+		assertThat(result, not(empty()));
+		assertThat(result.get(0).hasHigh(), equalTo(false));
+		assertThat(result, hasItem(hasProperty("low", hasProperty("value", equalTo(LOW_CRITICAL_VALUE)))));
 	}
 }

--- a/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/ObservationValueTranslatorImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/ObservationValueTranslatorImplTest.java
@@ -144,6 +144,21 @@ public class ObservationValueTranslatorImplTest {
 	}
 	
 	@Test
+	public void toFhirResource_shouldConvertObsWithNumericValueToIntegerQuantity() {
+		ConceptNumeric cn = new ConceptNumeric();
+		cn.setAllowDecimal(false);
+		
+		obs.setValueNumeric(130.0d);
+		obs.setConcept(cn);
+		
+		Type result = obsValueTranslator.toFhirResource(obs);
+		
+		assertThat(result, notNullValue());
+		assertThat(result, instanceOf(Quantity.class));
+		assertThat(((Quantity) result).getValue().longValueExact(), equalTo(130l));
+	}
+	
+	@Test
 	public void toFhirResource_shouldConvertObsWithNumericValueAndUnitsToQuantityWithUnits() {
 		ConceptNumeric cn = new ConceptNumeric();
 		cn.setUnits("cm");

--- a/integration-tests/src/test/java/org/openmrs/module/fhir2/providers/r3/ObservationFhirResourceProviderIntegrationTest.java
+++ b/integration-tests/src/test/java/org/openmrs/module/fhir2/providers/r3/ObservationFhirResourceProviderIntegrationTest.java
@@ -71,11 +71,11 @@ public class ObservationFhirResourceProviderIntegrationTest extends BaseFhirR3In
 	
 	private static final String OBS_CONCEPT_CIEL_ID = "5085";
 	
-	private static final BigDecimal OBS_CONCEPT_VALUE = BigDecimal.valueOf(115.0);
+	private static final BigDecimal OBS_CONCEPT_VALUE = BigDecimal.valueOf(115);
 	
-	private static final BigDecimal OBS_LOW_REFERENCE_RANGE = BigDecimal.valueOf(0.0);
+	private static final BigDecimal OBS_LOW_REFERENCE_RANGE = BigDecimal.valueOf(0);
 	
-	private static final BigDecimal OBS_HIGH_REFERENCE_RANGE = BigDecimal.valueOf(250.0);
+	private static final BigDecimal OBS_HIGH_REFERENCE_RANGE = BigDecimal.valueOf(250);
 	
 	private static final String OBS_PATIENT_UUID = "5946f880-b197-400b-9caa-a3c661d23041";
 	
@@ -249,7 +249,7 @@ public class ObservationFhirResourceProviderIntegrationTest extends BaseFhirR3In
 		assertThat(observation.getContext().getReference(), endsWith("6519d653-393b-4118-9c83-a3715b82d4ac"));
 		assertThat(observation.getValue(), notNullValue());
 		assertThat(observation.getValueQuantity(), notNullValue());
-		assertThat(observation.getValueQuantity().getValue(), equalTo(BigDecimal.valueOf(156.0)));
+		assertThat(observation.getValueQuantity().getValue(), equalTo(BigDecimal.valueOf(156)));
 		assertThat(observation.getValueQuantity().getUnit(), equalTo("cm"));
 		assertThat(observation.getValueQuantity().getSystem(), equalTo(FhirConstants.UCUM_SYSTEM_URI));
 		assertThat(observation, validResource());
@@ -294,7 +294,7 @@ public class ObservationFhirResourceProviderIntegrationTest extends BaseFhirR3In
 		assertThat(observation.getContext().getReference(), endsWith("6519d653-393b-4118-9c83-a3715b82d4ac"));
 		assertThat(observation.getValue(), notNullValue());
 		assertThat(observation.getValueQuantity(), notNullValue());
-		assertThat(observation.getValueQuantity().getValue(), equalTo(BigDecimal.valueOf(156.0)));
+		assertThat(observation.getValueQuantity().getValue(), equalTo(BigDecimal.valueOf(156)));
 		assertThat(observation.getValueQuantity().getUnit(), equalTo("cm"));
 		assertThat(observation.getValueQuantity().getSystem(), equalTo(FhirConstants.UCUM_SYSTEM_URI));
 		assertThat(observation, validResource());

--- a/integration-tests/src/test/java/org/openmrs/module/fhir2/providers/r4/ObservationFhirResourceProviderIntegrationTest.java
+++ b/integration-tests/src/test/java/org/openmrs/module/fhir2/providers/r4/ObservationFhirResourceProviderIntegrationTest.java
@@ -81,11 +81,11 @@ public class ObservationFhirResourceProviderIntegrationTest extends BaseFhirR4In
 	
 	private static final String OBS_CONCEPT_CIEL_ID = "5085";
 	
-	private static final BigDecimal OBS_CONCEPT_VALUE = BigDecimal.valueOf(115.0);
+	private static final BigDecimal OBS_CONCEPT_VALUE = BigDecimal.valueOf(115);
 	
-	private static final BigDecimal OBS_LOW_REFERENCE_RANGE = BigDecimal.valueOf(0.0);
+	private static final BigDecimal OBS_LOW_REFERENCE_RANGE = BigDecimal.valueOf(0);
 	
-	private static final BigDecimal OBS_HIGH_REFERENCE_RANGE = BigDecimal.valueOf(250.0);
+	private static final BigDecimal OBS_HIGH_REFERENCE_RANGE = BigDecimal.valueOf(250);
 	
 	private static final String OBS_PATIENT_UUID = "5946f880-b197-400b-9caa-a3c661d23041";
 	
@@ -260,7 +260,7 @@ public class ObservationFhirResourceProviderIntegrationTest extends BaseFhirR4In
 		assertThat(observation.getEncounter().getReference(), endsWith("6519d653-393b-4118-9c83-a3715b82d4ac"));
 		assertThat(observation.getValue(), notNullValue());
 		assertThat(observation.getValueQuantity(), notNullValue());
-		assertThat(observation.getValueQuantity().getValue(), equalTo(BigDecimal.valueOf(156.0)));
+		assertThat(observation.getValueQuantity().getValue(), equalTo(BigDecimal.valueOf(156)));
 		assertThat(observation.getValueQuantity().getUnit(), equalTo("cm"));
 		assertThat(observation.getValueQuantity().getSystem(), equalTo(FhirConstants.UCUM_SYSTEM_URI));
 		assertThat(observation, validResource());
@@ -305,7 +305,7 @@ public class ObservationFhirResourceProviderIntegrationTest extends BaseFhirR4In
 		assertThat(observation.getEncounter().getReference(), endsWith("6519d653-393b-4118-9c83-a3715b82d4ac"));
 		assertThat(observation.getValue(), notNullValue());
 		assertThat(observation.getValueQuantity(), notNullValue());
-		assertThat(observation.getValueQuantity().getValue(), equalTo(BigDecimal.valueOf(156.0)));
+		assertThat(observation.getValueQuantity().getValue(), equalTo(BigDecimal.valueOf(156)));
 		assertThat(observation.getValueQuantity().getUnit(), equalTo("cm"));
 		assertThat(observation.getValueQuantity().getSystem(), equalTo(FhirConstants.UCUM_SYSTEM_URI));
 		assertThat(observation, validResource());


### PR DESCRIPTION
## Description of what I changed

OpenMRS numeric obs store their values a double-precision floating point numbers, which allows values with a decimal and those without one. We also have metadata on the concept indicating whether the numbers after the decimal should be retained or not. Previously, when displaying obs values, we were ignoring this distinction and always returning a double-precision floating point value which was treated as having at least one significant decimal point.

This PR fixes that so that for concepts that are marked as not supporting decimals are treated as integer values.

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/FM2-656

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
