### PR TITLE
O3-4544: Improve FHIR Location endpoint performance

### DIFF
--- a/api-2.6/src/test/java/org/openmrs/module/fhir2/api/impl/FhirMedicationDispenseServiceImpl_2_6Test.java
+++ b/api-2.6/src/test/java/org/openmrs/module/fhir2/api/impl/FhirMedicationDispenseServiceImpl_2_6Test.java
@@ -18,6 +18,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
@@ -238,6 +239,7 @@ public class FhirMedicationDispenseServiceImpl_2_6Test {
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(translator.toFhirResource(openmrsDispense)).thenReturn(fhirDispense);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		MedicationDispenseSearchParams params = new MedicationDispenseSearchParams();
 		params.setId(idParam);

--- a/api/src/main/java/org/openmrs/module/fhir2/api/dao/FhirLocationDao.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/dao/FhirLocationDao.java
@@ -11,7 +11,9 @@ package org.openmrs.module.fhir2.api.dao;
 
 import javax.annotation.Nonnull;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import org.openmrs.Location;
 import org.openmrs.LocationAttribute;
@@ -30,6 +32,9 @@ public interface FhirLocationDao extends FhirDao<Location> {
 	@Authorized(PrivilegeConstants.GET_LOCATIONS)
 	List<LocationAttribute> getActiveAttributesByLocationAndAttributeTypeUuid(@Nonnull Location location,
 	        @Nonnull String locationAttributeTypeUuid);
+	
+	Map<Location, List<LocationAttribute>> getActiveAttributesByLocationsAndAttributeTypeUuid(
+	        @Nonnull Collection<Location> location, @Nonnull String locationAttributeTypeUuid);
 	
 	@Override
 	@Authorized(PrivilegeConstants.MANAGE_LOCATIONS)

--- a/api/src/main/java/org/openmrs/module/fhir2/api/dao/impl/BaseFhirDao.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/dao/impl/BaseFhirDao.java
@@ -33,6 +33,7 @@ import com.google.common.reflect.TypeToken;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import org.hibernate.CacheMode;
 import org.hibernate.Criteria;
 import org.hibernate.Hibernate;
@@ -68,6 +69,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @param <T> the {@link OpenmrsObject} managed by this Dao
  */
 @Transactional
+@Slf4j
 public abstract class BaseFhirDao<T extends OpenmrsObject & Auditable> extends BaseDao implements FhirDao<T> {
 	
 	@SuppressWarnings("UnstableApiUsage")
@@ -249,6 +251,7 @@ public abstract class BaseFhirDao<T extends OpenmrsObject & Auditable> extends B
 			
 			results = idsCriteria.list();
 		}
+		
 		return results.stream().map(this::deproxyResult).collect(Collectors.toList());
 	}
 	

--- a/api/src/main/java/org/openmrs/module/fhir2/api/search/SearchQuery.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/search/SearchQuery.java
@@ -18,7 +18,7 @@ import org.openmrs.module.fhir2.FhirConstants;
 import org.openmrs.module.fhir2.api.FhirGlobalPropertyService;
 import org.openmrs.module.fhir2.api.dao.FhirDao;
 import org.openmrs.module.fhir2.api.search.param.SearchParameterMap;
-import org.openmrs.module.fhir2.api.translators.ToFhirTranslator;
+import org.openmrs.module.fhir2.api.translators.OpenmrsFhirTranslator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -29,7 +29,7 @@ import org.springframework.stereotype.Component;
  * @param <T> FHIR generic translator Class
  */
 @Component
-public class SearchQuery<T extends OpenmrsObject & Auditable, U extends IBaseResource, O extends FhirDao<T>, V extends ToFhirTranslator<T, U>, W extends SearchQueryInclude<U>> {
+public class SearchQuery<T extends OpenmrsObject & Auditable, U extends IBaseResource, O extends FhirDao<T>, V extends OpenmrsFhirTranslator<T, U>, W extends SearchQueryInclude<U>> {
 	
 	@Autowired
 	private FhirGlobalPropertyService globalPropertyService;

--- a/api/src/main/java/org/openmrs/module/fhir2/api/search/SearchQueryBundleProvider.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/search/SearchQueryBundleProvider.java
@@ -16,10 +16,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import ca.uhn.fhir.model.primitive.InstantDt;
 import ca.uhn.fhir.rest.api.server.IBundleProvider;
@@ -33,7 +30,7 @@ import org.openmrs.module.fhir2.FhirConstants;
 import org.openmrs.module.fhir2.api.FhirGlobalPropertyService;
 import org.openmrs.module.fhir2.api.dao.FhirDao;
 import org.openmrs.module.fhir2.api.search.param.SearchParameterMap;
-import org.openmrs.module.fhir2.api.translators.ToFhirTranslator;
+import org.openmrs.module.fhir2.api.translators.OpenmrsFhirTranslator;
 import org.openmrs.module.fhir2.api.util.FhirUtils;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -49,7 +46,7 @@ public class SearchQueryBundleProvider<T extends OpenmrsObject & Auditable, U ex
 	
 	private final SearchParameterMap searchParameterMap;
 	
-	private final ToFhirTranslator<T, U> translator;
+	private final OpenmrsFhirTranslator<T, U> translator;
 	
 	@Getter
 	private final String uuid;
@@ -63,7 +60,7 @@ public class SearchQueryBundleProvider<T extends OpenmrsObject & Auditable, U ex
 	private final SearchQueryInclude<U> searchQueryInclude;
 	
 	public SearchQueryBundleProvider(SearchParameterMap searchParameterMap, FhirDao<T> dao,
-	    ToFhirTranslator<T, U> translator, FhirGlobalPropertyService globalPropertyService,
+	    OpenmrsFhirTranslator<T, U> translator, FhirGlobalPropertyService globalPropertyService,
 	    SearchQueryInclude<U> searchQueryInclude) {
 		this.dao = dao;
 		this.published = InstantDt.withCurrentTime();
@@ -81,15 +78,12 @@ public class SearchQueryBundleProvider<T extends OpenmrsObject & Auditable, U ex
 		searchParameterMap.setFromIndex(fromIndex);
 		searchParameterMap.setToIndex(toIndex);
 		
-		List<T> openmrsDaos = dao.getSearchResults(searchParameterMap);
-		Map<T, U> mapping = translator.toFhirResources(openmrsDaos);
-		List<U> returnedResourceList = openmrsDaos.stream().map(mapping::get).filter(Objects::nonNull)
-		        .collect(Collectors.toList());
+		List<U> resources = translator.toFhirResources(dao.getSearchResults(searchParameterMap));
 		
-		Set<IBaseResource> includedResources = searchQueryInclude.getIncludedResources(returnedResourceList,
-		    this.searchParameterMap);
+		Set<IBaseResource> includedResources = searchQueryInclude.getIncludedResources(resources, this.searchParameterMap);
 		
-		List<IBaseResource> resultList = new ArrayList<>(returnedResourceList);
+		List<IBaseResource> resultList = new ArrayList<>(resources.size() + includedResources.size());
+		resultList.addAll(resources);
 		resultList.addAll(includedResources);
 		
 		return resultList;

--- a/api/src/main/java/org/openmrs/module/fhir2/api/translators/LocationTranslator.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/translators/LocationTranslator.java
@@ -11,6 +11,9 @@ package org.openmrs.module.fhir2.api.translators;
 
 import javax.annotation.Nonnull;
 
+import java.util.Collection;
+import java.util.Map;
+
 import org.hl7.fhir.r4.model.Location;
 
 public interface LocationTranslator extends OpenmrsFhirUpdatableTranslator<org.openmrs.Location, Location> {
@@ -23,6 +26,15 @@ public interface LocationTranslator extends OpenmrsFhirUpdatableTranslator<org.o
 	 */
 	@Override
 	Location toFhirResource(@Nonnull org.openmrs.Location openmrsLocation);
+	
+	/**
+	 * Maps a collection of {@link org.openmrs.Location}s to a {@link org.hl7.fhir.r4.model.Location}
+	 *
+	 * @param openmrsLocations the collection of locations to translate
+	 * @return the mapping of OpenMRS location to corresponding FHIR location resource
+	 */
+	@Override
+	Map<org.openmrs.Location, Location> toFhirResources(Collection<org.openmrs.Location> openmrsLocations);
 	
 	/**
 	 * Maps a {@link org.hl7.fhir.r4.model.Location} to an {@link org.openmrs.Location}

--- a/api/src/main/java/org/openmrs/module/fhir2/api/translators/LocationTranslator.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/translators/LocationTranslator.java
@@ -12,7 +12,7 @@ package org.openmrs.module.fhir2.api.translators;
 import javax.annotation.Nonnull;
 
 import java.util.Collection;
-import java.util.Map;
+import java.util.List;
 
 import org.hl7.fhir.r4.model.Location;
 
@@ -34,7 +34,7 @@ public interface LocationTranslator extends OpenmrsFhirUpdatableTranslator<org.o
 	 * @return the mapping of OpenMRS location to corresponding FHIR location resource
 	 */
 	@Override
-	Map<org.openmrs.Location, Location> toFhirResources(Collection<org.openmrs.Location> openmrsLocations);
+	List<Location> toFhirResources(Collection<org.openmrs.Location> openmrsLocations);
 	
 	/**
 	 * Maps a {@link org.hl7.fhir.r4.model.Location} to an {@link org.openmrs.Location}

--- a/api/src/main/java/org/openmrs/module/fhir2/api/translators/OpenmrsFhirTranslator.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/translators/OpenmrsFhirTranslator.java
@@ -9,10 +9,25 @@
  */
 package org.openmrs.module.fhir2.api.translators;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
 /**
  * Generic interface for a translator between OpenMRS data and FHIR resources
  * 
  * @param <T> OpenMRS data type
  * @param <U> FHIR resource type
  */
-public interface OpenmrsFhirTranslator<T, U> extends ToFhirTranslator<T, U>, ToOpenmrsTranslator<T, U> {}
+public interface OpenmrsFhirTranslator<T, U> extends ToFhirTranslator<T, U>, ToOpenmrsTranslator<T, U> {
+	
+	/**
+	 * Maps OpenMRS data elements to FHIR resources.
+	 *
+	 * @param data the collection of OpenMRS data elements to translate
+	 * @return the mapping of OpenMRS data element to corresponding FHIR resource
+	 */
+	default List<U> toFhirResources(Collection<T> data) {
+		return data.stream().distinct().map(this::toFhirResource).collect(Collectors.toList());
+	}
+}

--- a/api/src/main/java/org/openmrs/module/fhir2/api/translators/ToFhirTranslator.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/translators/ToFhirTranslator.java
@@ -9,7 +9,13 @@
  */
 package org.openmrs.module.fhir2.api.translators;
 
+import static java.util.stream.Collectors.toMap;
+
 import javax.annotation.Nonnull;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Function;
 
 /**
  * Generic interface for a translator between OpenMRS data and FHIR resources
@@ -26,4 +32,14 @@ public interface ToFhirTranslator<T, U> extends FhirTranslator {
 	 * @return the corresponding FHIR resource
 	 */
 	U toFhirResource(@Nonnull T data);
+	
+	/**
+	 * Maps OpenMRS data elements to FHIR resources.
+	 *
+	 * @param data the collection of OpenMRS data elements to translate
+	 * @return the mapping of OpenMRS data element to corresponding FHIR resource
+	 */
+	default Map<T, U> toFhirResources(Collection<T> data) {
+		return data.stream().distinct().collect(toMap(Function.identity(), this::toFhirResource));
+	}
 }

--- a/api/src/main/java/org/openmrs/module/fhir2/api/translators/ToFhirTranslator.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/translators/ToFhirTranslator.java
@@ -9,13 +9,7 @@
  */
 package org.openmrs.module.fhir2.api.translators;
 
-import static java.util.stream.Collectors.toMap;
-
 import javax.annotation.Nonnull;
-
-import java.util.Collection;
-import java.util.Map;
-import java.util.function.Function;
 
 /**
  * Generic interface for a translator between OpenMRS data and FHIR resources
@@ -33,13 +27,4 @@ public interface ToFhirTranslator<T, U> extends FhirTranslator {
 	 */
 	U toFhirResource(@Nonnull T data);
 	
-	/**
-	 * Maps OpenMRS data elements to FHIR resources.
-	 *
-	 * @param data the collection of OpenMRS data elements to translate
-	 * @return the mapping of OpenMRS data element to corresponding FHIR resource
-	 */
-	default Map<T, U> toFhirResources(Collection<T> data) {
-		return data.stream().distinct().collect(toMap(Function.identity(), this::toFhirResource));
-	}
 }

--- a/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/LocationTranslatorImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/LocationTranslatorImpl.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import lombok.AccessLevel;
@@ -79,17 +78,14 @@ public class LocationTranslatorImpl implements LocationTranslator {
 	 */
 	@Override
 	public Location toFhirResource(@Nonnull org.openmrs.Location openmrsLocation) {
-		return toFhirResources(Collections.singletonList(openmrsLocation)).get(openmrsLocation);
+		return toFhirResources(Collections.singletonList(openmrsLocation)).get(0);
 	}
 	
 	@Override
-	public Map<org.openmrs.Location, Location> toFhirResources(Collection<org.openmrs.Location> openmrsLocations) {
-		final Map<org.openmrs.Location, List<ContactPoint>> contactDetailsByLocation = getLocationContactDetails(
-		    openmrsLocations);
-		final LocationTranslatorContext context = new LocationTranslatorContext(contactDetailsByLocation);
+	public List<Location> toFhirResources(Collection<org.openmrs.Location> openmrsLocations) {
+		final LocationTranslatorContext context = new LocationTranslatorContext(getLocationContactDetails(openmrsLocations));
 		
-		return openmrsLocations.stream()
-		        .collect(Collectors.toMap(Function.identity(), location -> toFhirResource(location, context)));
+		return openmrsLocations.stream().map((location) -> toFhirResource(location, context)).collect(Collectors.toList());
 	}
 	
 	/**
@@ -172,7 +168,7 @@ public class LocationTranslatorImpl implements LocationTranslator {
 		        .getGlobalProperty(FhirConstants.LOCATION_CONTACT_POINT_ATTRIBUTE_TYPE);
 		
 		if (locationContactPointAttributeType == null || locationContactPointAttributeType.isEmpty()) {
-			return locations.stream().collect(Collectors.toMap(Function.identity(), ignored -> Collections.emptyList()));
+			return Collections.emptyMap();
 		}
 		
 		final Map<org.openmrs.Location, List<LocationAttribute>> contactPointAttributes = fhirLocationDao

--- a/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/LocationTranslatorImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/LocationTranslatorImpl.java
@@ -16,13 +16,18 @@ import static org.openmrs.module.fhir2.api.util.FhirUtils.getMetadataTranslation
 
 import javax.annotation.Nonnull;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.math.NumberUtils;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.ContactPoint;
@@ -45,6 +50,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Setter(AccessLevel.PACKAGE)
+@Slf4j
 public class LocationTranslatorImpl implements LocationTranslator {
 	
 	@Autowired
@@ -73,76 +79,17 @@ public class LocationTranslatorImpl implements LocationTranslator {
 	 */
 	@Override
 	public Location toFhirResource(@Nonnull org.openmrs.Location openmrsLocation) {
-		if (openmrsLocation == null) {
-			return null;
-		}
-		
-		Location fhirLocation = new Location();
-		fhirLocation.setId(openmrsLocation.getUuid());
-		fhirLocation.setName(getMetadataTranslation(openmrsLocation));
-		fhirLocation.setDescription(openmrsLocation.getDescription());
-		fhirLocation.setAddress(locationAddressTranslator.toFhirResource(openmrsLocation));
-		
-		Location.LocationPositionComponent position = null;
-		if (openmrsLocation.getLatitude() != null && !openmrsLocation.getLatitude().isEmpty()) {
-			double latitude = NumberUtils.toDouble(openmrsLocation.getLatitude(), -1.0d);
-			if (latitude >= 0.0d) {
-				position = new Location.LocationPositionComponent();
-				position.setLatitude(latitude);
-			}
-		}
-		
-		if (openmrsLocation.getLongitude() != null && !openmrsLocation.getLongitude().isEmpty()) {
-			double longitude = NumberUtils.toDouble(openmrsLocation.getLongitude(), -1.0d);
-			if (longitude >= 0.0d) {
-				if (position == null) {
-					position = new Location.LocationPositionComponent();
-				}
-				position.setLongitude(longitude);
-			}
-		}
-		
-		if (position != null) {
-			fhirLocation.setPosition(position);
-		}
-		
-		if (!openmrsLocation.getRetired()) {
-			fhirLocation.setStatus(Location.LocationStatus.ACTIVE);
-		} else {
-			fhirLocation.setStatus(Location.LocationStatus.INACTIVE);
-		}
-		
-		fhirLocation.setTelecom(getLocationContactDetails(openmrsLocation));
-		
-		fhirLocation.setType(locationTypeTranslator.toFhirResource(openmrsLocation));
-		
-		if (openmrsLocation.getTags() != null) {
-			for (LocationTag tag : openmrsLocation.getTags()) {
-				fhirLocation.getMeta().addTag(FhirConstants.OPENMRS_FHIR_EXT_LOCATION_TAG, tag.getName(),
-				    tag.getDescription());
-			}
-		}
-		
-		if (openmrsLocation.getParentLocation() != null) {
-			fhirLocation.setPartOf(locationReferenceTranslator.toFhirResource(openmrsLocation.getParentLocation()));
-		}
-		
-		fhirLocation.getMeta().setLastUpdated(getLastUpdated(openmrsLocation));
-		fhirLocation.getMeta().setVersionId(getVersionId(openmrsLocation));
-		
-		return fhirLocation;
+		return toFhirResources(Collections.singletonList(openmrsLocation)).get(openmrsLocation);
 	}
 	
-	protected List<ContactPoint> getLocationContactDetails(@Nonnull org.openmrs.Location location) {
-		String locationContactPointAttributeType = propertyService
-		        .getGlobalProperty(FhirConstants.LOCATION_CONTACT_POINT_ATTRIBUTE_TYPE);
+	@Override
+	public Map<org.openmrs.Location, Location> toFhirResources(Collection<org.openmrs.Location> openmrsLocations) {
+		final Map<org.openmrs.Location, List<ContactPoint>> contactDetailsByLocation = getLocationContactDetails(
+		    openmrsLocations);
+		final LocationTranslatorContext context = new LocationTranslatorContext(contactDetailsByLocation);
 		
-		if (locationContactPointAttributeType == null || locationContactPointAttributeType.isEmpty()) {
-			return Collections.emptyList();
-		}
-		
-		return fhirLocationDao.getActiveAttributesByLocationAndAttributeTypeUuid(location, locationContactPointAttributeType)
-		        .stream().map(telecomTranslator::toFhirResource).collect(Collectors.toList());
+		return openmrsLocations.stream()
+		        .collect(Collectors.toMap(Function.identity(), location -> toFhirResource(location, context)));
 	}
 	
 	/**
@@ -217,5 +164,84 @@ public class LocationTranslatorImpl implements LocationTranslator {
 		}
 		
 		return locationReferenceTranslator.toOpenmrsType(location);
+	}
+	
+	private Map<org.openmrs.Location, List<ContactPoint>> getLocationContactDetails(
+	        Collection<org.openmrs.Location> locations) {
+		final String locationContactPointAttributeType = propertyService
+		        .getGlobalProperty(FhirConstants.LOCATION_CONTACT_POINT_ATTRIBUTE_TYPE);
+		
+		if (locationContactPointAttributeType == null || locationContactPointAttributeType.isEmpty()) {
+			return locations.stream().collect(Collectors.toMap(Function.identity(), ignored -> Collections.emptyList()));
+		}
+		
+		final Map<org.openmrs.Location, List<LocationAttribute>> contactPointAttributes = fhirLocationDao
+		        .getActiveAttributesByLocationsAndAttributeTypeUuid(locations, locationContactPointAttributeType);
+		
+		return contactPointAttributes.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey,
+		    entry -> entry.getValue().stream().map(telecomTranslator::toFhirResource).collect(Collectors.toList())));
+	}
+	
+	private Location toFhirResource(org.openmrs.Location openmrsLocation, LocationTranslatorContext context) {
+		final Location fhirLocation = new Location();
+		fhirLocation.setId(openmrsLocation.getUuid());
+		fhirLocation.setName(getMetadataTranslation(openmrsLocation));
+		fhirLocation.setDescription(openmrsLocation.getDescription());
+		fhirLocation.setAddress(locationAddressTranslator.toFhirResource(openmrsLocation));
+		
+		Location.LocationPositionComponent position = null;
+		if (openmrsLocation.getLatitude() != null && !openmrsLocation.getLatitude().isEmpty()) {
+			double latitude = NumberUtils.toDouble(openmrsLocation.getLatitude(), -1.0d);
+			if (latitude >= 0.0d) {
+				position = new Location.LocationPositionComponent();
+				position.setLatitude(latitude);
+			}
+		}
+		
+		if (openmrsLocation.getLongitude() != null && !openmrsLocation.getLongitude().isEmpty()) {
+			double longitude = NumberUtils.toDouble(openmrsLocation.getLongitude(), -1.0d);
+			if (longitude >= 0.0d) {
+				if (position == null) {
+					position = new Location.LocationPositionComponent();
+				}
+				position.setLongitude(longitude);
+			}
+		}
+		
+		if (position != null) {
+			fhirLocation.setPosition(position);
+		}
+		
+		if (!openmrsLocation.getRetired()) {
+			fhirLocation.setStatus(Location.LocationStatus.ACTIVE);
+		} else {
+			fhirLocation.setStatus(Location.LocationStatus.INACTIVE);
+		}
+		
+		fhirLocation.setTelecom(context.locationContactDetails.get(openmrsLocation));
+		
+		fhirLocation.setType(locationTypeTranslator.toFhirResource(openmrsLocation));
+		
+		if (openmrsLocation.getTags() != null) {
+			for (LocationTag tag : openmrsLocation.getTags()) {
+				fhirLocation.getMeta().addTag(FhirConstants.OPENMRS_FHIR_EXT_LOCATION_TAG, tag.getName(),
+				    tag.getDescription());
+			}
+		}
+		
+		if (openmrsLocation.getParentLocation() != null) {
+			fhirLocation.setPartOf(locationReferenceTranslator.toFhirResource(openmrsLocation.getParentLocation()));
+		}
+		
+		fhirLocation.getMeta().setLastUpdated(getLastUpdated(openmrsLocation));
+		fhirLocation.getMeta().setVersionId(getVersionId(openmrsLocation));
+		
+		return fhirLocation;
+	}
+	
+	@AllArgsConstructor
+	private static class LocationTranslatorContext {
+		
+		final Map<org.openmrs.Location, List<ContactPoint>> locationContactDetails;
 	}
 }

--- a/api/src/test/java/org/openmrs/module/fhir2/api/dao/impl/FhirLocationDaoImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/dao/impl/FhirLocationDaoImplTest.java
@@ -9,12 +9,14 @@
  */
 package org.openmrs.module.fhir2.api.dao.impl;
 
+import static java.util.Collections.singleton;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -77,6 +79,17 @@ public class FhirLocationDaoImplTest extends BaseFhirContextSensitiveTest {
 		    LOCATION_ATTRIBUTE_TYPE_UUID);
 		
 		assertThat(attributeList, notNullValue());
+	}
+	
+	@Test
+	public void getActiveAttributesByLocationsAndAttributeTypeUuid_shouldReturnLocationAttribute() {
+		Location location = new Location();
+		location.setUuid(LOCATION_UUID);
+		
+		Map<Location, List<LocationAttribute>> attributes = fhirLocationDao
+		        .getActiveAttributesByLocationsAndAttributeTypeUuid(singleton(location), LOCATION_ATTRIBUTE_TYPE_UUID);
+		
+		assertThat(attributes, notNullValue());
 	}
 	
 	@Test

--- a/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirAllergyIntoleranceServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirAllergyIntoleranceServiceImplTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -160,6 +161,7 @@ public class FhirAllergyIntoleranceServiceImplTest {
 		        allergyIntoleranceDao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(translator.toFhirResource(omrsAllergy)).thenReturn(fhirAllergy);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = service.searchForAllergies(
 		    new FhirAllergyIntoleranceSearchParams(patientParam, null, null, null, null, null, null, null, null, null));
@@ -191,6 +193,7 @@ public class FhirAllergyIntoleranceServiceImplTest {
 		        allergyIntoleranceDao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(translator.toFhirResource(omrsAllergy)).thenReturn(fhirAllergy);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = service.searchForAllergies(
 		    new FhirAllergyIntoleranceSearchParams(patientParam, null, null, null, null, null, null, null, null, null));
@@ -222,6 +225,7 @@ public class FhirAllergyIntoleranceServiceImplTest {
 		        allergyIntoleranceDao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(translator.toFhirResource(omrsAllergy)).thenReturn(fhirAllergy);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = service.searchForAllergies(
 		    new FhirAllergyIntoleranceSearchParams(patientParam, null, null, null, null, null, null, null, null, null));
@@ -253,6 +257,7 @@ public class FhirAllergyIntoleranceServiceImplTest {
 		        allergyIntoleranceDao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(translator.toFhirResource(omrsAllergy)).thenReturn(fhirAllergy);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = service.searchForAllergies(
 		    new FhirAllergyIntoleranceSearchParams(patientParam, null, null, null, null, null, null, null, null, null));
@@ -280,6 +285,7 @@ public class FhirAllergyIntoleranceServiceImplTest {
 		        allergyIntoleranceDao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(translator.toFhirResource(omrsAllergy)).thenReturn(fhirAllergy);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = service.searchForAllergies(
 		    new FhirAllergyIntoleranceSearchParams(null, category, null, null, null, null, null, null, null, null));
@@ -307,6 +313,7 @@ public class FhirAllergyIntoleranceServiceImplTest {
 		        allergyIntoleranceDao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(translator.toFhirResource(omrsAllergy)).thenReturn(fhirAllergy);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = service.searchForAllergies(
 		    new FhirAllergyIntoleranceSearchParams(null, null, allergen, null, null, null, null, null, null, null));
@@ -334,6 +341,7 @@ public class FhirAllergyIntoleranceServiceImplTest {
 		        allergyIntoleranceDao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(translator.toFhirResource(omrsAllergy)).thenReturn(fhirAllergy);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = service.searchForAllergies(
 		    new FhirAllergyIntoleranceSearchParams(null, null, null, severity, null, null, null, null, null, null));
@@ -361,6 +369,7 @@ public class FhirAllergyIntoleranceServiceImplTest {
 		        allergyIntoleranceDao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(translator.toFhirResource(omrsAllergy)).thenReturn(fhirAllergy);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = service.searchForAllergies(
 		    new FhirAllergyIntoleranceSearchParams(null, null, null, null, manifestation, null, null, null, null, null));
@@ -387,6 +396,7 @@ public class FhirAllergyIntoleranceServiceImplTest {
 		        allergyIntoleranceDao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(translator.toFhirResource(omrsAllergy)).thenReturn(fhirAllergy);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = service.searchForAllergies(
 		    new FhirAllergyIntoleranceSearchParams(null, null, null, null, null, status, null, null, null, null));
@@ -410,6 +420,7 @@ public class FhirAllergyIntoleranceServiceImplTest {
 		        allergyIntoleranceDao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(translator.toFhirResource(omrsAllergy)).thenReturn(fhirAllergy);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = service.searchForAllergies(
 		    new FhirAllergyIntoleranceSearchParams(null, null, null, null, null, null, uuid, null, null, null));
@@ -433,6 +444,7 @@ public class FhirAllergyIntoleranceServiceImplTest {
 		        allergyIntoleranceDao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(translator.toFhirResource(omrsAllergy)).thenReturn(fhirAllergy);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = service.searchForAllergies(
 		    new FhirAllergyIntoleranceSearchParams(null, null, null, null, null, null, null, lastUpdated, null, null));
@@ -456,6 +468,7 @@ public class FhirAllergyIntoleranceServiceImplTest {
 		        allergyIntoleranceDao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.singleton(new Patient()));
 		when(translator.toFhirResource(omrsAllergy)).thenReturn(fhirAllergy);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = service.searchForAllergies(
 		    new FhirAllergyIntoleranceSearchParams(null, null, null, null, null, null, null, null, null, includes));
@@ -479,6 +492,7 @@ public class FhirAllergyIntoleranceServiceImplTest {
 		        allergyIntoleranceDao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(translator.toFhirResource(omrsAllergy)).thenReturn(fhirAllergy);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = service.searchForAllergies(
 		    new FhirAllergyIntoleranceSearchParams(null, null, null, null, null, null, null, null, null, includes));

--- a/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirConditionServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirConditionServiceImplTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
@@ -261,6 +262,7 @@ public class FhirConditionServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, conditionTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(conditionTranslator.toFhirResource(openmrsCondition)).thenReturn(fhirCondition);
+		when(conditionTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider result = conditionService.searchConditions(new ConditionSearchParams(patientReference, codeList,
 		        clinicalList, onsetDate, onsetAge, recordDate, uuid, lastUpdated, sort, includes));

--- a/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirDiagnosticReportServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirDiagnosticReportServiceImplTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -210,6 +211,7 @@ public class FhirDiagnosticReportServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(fhirDiagnosticReports);
 		when(translator.toFhirResource(fhirDiagnosticReport)).thenReturn(diagnosticReport);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -242,6 +244,7 @@ public class FhirDiagnosticReportServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(diagnosticReportList);
 		when(translator.toFhirResource(fhirDiagnosticReport)).thenReturn(diagnosticReport);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.singleton(new Patient()));
@@ -275,6 +278,7 @@ public class FhirDiagnosticReportServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(diagnosticReportList);
 		when(translator.toFhirResource(fhirDiagnosticReport)).thenReturn(diagnosticReport);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());

--- a/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirEncounterServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirEncounterServiceImplTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -309,6 +310,7 @@ public class FhirEncounterServiceImplTest {
 		when(dao.getSearchResults(any())).thenReturn(encounters);
 		when(dao.getSearchResultsCount(any())).thenReturn(1);
 		when(encounterTranslator.toFhirResource(openMrsEncounter)).thenReturn(fhirEncounter);
+		when(encounterTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, encounterTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -341,6 +343,7 @@ public class FhirEncounterServiceImplTest {
 		when(dao.getSearchResults(any())).thenReturn(encounters);
 		when(dao.getSearchResultsCount(any())).thenReturn(1);
 		when(encounterTranslator.toFhirResource(openMrsEncounter)).thenReturn(fhirEncounter);
+		when(encounterTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, encounterTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -376,6 +379,7 @@ public class FhirEncounterServiceImplTest {
 		when(dao.getSearchResults(any())).thenReturn(encounters);
 		when(dao.getSearchResultsCount(any())).thenReturn(1);
 		when(encounterTranslator.toFhirResource(openMrsEncounter)).thenReturn(fhirEncounter);
+		when(encounterTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, encounterTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -411,6 +415,7 @@ public class FhirEncounterServiceImplTest {
 		when(dao.getSearchResults(any())).thenReturn(encounters);
 		when(dao.getSearchResultsCount(any())).thenReturn(1);
 		when(encounterTranslator.toFhirResource(openMrsEncounter)).thenReturn(fhirEncounter);
+		when(encounterTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, encounterTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -438,6 +443,7 @@ public class FhirEncounterServiceImplTest {
 		when(dao.getSearchResults(any())).thenReturn(Collections.singletonList(openMrsEncounter));
 		when(dao.getSearchResultsCount(any())).thenReturn(1);
 		when(encounterTranslator.toFhirResource(openMrsEncounter)).thenReturn(fhirEncounter);
+		when(encounterTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, encounterTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -469,6 +475,7 @@ public class FhirEncounterServiceImplTest {
 		when(dao.getSearchResults(any())).thenReturn(encounters);
 		when(dao.getSearchResultsCount(any())).thenReturn(1);
 		when(encounterTranslator.toFhirResource(openMrsEncounter)).thenReturn(fhirEncounter);
+		when(encounterTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, encounterTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -496,6 +503,7 @@ public class FhirEncounterServiceImplTest {
 		when(dao.getSearchResults(any())).thenReturn(Collections.singletonList(openMrsEncounter));
 		when(dao.getSearchResultsCount(any())).thenReturn(1);
 		when(encounterTranslator.toFhirResource(openMrsEncounter)).thenReturn(fhirEncounter);
+		when(encounterTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, encounterTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -523,6 +531,7 @@ public class FhirEncounterServiceImplTest {
 		when(dao.getSearchResults(any())).thenReturn(Collections.singletonList(openMrsEncounter));
 		when(dao.getSearchResultsCount(any())).thenReturn(1);
 		when(encounterTranslator.toFhirResource(openMrsEncounter)).thenReturn(fhirEncounter);
+		when(encounterTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, encounterTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.singleton(new Patient()));
@@ -550,6 +559,7 @@ public class FhirEncounterServiceImplTest {
 		when(dao.getSearchResults(any())).thenReturn(Collections.singletonList(openMrsEncounter));
 		when(dao.getSearchResultsCount(any())).thenReturn(1);
 		when(encounterTranslator.toFhirResource(openMrsEncounter)).thenReturn(fhirEncounter);
+		when(encounterTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, encounterTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -578,6 +588,7 @@ public class FhirEncounterServiceImplTest {
 		when(dao.getSearchResults(any())).thenReturn(Collections.singletonList(openMrsEncounter));
 		when(dao.getSearchResultsCount(any())).thenReturn(1);
 		when(encounterTranslator.toFhirResource(openMrsEncounter)).thenReturn(fhirEncounter);
+		when(encounterTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, encounterTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.singleton(new Observation()));
@@ -606,6 +617,7 @@ public class FhirEncounterServiceImplTest {
 		when(dao.getSearchResults(any())).thenReturn(Collections.singletonList(openMrsEncounter));
 		when(dao.getSearchResultsCount(any())).thenReturn(1);
 		when(encounterTranslator.toFhirResource(openMrsEncounter)).thenReturn(fhirEncounter);
+		when(encounterTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, encounterTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -635,6 +647,7 @@ public class FhirEncounterServiceImplTest {
 		when(dao.getSearchResults(any())).thenReturn(Collections.singletonList(openMrsEncounter));
 		when(dao.getSearchResultsCount(any())).thenReturn(1);
 		when(encounterTranslator.toFhirResource(openMrsEncounter)).thenReturn(fhirEncounter);
+		when(encounterTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, encounterTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -743,6 +756,7 @@ public class FhirEncounterServiceImplTest {
 		when(dao.getSearchResults(any())).thenReturn(Collections.singletonList(openMrsEncounter));
 		when(dao.getSearchResultsCount(any())).thenReturn(1);
 		when(encounterTranslator.toFhirResource(openMrsEncounter)).thenReturn(fhirEncounter);
+		when(encounterTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, encounterTranslator, globalPropertyService, searchQueryInclude));
 		

--- a/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirGroupServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirGroupServiceImplTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -210,6 +211,7 @@ public class FhirGroupServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(cohorts);
 		when(translator.toFhirResource(cohort)).thenReturn(group);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());

--- a/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirLocationServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirLocationServiceImplTest.java
@@ -10,7 +10,6 @@
 package org.openmrs.module.fhir2.api.impl;
 
 import static java.util.Collections.singletonList;
-import static java.util.Collections.singletonMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -154,7 +153,7 @@ public class FhirLocationServiceImplTest {
 		        locationDao, locationTranslator, globalPropertyService, searchQueryInclude));
 		
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
-		when(locationTranslator.toFhirResources(singletonList(location))).thenReturn(singletonMap(location, fhirLocation));
+		when(locationTranslator.toFhirResources(singletonList(location))).thenReturn(singletonList(fhirLocation));
 		when(locationDao.getSearchResults(any())).thenReturn(locations);
 		
 		IBundleProvider results = fhirLocationService.searchForLocations(

--- a/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirLocationServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirLocationServiceImplTest.java
@@ -9,6 +9,8 @@
  */
 package org.openmrs.module.fhir2.api.impl;
 
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -152,7 +154,7 @@ public class FhirLocationServiceImplTest {
 		        locationDao, locationTranslator, globalPropertyService, searchQueryInclude));
 		
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
-		when(locationTranslator.toFhirResource(location)).thenReturn(fhirLocation);
+		when(locationTranslator.toFhirResources(singletonList(location))).thenReturn(singletonMap(location, fhirLocation));
 		when(locationDao.getSearchResults(any())).thenReturn(locations);
 		
 		IBundleProvider results = fhirLocationService.searchForLocations(

--- a/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirMedicationRequestServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirMedicationRequestServiceImplTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -154,6 +155,7 @@ public class FhirMedicationRequestServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(drugOrders);
 		when(medicationRequestTranslator.toFhirResource(drugOrder)).thenReturn(medicationRequest);
+		when(medicationRequestTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(new SearchQueryBundleProvider<>(theParams,
 		        dao, medicationRequestTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -185,6 +187,7 @@ public class FhirMedicationRequestServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(drugOrders);
 		when(medicationRequestTranslator.toFhirResource(drugOrder)).thenReturn(medicationRequest);
+		when(medicationRequestTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(new SearchQueryBundleProvider<>(theParams,
 		        dao, medicationRequestTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -217,6 +220,7 @@ public class FhirMedicationRequestServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(drugOrders);
 		when(medicationRequestTranslator.toFhirResource(drugOrder)).thenReturn(medicationRequest);
+		when(medicationRequestTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(new SearchQueryBundleProvider<>(theParams,
 		        dao, medicationRequestTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -245,6 +249,7 @@ public class FhirMedicationRequestServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(drugOrders);
 		when(medicationRequestTranslator.toFhirResource(drugOrder)).thenReturn(medicationRequest);
+		when(medicationRequestTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(new SearchQueryBundleProvider<>(theParams,
 		        dao, medicationRequestTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -277,6 +282,7 @@ public class FhirMedicationRequestServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(drugOrders);
 		when(medicationRequestTranslator.toFhirResource(drugOrder)).thenReturn(medicationRequest);
+		when(medicationRequestTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(new SearchQueryBundleProvider<>(theParams,
 		        dao, medicationRequestTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -300,6 +306,7 @@ public class FhirMedicationRequestServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(Collections.singletonList(drugOrder));
 		when(medicationRequestTranslator.toFhirResource(drugOrder)).thenReturn(medicationRequest);
+		when(medicationRequestTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(new SearchQueryBundleProvider<>(theParams,
 		        dao, medicationRequestTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -324,6 +331,7 @@ public class FhirMedicationRequestServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(Collections.singletonList(drugOrder));
 		when(medicationRequestTranslator.toFhirResource(drugOrder)).thenReturn(medicationRequest);
+		when(medicationRequestTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(new SearchQueryBundleProvider<>(theParams,
 		        dao, medicationRequestTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -347,6 +355,7 @@ public class FhirMedicationRequestServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(Collections.singletonList(drugOrder));
 		when(medicationRequestTranslator.toFhirResource(drugOrder)).thenReturn(medicationRequest);
+		when(medicationRequestTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(new SearchQueryBundleProvider<>(theParams,
 		        dao, medicationRequestTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -374,6 +383,7 @@ public class FhirMedicationRequestServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(Collections.singletonList(drugOrder));
 		when(medicationRequestTranslator.toFhirResource(drugOrder)).thenReturn(medicationRequest);
+		when(medicationRequestTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(new SearchQueryBundleProvider<>(theParams,
 		        dao, medicationRequestTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.singleton(new Practitioner()));
@@ -402,6 +412,7 @@ public class FhirMedicationRequestServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(Collections.singletonList(drugOrder));
 		when(medicationRequestTranslator.toFhirResource(drugOrder)).thenReturn(medicationRequest);
+		when(medicationRequestTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(new SearchQueryBundleProvider<>(theParams,
 		        dao, medicationRequestTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any()))
@@ -430,6 +441,7 @@ public class FhirMedicationRequestServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(Collections.singletonList(drugOrder));
 		when(medicationRequestTranslator.toFhirResource(drugOrder)).thenReturn(medicationRequest);
+		when(medicationRequestTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(new SearchQueryBundleProvider<>(theParams,
 		        dao, medicationRequestTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());

--- a/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirMedicationServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirMedicationServiceImplTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -149,6 +150,7 @@ public class FhirMedicationServiceImplTest {
 		        medicationDao, medicationTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(medicationTranslator.toFhirResource(drug)).thenReturn(medication);
+		when(medicationTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider result = fhirMedicationService
 		        .searchForMedications(new MedicationSearchParams(code, null, null, null, null, null));
@@ -176,6 +178,7 @@ public class FhirMedicationServiceImplTest {
 		        medicationDao, medicationTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(medicationTranslator.toFhirResource(drug)).thenReturn(medication);
+		when(medicationTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider result = fhirMedicationService
 		        .searchForMedications(new MedicationSearchParams(null, dosageForm, null, null, null, null));
@@ -202,6 +205,7 @@ public class FhirMedicationServiceImplTest {
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(new SearchQueryBundleProvider<>(theParams,
 		        medicationDao, medicationTranslator, globalPropertyService, searchQueryInclude));
 		when(medicationTranslator.toFhirResource(drug)).thenReturn(medication);
+		when(medicationTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		
 		IBundleProvider result = fhirMedicationService
@@ -226,6 +230,7 @@ public class FhirMedicationServiceImplTest {
 		        medicationDao, medicationTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(medicationTranslator.toFhirResource(drug)).thenReturn(medication);
+		when(medicationTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider result = fhirMedicationService
 		        .searchForMedications(new MedicationSearchParams(null, null, null, uuid, null, null));
@@ -249,6 +254,7 @@ public class FhirMedicationServiceImplTest {
 		        medicationDao, medicationTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(medicationTranslator.toFhirResource(drug)).thenReturn(medication);
+		when(medicationTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider result = fhirMedicationService
 		        .searchForMedications(new MedicationSearchParams(null, null, null, null, lastUpdated, null));
@@ -274,6 +280,7 @@ public class FhirMedicationServiceImplTest {
 		when(searchQueryInclude.getIncludedResources(any(), any()))
 		        .thenReturn(Collections.singleton(new MedicationRequest()));
 		when(medicationTranslator.toFhirResource(drug)).thenReturn(medication);
+		when(medicationTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = fhirMedicationService
 		        .searchForMedications(new MedicationSearchParams(null, null, null, null, null, revIncludes));
@@ -298,6 +305,7 @@ public class FhirMedicationServiceImplTest {
 		        medicationDao, medicationTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(medicationTranslator.toFhirResource(drug)).thenReturn(medication);
+		when(medicationTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = fhirMedicationService
 		        .searchForMedications(new MedicationSearchParams(null, null, null, null, null, revIncludes));

--- a/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirObservationServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirObservationServiceImplTest.java
@@ -16,6 +16,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
@@ -138,6 +139,7 @@ public class FhirObservationServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(translator.toFhirResource(obs)).thenReturn(observation);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		ObservationSearchParams observationSearchParams = new ObservationSearchParams();
 		observationSearchParams.setPatient(patientReference);
@@ -189,6 +191,7 @@ public class FhirObservationServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(translator.toFhirResource(obs)).thenReturn(observation);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		ObservationSearchParams searchParams = new ObservationSearchParams();
 		searchParams.setPatient(referenceParam);
@@ -242,6 +245,7 @@ public class FhirObservationServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(translator.toFhirResource(obs)).thenReturn(observation);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		ObservationSearchParams searchParams = new ObservationSearchParams();
 		searchParams.setPatient(referenceParam);
@@ -287,6 +291,7 @@ public class FhirObservationServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(translator.toFhirResource(obs)).thenReturn(observation);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		ObservationSearchParams searchParams = new ObservationSearchParams();
 		searchParams.setCategory(categories);
@@ -339,6 +344,7 @@ public class FhirObservationServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(translator.toFhirResource(obs)).thenReturn(observation);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		ObservationSearchParams searchParams = new ObservationSearchParams();
 		searchParams.setPatient(referenceParam);
@@ -392,6 +398,7 @@ public class FhirObservationServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(translator.toFhirResource(obs)).thenReturn(observation);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		ObservationSearchParams searchParams = new ObservationSearchParams();
 		searchParams.setPatient(referenceParam);
@@ -437,6 +444,7 @@ public class FhirObservationServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(translator.toFhirResource(obs)).thenReturn(observation);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		ObservationSearchParams searchParams = new ObservationSearchParams();
 		searchParams.setCategory(categories);

--- a/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirPatientServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirPatientServiceImplTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -232,6 +233,7 @@ public class FhirPatientServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, patientTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(patientTranslator.toFhirResource(patient)).thenReturn(fhirPatient);
+		when(patientTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = patientService.searchForPatients(new PatientSearchParams(stringAndListParam, null, null,
 		        null, null, null, null, null, null, null, null, null, null, null, null, null, null));
@@ -256,6 +258,7 @@ public class FhirPatientServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, patientTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(patientTranslator.toFhirResource(patient)).thenReturn(fhirPatient);
+		when(patientTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = patientService.searchForPatients(new PatientSearchParams(null, stringAndListParam, null,
 		        null, null, null, null, null, null, null, null, null, null, null, null, null, null));
@@ -282,6 +285,7 @@ public class FhirPatientServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, patientTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(patientTranslator.toFhirResource(patient)).thenReturn(fhirPatient);
+		when(patientTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = patientService.searchForPatients(new PatientSearchParams(null, null, stringAndListParam,
 		        null, null, null, null, null, null, null, null, null, null, null, null, null, null));
@@ -306,6 +310,7 @@ public class FhirPatientServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, patientTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(patientTranslator.toFhirResource(patient)).thenReturn(fhirPatient);
+		when(patientTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = patientService.searchForPatients(new PatientSearchParams(null, stringAndListParam, null,
 		        null, null, null, null, null, null, null, null, null, null, null, null, null, null));
@@ -330,6 +335,7 @@ public class FhirPatientServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, patientTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(patientTranslator.toFhirResource(patient)).thenReturn(fhirPatient);
+		when(patientTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = patientService.searchForPatients(new PatientSearchParams(null, null, stringAndListParam,
 		        null, null, null, null, null, null, null, null, null, null, null, null, null, null));
@@ -404,6 +410,7 @@ public class FhirPatientServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, patientTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(patientTranslator.toFhirResource(patient)).thenReturn(fhirPatient);
+		when(patientTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = patientService.searchForPatients(new PatientSearchParams(null, null, null, null,
 		        tokenAndListParam, null, null, null, null, null, null, null, null, null, null, null, null));
@@ -447,6 +454,7 @@ public class FhirPatientServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, patientTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(patientTranslator.toFhirResource(patient)).thenReturn(fhirPatient);
+		when(patientTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = patientService.searchForPatients(new PatientSearchParams(null, null, null, null, null,
 		        dateRangeParam, null, null, null, null, null, null, null, null, null, null, null));
@@ -490,6 +498,7 @@ public class FhirPatientServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, patientTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(patientTranslator.toFhirResource(patient)).thenReturn(fhirPatient);
+		when(patientTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = patientService.searchForPatients(new PatientSearchParams(null, null, null, null, null,
 		        null, dateRangeParam, null, null, null, null, null, null, null, null, null, null));
@@ -529,6 +538,7 @@ public class FhirPatientServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, patientTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(patientTranslator.toFhirResource(patient)).thenReturn(fhirPatient);
+		when(patientTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = patientService.searchForPatients(new PatientSearchParams(null, null, null, null, null,
 		        null, null, null, stringAndListParam, null, null, null, null, null, null, null, null));
@@ -568,6 +578,7 @@ public class FhirPatientServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, patientTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(patientTranslator.toFhirResource(patient)).thenReturn(fhirPatient);
+		when(patientTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = patientService.searchForPatients(new PatientSearchParams(null, null, null, null, null,
 		        null, null, null, null, stringAndListParam, null, null, null, null, null, null, null));
@@ -607,6 +618,7 @@ public class FhirPatientServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, patientTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(patientTranslator.toFhirResource(patient)).thenReturn(fhirPatient);
+		when(patientTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = patientService.searchForPatients(new PatientSearchParams(null, null, null, null, null,
 		        null, null, null, null, null, stringAndListParam, null, null, null, null, null, null));
@@ -645,6 +657,7 @@ public class FhirPatientServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, patientTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(patientTranslator.toFhirResource(patient)).thenReturn(fhirPatient);
+		when(patientTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = patientService.searchForPatients(new PatientSearchParams(null, null, null, null, null,
 		        null, null, null, null, null, null, stringAndListParam, null, null, null, null, null));
@@ -683,6 +696,7 @@ public class FhirPatientServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, patientTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(patientTranslator.toFhirResource(patient)).thenReturn(fhirPatient);
+		when(patientTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = patientService.searchForPatients(new PatientSearchParams(null, null, null, null, null,
 		        null, null, null, null, null, null, null, uuid, null, null, null, null));
@@ -722,6 +736,7 @@ public class FhirPatientServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, patientTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(patientTranslator.toFhirResource(patient)).thenReturn(fhirPatient);
+		when(patientTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = patientService.searchForPatients(new PatientSearchParams(null, null, null, null, null,
 		        null, null, null, null, null, null, null, null, null, lastUpdated, null, null));
@@ -762,6 +777,7 @@ public class FhirPatientServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, patientTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.singleton(new Observation()));
 		when(patientTranslator.toFhirResource(patient)).thenReturn(fhirPatient);
+		when(patientTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = patientService.searchForPatients(new PatientSearchParams(null, null, null, null, null,
 		        null, null, null, null, null, null, null, null, null, null, null, revIncludes));
@@ -786,6 +802,7 @@ public class FhirPatientServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, patientTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(patientTranslator.toFhirResource(patient)).thenReturn(fhirPatient);
+		when(patientTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = patientService.searchForPatients(new PatientSearchParams(null, null, null, null, null,
 		        null, null, null, null, null, null, null, null, null, null, null, revIncludes));
@@ -811,6 +828,7 @@ public class FhirPatientServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, patientTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(patientTranslator.toFhirResource(patient)).thenReturn(fhirPatient);
+		when(patientTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = patientService
 		        .searchForPatients(OpenmrsPatientSearchParams.builder().query(stringAndListParam).build());
@@ -845,6 +863,7 @@ public class FhirPatientServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, patientTranslator, globalPropertyService, searchQueryInclude));
 		
 		when(patientTranslator.toFhirResource(patient)).thenReturn(fhirPatient);
+		when(patientTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = patientService.getPatientEverything(patientId);
 		
@@ -877,6 +896,7 @@ public class FhirPatientServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, patientTranslator, globalPropertyService, searchQueryInclude));
 		
 		when(patientTranslator.toFhirResource(patient)).thenReturn(fhirPatient);
+		when(patientTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = patientService.getPatientEverything();
 		

--- a/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirPersonServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirPersonServiceImplTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.when;
 
 import java.text.ParseException;
@@ -185,6 +186,7 @@ public class FhirPersonServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, personTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(personTranslator.toFhirResource(person)).thenReturn(fhirPerson);
+		when(personTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = personService.searchForPeople(
 		    new PersonSearchParams(stringAndListParam, null, null, null, null, null, null, null, null, null, null));
@@ -209,6 +211,7 @@ public class FhirPersonServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, personTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(personTranslator.toFhirResource(person)).thenReturn(fhirPerson);
+		when(personTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = personService.searchForPeople(
 		    new PersonSearchParams(stringAndListParam, null, null, null, null, null, null, null, null, null, null));
@@ -252,6 +255,7 @@ public class FhirPersonServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, personTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(personTranslator.toFhirResource(person)).thenReturn(fhirPerson);
+		when(personTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = personService.searchForPeople(
 		    new PersonSearchParams(null, tokenAndListParam, null, null, null, null, null, null, null, null, null));
@@ -298,6 +302,7 @@ public class FhirPersonServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, personTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(personTranslator.toFhirResource(person)).thenReturn(fhirPerson);
+		when(personTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = personService.searchForPeople(
 		    new PersonSearchParams(null, null, dateRangeParam, null, null, null, null, null, null, null, null));
@@ -342,6 +347,7 @@ public class FhirPersonServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, personTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(personTranslator.toFhirResource(person)).thenReturn(fhirPerson);
+		when(personTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = personService.searchForPeople(
 		    new PersonSearchParams(null, null, null, stringAndListParam, null, null, null, null, null, null, null));
@@ -386,6 +392,7 @@ public class FhirPersonServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, personTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(personTranslator.toFhirResource(person)).thenReturn(fhirPerson);
+		when(personTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = personService.searchForPeople(
 		    new PersonSearchParams(null, null, null, null, stringAndListParam, null, null, null, null, null, null));
@@ -430,6 +437,7 @@ public class FhirPersonServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, personTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(personTranslator.toFhirResource(person)).thenReturn(fhirPerson);
+		when(personTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = personService.searchForPeople(
 		    new PersonSearchParams(null, null, null, null, null, stringAndListParam, null, null, null, null, null));
@@ -474,6 +482,7 @@ public class FhirPersonServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, personTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(personTranslator.toFhirResource(person)).thenReturn(fhirPerson);
+		when(personTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = personService.searchForPeople(
 		    new PersonSearchParams(null, null, null, null, null, null, stringAndListParam, null, null, null, null));
@@ -518,6 +527,7 @@ public class FhirPersonServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, personTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(personTranslator.toFhirResource(person)).thenReturn(fhirPerson);
+		when(personTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = personService
 		        .searchForPeople(new PersonSearchParams(null, null, null, null, null, null, null, uuid, null, null, null));
@@ -557,6 +567,7 @@ public class FhirPersonServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, personTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(personTranslator.toFhirResource(person)).thenReturn(fhirPerson);
+		when(personTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = personService.searchForPeople(
 		    new PersonSearchParams(null, null, null, null, null, null, null, null, lastUpdated, null, null));
@@ -596,6 +607,7 @@ public class FhirPersonServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, personTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.singleton(new Patient()));
 		when(personTranslator.toFhirResource(person)).thenReturn(fhirPerson);
+		when(personTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = personService.searchForPeople(
 		    new PersonSearchParams(null, null, null, null, null, null, null, null, null, null, includes));
@@ -619,6 +631,7 @@ public class FhirPersonServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, personTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(personTranslator.toFhirResource(person)).thenReturn(fhirPerson);
+		when(personTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = personService.searchForPeople(
 		    new PersonSearchParams(null, null, null, null, null, null, null, null, null, null, includes));

--- a/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirPractitionerServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirPractitionerServiceImplTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 import static org.openmrs.module.fhir2.FhirConstants.FAMILY_PROPERTY;
@@ -217,6 +218,7 @@ public class FhirPractitionerServiceImplTest {
 		        practitionerDao, practitionerTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(practitionerTranslator.toFhirResource(provider)).thenReturn(practitioner);
+		when(practitionerTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		when(userService.searchForUsers(any())).thenReturn(new SimpleBundleProvider());
 		
@@ -260,6 +262,7 @@ public class FhirPractitionerServiceImplTest {
 		        practitionerDao, practitionerTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(practitionerTranslator.toFhirResource(provider)).thenReturn(practitioner);
+		when(practitionerTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		when(userService.searchForUsers(any())).thenReturn(new SimpleBundleProvider(practitioner2));
 		
@@ -303,6 +306,7 @@ public class FhirPractitionerServiceImplTest {
 		        practitionerDao, practitionerTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(practitionerTranslator.toFhirResource(provider)).thenReturn(practitioner);
+		when(practitionerTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(userService.searchForUsers(any())).thenReturn(new SimpleBundleProvider());
 		
 		IBundleProvider results = practitionerService.searchForPractitioners(
@@ -347,6 +351,7 @@ public class FhirPractitionerServiceImplTest {
 		        practitionerDao, practitionerTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(practitionerTranslator.toFhirResource(provider)).thenReturn(practitioner);
+		when(practitionerTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		when(userService.searchForUsers(any())).thenReturn(new SimpleBundleProvider(practitioner2));
 		
@@ -392,6 +397,7 @@ public class FhirPractitionerServiceImplTest {
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(new SearchQueryBundleProvider<>(theParams,
 		        practitionerDao, practitionerTranslator, globalPropertyService, searchQueryInclude));
 		when(practitionerTranslator.toFhirResource(provider)).thenReturn(practitioner);
+		when(practitionerTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		when(userService.searchForUsers(any())).thenReturn(new SimpleBundleProvider());
 		
@@ -437,6 +443,7 @@ public class FhirPractitionerServiceImplTest {
 		        practitionerDao, practitionerTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(practitionerTranslator.toFhirResource(provider)).thenReturn(practitioner);
+		when(practitionerTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(userService.searchForUsers(any())).thenReturn(new SimpleBundleProvider(practitioner2));
 		
 		IBundleProvider results = practitionerService.searchForPractitioners(
@@ -480,6 +487,7 @@ public class FhirPractitionerServiceImplTest {
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(new SearchQueryBundleProvider<>(theParams,
 		        practitionerDao, practitionerTranslator, globalPropertyService, searchQueryInclude));
 		when(practitionerTranslator.toFhirResource(provider)).thenReturn(practitioner);
+		when(practitionerTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(userService.searchForUsers(any())).thenReturn(new SimpleBundleProvider());
 		
 		IBundleProvider results = practitionerService.searchForPractitioners(
@@ -523,6 +531,7 @@ public class FhirPractitionerServiceImplTest {
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(new SearchQueryBundleProvider<>(theParams,
 		        practitionerDao, practitionerTranslator, globalPropertyService, searchQueryInclude));
 		when(practitionerTranslator.toFhirResource(provider)).thenReturn(practitioner);
+		when(practitionerTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(userService.searchForUsers(any())).thenReturn(new SimpleBundleProvider());
 		
 		IBundleProvider results = practitionerService.searchForPractitioners(
@@ -566,6 +575,7 @@ public class FhirPractitionerServiceImplTest {
 		        practitionerDao, practitionerTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(practitionerTranslator.toFhirResource(provider)).thenReturn(practitioner);
+		when(practitionerTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(userService.searchForUsers(any())).thenReturn(new SimpleBundleProvider());
 		
 		IBundleProvider results = practitionerService.searchForPractitioners(
@@ -609,6 +619,7 @@ public class FhirPractitionerServiceImplTest {
 		        practitionerDao, practitionerTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(practitionerTranslator.toFhirResource(provider)).thenReturn(practitioner);
+		when(practitionerTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(userService.searchForUsers(any())).thenReturn(new SimpleBundleProvider());
 		
 		IBundleProvider results = practitionerService.searchForPractitioners(
@@ -653,6 +664,7 @@ public class FhirPractitionerServiceImplTest {
 		        practitionerDao, practitionerTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(practitionerTranslator.toFhirResource(provider)).thenReturn(practitioner);
+		when(practitionerTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(userService.searchForUsers(any())).thenReturn(new SimpleBundleProvider());
 		
 		IBundleProvider results = practitionerService.searchForPractitioners(
@@ -698,6 +710,7 @@ public class FhirPractitionerServiceImplTest {
 		        practitionerDao, practitionerTranslator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(practitionerTranslator.toFhirResource(provider)).thenReturn(practitioner);
+		when(practitionerTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(userService.searchForUsers(any())).thenReturn(new SimpleBundleProvider());
 		
 		IBundleProvider results = practitionerService.searchForPractitioners(
@@ -746,6 +759,7 @@ public class FhirPractitionerServiceImplTest {
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(new SearchQueryBundleProvider<>(theParams,
 		        practitionerDao, practitionerTranslator, globalPropertyService, searchQueryInclude));
 		when(practitionerTranslator.toFhirResource(provider)).thenReturn(practitioner);
+		when(practitionerTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		when(userService.searchForUsers(any())).thenReturn(new SimpleBundleProvider());
 		
@@ -773,6 +787,7 @@ public class FhirPractitionerServiceImplTest {
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(new SearchQueryBundleProvider<>(theParams,
 		        practitionerDao, practitionerTranslator, globalPropertyService, searchQueryInclude));
 		when(practitionerTranslator.toFhirResource(provider)).thenReturn(practitioner);
+		when(practitionerTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(userService.searchForUsers(any())).thenReturn(new SimpleBundleProvider());
 		
 		IBundleProvider results = practitionerService.searchForPractitioners(
@@ -799,6 +814,7 @@ public class FhirPractitionerServiceImplTest {
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(new SearchQueryBundleProvider<>(theParams,
 		        practitionerDao, practitionerTranslator, globalPropertyService, searchQueryInclude));
 		when(practitionerTranslator.toFhirResource(provider)).thenReturn(practitioner);
+		when(practitionerTranslator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(userService.searchForUsers(any())).thenReturn(userPractitionerSearchQueryBundleProvider);
 		
 		when(userPractitionerSearchQueryBundleProvider.size()).thenReturn(1);

--- a/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirRelatedPersonServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirRelatedPersonServiceImplTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.when;
 
 import java.text.ParseException;
@@ -226,6 +227,7 @@ public class FhirRelatedPersonServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(singletonList(relationship));
 		when(translator.toFhirResource(relationship)).thenReturn(relatedPerson);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -250,6 +252,7 @@ public class FhirRelatedPersonServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(singletonList(relationship));
 		when(translator.toFhirResource(relationship)).thenReturn(relatedPerson);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -293,6 +296,7 @@ public class FhirRelatedPersonServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(singletonList(relationship));
 		when(translator.toFhirResource(relationship)).thenReturn(relatedPerson);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -340,6 +344,7 @@ public class FhirRelatedPersonServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(singletonList(relationship));
 		when(translator.toFhirResource(relationship)).thenReturn(relatedPerson);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -384,6 +389,7 @@ public class FhirRelatedPersonServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(singletonList(relationship));
 		when(translator.toFhirResource(relationship)).thenReturn(relatedPerson);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -428,6 +434,7 @@ public class FhirRelatedPersonServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(singletonList(relationship));
 		when(translator.toFhirResource(relationship)).thenReturn(relatedPerson);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -472,6 +479,7 @@ public class FhirRelatedPersonServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(singletonList(relationship));
 		when(translator.toFhirResource(relationship)).thenReturn(relatedPerson);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -516,6 +524,7 @@ public class FhirRelatedPersonServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(singletonList(relationship));
 		when(translator.toFhirResource(relationship)).thenReturn(relatedPerson);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -560,6 +569,7 @@ public class FhirRelatedPersonServiceImplTest {
 		when(dao.getSearchResults(any())).thenReturn(singletonList(relationship));
 		when(dao.getSearchResultsCount(any())).thenReturn(1);
 		when(translator.toFhirResource(relationship)).thenReturn(relatedPerson);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -599,6 +609,7 @@ public class FhirRelatedPersonServiceImplTest {
 		when(dao.getSearchResults(any())).thenReturn(singletonList(relationship));
 		when(dao.getSearchResultsCount(any())).thenReturn(1);
 		when(translator.toFhirResource(relationship)).thenReturn(relatedPerson);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -638,6 +649,7 @@ public class FhirRelatedPersonServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(singletonList(relationship));
 		when(translator.toFhirResource(relationship)).thenReturn(relatedPerson);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.singleton(new Patient()));
@@ -661,6 +673,7 @@ public class FhirRelatedPersonServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(singletonList(relationship));
 		when(translator.toFhirResource(relationship)).thenReturn(relatedPerson);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());

--- a/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirServiceRequestServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirServiceRequestServiceImplTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hl7.fhir.r4.model.Patient.SP_GIVEN;
 import static org.hl7.fhir.r4.model.Practitioner.SP_IDENTIFIER;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.when;
 import static org.openmrs.module.fhir2.FhirConstants.CODED_SEARCH_HANDLER;
 import static org.openmrs.module.fhir2.FhirConstants.DATE_RANGE_SEARCH_HANDLER;
@@ -152,6 +153,7 @@ public class FhirServiceRequestServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(Collections.singletonList(order));
 		when(translator.toFhirResource(order)).thenReturn(fhirServiceRequest);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -175,6 +177,7 @@ public class FhirServiceRequestServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(Collections.singletonList(order));
 		when(translator.toFhirResource(order)).thenReturn(fhirServiceRequest);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -199,6 +202,7 @@ public class FhirServiceRequestServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(Collections.singletonList(order));
 		when(translator.toFhirResource(order)).thenReturn(fhirServiceRequest);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -223,6 +227,7 @@ public class FhirServiceRequestServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(Collections.singletonList(order));
 		when(translator.toFhirResource(order)).thenReturn(fhirServiceRequest);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -246,6 +251,7 @@ public class FhirServiceRequestServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(Collections.singletonList(order));
 		when(translator.toFhirResource(order)).thenReturn(fhirServiceRequest);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -269,6 +275,7 @@ public class FhirServiceRequestServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(Collections.singletonList(order));
 		when(translator.toFhirResource(order)).thenReturn(fhirServiceRequest);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -292,6 +299,7 @@ public class FhirServiceRequestServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(Collections.singletonList(order));
 		when(translator.toFhirResource(order)).thenReturn(fhirServiceRequest);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
@@ -315,6 +323,7 @@ public class FhirServiceRequestServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(Collections.singletonList(order));
 		when(translator.toFhirResource(order)).thenReturn(fhirServiceRequest);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.singleton(new Patient()));
@@ -339,6 +348,7 @@ public class FhirServiceRequestServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(Collections.singletonList(order));
 		when(translator.toFhirResource(order)).thenReturn(fhirServiceRequest);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.singleton(new Patient()));
@@ -362,6 +372,7 @@ public class FhirServiceRequestServiceImplTest {
 		
 		when(dao.getSearchResults(any())).thenReturn(Collections.singletonList(order));
 		when(translator.toFhirResource(order)).thenReturn(fhirServiceRequest);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());

--- a/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirTaskServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirTaskServiceImplTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -214,6 +215,7 @@ public class FhirTaskServiceImplTest {
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, fhirGlobalPropertyService, searchQueryInclude));
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		when(translator.toFhirResource(openmrsTask)).thenReturn(task);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = fhirTaskService
 		        .searchForTasks(new TaskSearchParams(null, null, null, null, null, null, null, null, null));

--- a/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirUserServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirUserServiceImplTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.when;
 import static org.openmrs.module.fhir2.FhirConstants.ADDRESS_SEARCH_HANDLER;
 import static org.openmrs.module.fhir2.FhirConstants.CITY_PROPERTY;
@@ -160,6 +161,7 @@ public class FhirUserServiceImplTest {
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(translator.toFhirResource(user)).thenReturn(practitioner);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		
 		IBundleProvider results = userService.searchForUsers(theParams);
@@ -197,6 +199,7 @@ public class FhirUserServiceImplTest {
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(translator.toFhirResource(user)).thenReturn(practitioner);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		
 		IBundleProvider results = userService.searchForUsers(theParams);
@@ -234,6 +237,7 @@ public class FhirUserServiceImplTest {
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(translator.toFhirResource(user)).thenReturn(practitioner);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		
 		IBundleProvider results = userService.searchForUsers(theParams);
@@ -271,6 +275,7 @@ public class FhirUserServiceImplTest {
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(translator.toFhirResource(user)).thenReturn(practitioner);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		
 		IBundleProvider results = userService.searchForUsers(theParams);
@@ -309,6 +314,7 @@ public class FhirUserServiceImplTest {
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(translator.toFhirResource(user)).thenReturn(practitioner);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		
 		IBundleProvider results = userService.searchForUsers(theParams);
@@ -347,6 +353,7 @@ public class FhirUserServiceImplTest {
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(translator.toFhirResource(user)).thenReturn(practitioner);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		
 		IBundleProvider results = userService.searchForUsers(theParams);
@@ -385,6 +392,7 @@ public class FhirUserServiceImplTest {
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(translator.toFhirResource(user)).thenReturn(practitioner);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		
 		IBundleProvider results = userService.searchForUsers(theParams);
@@ -426,6 +434,7 @@ public class FhirUserServiceImplTest {
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(translator.toFhirResource(user)).thenReturn(practitioner);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = userService.searchForUsers(theParams);
 		
@@ -467,6 +476,7 @@ public class FhirUserServiceImplTest {
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(translator.toFhirResource(user)).thenReturn(practitioner);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		
 		IBundleProvider results = userService.searchForUsers(theParams);
 		

--- a/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirValueSetServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/impl/FhirValueSetServiceImplTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
@@ -120,6 +121,7 @@ public class FhirValueSetServiceImplTest {
 		when(searchQuery.getQueryResults(any(), any(), any(), any())).thenReturn(
 		    new SearchQueryBundleProvider<>(theParams, dao, translator, globalPropertyService, searchQueryInclude));
 		when(translator.toFhirResource(concept)).thenReturn(valueSet);
+		when(translator.toFhirResources(anyCollection())).thenCallRealMethod();
 		when(searchQueryInclude.getIncludedResources(any(), any())).thenReturn(Collections.emptySet());
 		
 		IBundleProvider results = fhirValueSetService.searchForValueSets(titleParam);

--- a/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/LocationTranslatorImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/LocationTranslatorImplTest.java
@@ -274,28 +274,6 @@ public class LocationTranslatorImplTest {
 	}
 	
 	@Test
-	public void getLocationContactDetails_shouldWorkAsExpected() {
-		Location omrsLocation = new Location();
-		omrsLocation.setUuid(LOCATION_UUID);
-		
-		LocationAttribute locationAttribute = new LocationAttribute();
-		locationAttribute.setUuid(LOCATION_ATTRIBUTE_UUID);
-		locationAttribute.setValue(LOCATION_ATTRIBUTE_VALUE);
-		
-		LocationAttributeType attributeType = new LocationAttributeType();
-		attributeType.setUuid(LOCATION_ATTRIBUTE_TYPE_UUID);
-		attributeType.setName(LOCATION_ATTRIBUTE_TYPE_NAME);
-		locationAttribute.setAttributeType(attributeType);
-		omrsLocation.setAttribute(locationAttribute);
-		
-		List<ContactPoint> contactPoints = locationTranslator.getLocationContactDetails(omrsLocation);
-		
-		assertThat(contactPoints, notNullValue());
-		assertThat(omrsLocation.getActiveAttributes().size(), equalTo(1));
-		
-	}
-	
-	@Test
 	public void toFhirResource_shouldTranslateOpenmrsTagsToFhirLocationTags() {
 		LocationTag tag = new LocationTag(LOGIN_TAG_NAME, LOGIN_TAG_DESCRIPTION);
 		omrsLocation.addTag(tag);

--- a/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/LocationTranslatorImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/LocationTranslatorImplTest.java
@@ -23,9 +23,12 @@ import static org.openmrs.module.fhir2.api.translators.impl.ReferenceHandlingTra
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.exparity.hamcrest.date.DateMatchers;
 import org.hl7.fhir.r4.model.CodeableConcept;
@@ -65,10 +68,6 @@ public class LocationTranslatorImplTest {
 	
 	private static final String LOCATION_LONGITUDE = "25.5";
 	
-	private static final String CONTACT_POINT_ID = "787e12bd-314e-4cc4-9b4d-1cdff9be9545";
-	
-	private static final String CONTACT_POINT_VALUE = "Pipeline";
-	
 	private static final String LOCATION_ATTRIBUTE_UUID = "b1aaf1e6-28e9-4736-a5a1-52960e282700";
 	
 	private static final String LOCATION_ATTRIBUTE_VALUE = "Neiya street";
@@ -92,7 +91,7 @@ public class LocationTranslatorImplTest {
 	@Mock
 	private LocationAddressTranslator locationAddressTranslator;
 	
-	private LocationReferenceTranslator locationReferenceTranslator = new LocationReferenceTranslatorImpl();
+	private final LocationReferenceTranslator locationReferenceTranslator = new LocationReferenceTranslatorImpl();
 	
 	@Mock
 	private LocationTagTranslator locationTagTranslator;
@@ -132,6 +131,7 @@ public class LocationTranslatorImplTest {
 	@Test
 	public void shouldTranslateOpenmrsLocationToFhirLocation() {
 		org.hl7.fhir.r4.model.Location fhirLocation = locationTranslator.toFhirResource(omrsLocation);
+		
 		assertThat(omrsLocation, notNullValue());
 		assertThat(fhirLocation, notNullValue());
 		assertThat(omrsLocation.getName(), equalTo(fhirLocation.getName()));
@@ -140,7 +140,9 @@ public class LocationTranslatorImplTest {
 	@Test
 	public void shouldTranslateLocationUuidToFhirIdType() {
 		omrsLocation.setUuid(LOCATION_UUID);
+		
 		org.hl7.fhir.r4.model.Location fhirLocation = locationTranslator.toFhirResource(omrsLocation);
+		
 		assertThat(fhirLocation, notNullValue());
 		assertThat(fhirLocation.getId(), notNullValue());
 		assertThat(fhirLocation.getId(), equalTo(LOCATION_UUID));
@@ -149,7 +151,9 @@ public class LocationTranslatorImplTest {
 	@Test
 	public void shouldTranslateLocationNameToFhirNameType() {
 		omrsLocation.setName(LOCATION_NAME);
+		
 		org.hl7.fhir.r4.model.Location fhirLocation = locationTranslator.toFhirResource(omrsLocation);
+		
 		assertThat(fhirLocation, notNullValue());
 		assertThat(fhirLocation.getName(), notNullValue());
 		assertThat(fhirLocation.getName(), equalTo(LOCATION_NAME));
@@ -158,7 +162,9 @@ public class LocationTranslatorImplTest {
 	@Test
 	public void shouldTranslateLocationDescriptionToFhirDescriptionType() {
 		omrsLocation.setDescription(LOCATION_DESCRIPTION);
+		
 		org.hl7.fhir.r4.model.Location fhirLocation = locationTranslator.toFhirResource(omrsLocation);
+		
 		assertThat(fhirLocation, notNullValue());
 		assertThat(fhirLocation.getDescription(), notNullValue());
 		assertThat(fhirLocation.getDescription(), equalTo(LOCATION_DESCRIPTION));
@@ -167,7 +173,9 @@ public class LocationTranslatorImplTest {
 	@Test
 	public void shouldTranslateFhirLocationToOmrsLocation() {
 		org.hl7.fhir.r4.model.Location location = new org.hl7.fhir.r4.model.Location();
+		
 		org.openmrs.Location omrsLocation = locationTranslator.toOpenmrsType(location);
+		
 		assertThat(omrsLocation, notNullValue());
 		assertThat(omrsLocation.getName(), equalTo(location.getName()));
 	}
@@ -176,7 +184,9 @@ public class LocationTranslatorImplTest {
 	public void shouldTranslateLocationIdToUuid() {
 		org.hl7.fhir.r4.model.Location location = new org.hl7.fhir.r4.model.Location();
 		location.setId(LOCATION_UUID);
+		
 		org.openmrs.Location omrsLocation = locationTranslator.toOpenmrsType(location);
+		
 		assertThat(omrsLocation, notNullValue());
 		assertThat(omrsLocation.getUuid(), notNullValue());
 		assertThat(omrsLocation.getUuid(), equalTo(LOCATION_UUID));
@@ -196,7 +206,9 @@ public class LocationTranslatorImplTest {
 	public void shouldTranslateLocationDescriptionToOpenmrsDescriptionType() {
 		org.hl7.fhir.r4.model.Location location = new org.hl7.fhir.r4.model.Location();
 		location.setDescription(LOCATION_DESCRIPTION);
+		
 		org.openmrs.Location omrsLocation = locationTranslator.toOpenmrsType(location);
+		
 		assertThat(omrsLocation, notNullValue());
 		assertThat(omrsLocation.getDescription(), notNullValue());
 		assertThat(omrsLocation.getDescription(), equalTo(LOCATION_DESCRIPTION));
@@ -206,7 +218,9 @@ public class LocationTranslatorImplTest {
 	public void shouldCreateFhirPositionObjectFromLatitudeAndLongitude() {
 		omrsLocation.setLatitude(LOCATION_LATITUDE);
 		omrsLocation.setLongitude(LOCATION_LONGITUDE);
+		
 		org.hl7.fhir.r4.model.Location fhirLocation = locationTranslator.toFhirResource(omrsLocation);
+		
 		assertThat(fhirLocation, notNullValue());
 		assertThat(fhirLocation.getPosition(), notNullValue());
 		assertThat(fhirLocation.getPosition().getLatitude(), notNullValue());
@@ -216,7 +230,9 @@ public class LocationTranslatorImplTest {
 	@Test
 	public void shouldSetFhirLocationToActiveIfLocationIsNotRetired() {
 		omrsLocation.setRetired(false);
+		
 		org.hl7.fhir.r4.model.Location fhirLocation = locationTranslator.toFhirResource(omrsLocation);
+		
 		assertThat(fhirLocation, notNullValue());
 		assertThat(fhirLocation.getStatus(), equalTo(org.hl7.fhir.r4.model.Location.LocationStatus.ACTIVE));
 	}
@@ -224,17 +240,15 @@ public class LocationTranslatorImplTest {
 	@Test
 	public void shouldSetFhirLocationToInActiveIfLocationIsRetired() {
 		omrsLocation.setRetired(true);
+		
 		org.hl7.fhir.r4.model.Location fhirLocation = locationTranslator.toFhirResource(omrsLocation);
+		
 		assertThat(fhirLocation, notNullValue());
 		assertThat(fhirLocation.getStatus(), equalTo(org.hl7.fhir.r4.model.Location.LocationStatus.INACTIVE));
 	}
 	
 	@Test
 	public void shouldTranslateLocationAttributeToFhirContactPoint() {
-		ContactPoint contactPoint = new ContactPoint();
-		contactPoint.setId(CONTACT_POINT_ID);
-		contactPoint.setValue(CONTACT_POINT_VALUE);
-		
 		LocationAttribute locationAttribute = new LocationAttribute();
 		locationAttribute.setUuid(LOCATION_ATTRIBUTE_UUID);
 		locationAttribute.setValue(LOCATION_ATTRIBUTE_VALUE);
@@ -244,9 +258,29 @@ public class LocationTranslatorImplTest {
 		attributeType.setUuid(LOCATION_ATTRIBUTE_TYPE_UUID);
 		locationAttribute.setAttributeType(attributeType);
 		
-		org.hl7.fhir.r4.model.Location location = locationTranslator.toFhirResource(new Location());
+		Location omrsLocation = new Location();
+		omrsLocation.setUuid(LOCATION_UUID);
+		omrsLocation.addAttribute(locationAttribute);
+		
+		when(propertyService.getGlobalProperty(FhirConstants.LOCATION_CONTACT_POINT_ATTRIBUTE_TYPE))
+		        .thenReturn(LOCATION_ATTRIBUTE_TYPE_UUID);
+		
+		Map<Location, List<LocationAttribute>> activeAttributeMap = new HashMap<>(1);
+		activeAttributeMap.put(omrsLocation, Collections.singletonList(locationAttribute));
+		when(fhirLocationDao.getActiveAttributesByLocationsAndAttributeTypeUuid(any(Collection.class),
+		    eq(LOCATION_ATTRIBUTE_TYPE_UUID))).thenReturn(activeAttributeMap);
+		
+		ContactPoint contactPoint = new ContactPoint();
+		contactPoint.setId(LOCATION_ATTRIBUTE_UUID);
+		contactPoint.setValue(LOCATION_ATTRIBUTE_VALUE);
+		when(telecomTranslator.toFhirResource(locationAttribute)).thenReturn(contactPoint);
+		
+		org.hl7.fhir.r4.model.Location location = locationTranslator.toFhirResource(omrsLocation);
+		
 		assertThat(location, notNullValue());
-		assertThat(location.getTelecom(), notNullValue());
+		assertThat(location.hasTelecom(), equalTo(true));
+		assertThat(location.getTelecom(), hasSize(greaterThanOrEqualTo(1)));
+		assertThat(location.getTelecom().get(0).getValue(), equalTo(LOCATION_ATTRIBUTE_VALUE));
 	}
 	
 	@Test
@@ -268,6 +302,7 @@ public class LocationTranslatorImplTest {
 		when(telecomTranslator.toOpenmrsType(any(LocationAttribute.class), eq(contactPoint))).thenReturn(locationAttribute);
 		
 		Location omrsLocation = locationTranslator.toOpenmrsType(location);
+		
 		assertThat(omrsLocation, notNullValue());
 		assertThat(omrsLocation.getAttributes(), notNullValue());
 		assertThat(omrsLocation.getAttributes(), hasSize(greaterThanOrEqualTo(1)));
@@ -277,7 +312,9 @@ public class LocationTranslatorImplTest {
 	public void toFhirResource_shouldTranslateOpenmrsTagsToFhirLocationTags() {
 		LocationTag tag = new LocationTag(LOGIN_TAG_NAME, LOGIN_TAG_DESCRIPTION);
 		omrsLocation.addTag(tag);
+		
 		org.hl7.fhir.r4.model.Location fhirLocation = locationTranslator.toFhirResource(omrsLocation);
+		
 		assertThat(fhirLocation.getMeta().getTag(), notNullValue());
 		assertThat(fhirLocation.getMeta().getTag(), hasSize(greaterThanOrEqualTo(1)));
 		assertThat(fhirLocation.getMeta().getTag().get(0).getCode(), is(LOGIN_TAG_NAME));
@@ -287,14 +324,19 @@ public class LocationTranslatorImplTest {
 	public void toOpenmrsType_shouldTranslateFhirTagsToOpenmrsLocationTags() {
 		LocationTag omrsTag = new LocationTag(LAB_TAG_NAME, LAB_TAG_DESCRIPTION);
 		List<Coding> tags = new ArrayList<>();
+		
 		Coding tag = new Coding();
 		tag.setCode(LAB_TAG_NAME);
 		tag.setDisplay(LAB_TAG_DESCRIPTION);
 		tags.add(tag);
+		
 		org.hl7.fhir.r4.model.Location fhirLocation = new org.hl7.fhir.r4.model.Location();
 		fhirLocation.getMeta().setTag(tags);
+		
 		when(locationTagTranslator.toOpenmrsType(tag)).thenReturn(omrsTag);
+		
 		omrsLocation = locationTranslator.toOpenmrsType(fhirLocation);
+		
 		assertThat(omrsLocation.getTags(), notNullValue());
 		assertThat(omrsLocation.getTags(), hasSize(greaterThanOrEqualTo(1)));
 		assertThat(omrsLocation.getTags().iterator().next().getName(), is(LAB_TAG_NAME));
@@ -348,6 +390,7 @@ public class LocationTranslatorImplTest {
 		omrsLocation.setDateChanged(new Date());
 		
 		org.hl7.fhir.r4.model.Location location = locationTranslator.toFhirResource(omrsLocation);
+		
 		assertThat(location, notNullValue());
 		assertThat(location.getMeta().getLastUpdated(), DateMatchers.sameDay(new Date()));
 	}
@@ -357,6 +400,7 @@ public class LocationTranslatorImplTest {
 		omrsLocation.setDateChanged(new Date());
 		
 		org.hl7.fhir.r4.model.Location location = locationTranslator.toFhirResource(omrsLocation);
+		
 		assertThat(location, notNullValue());
 		assertThat(location.getMeta().getVersionId(), notNullValue());
 	}
@@ -405,9 +449,12 @@ public class LocationTranslatorImplTest {
 		org.hl7.fhir.r4.model.Location.LocationPositionComponent position = new org.hl7.fhir.r4.model.Location.LocationPositionComponent();
 		position.setLatitude(new BigDecimal(LOCATION_LATITUDE));
 		position.setLongitude(new BigDecimal(LOCATION_LONGITUDE));
+		
 		org.hl7.fhir.r4.model.Location location = new org.hl7.fhir.r4.model.Location();
 		location.setPosition(position);
+		
 		org.openmrs.Location omrsLocation = locationTranslator.toOpenmrsType(location);
+		
 		assertThat(omrsLocation, notNullValue());
 		assertThat(omrsLocation.getLatitude(), is(LOCATION_LATITUDE));
 		assertThat(omrsLocation.getLongitude(), is(LOCATION_LONGITUDE));


### PR DESCRIPTION
## Description of what I changed

This is a performance improvement / a PoC of possibilities of performance improvements around FHIR API. This change implements a simple idea of "less db queries, faster application".
The `ToFhirTranslator` has been extended with a new method - `toFhirResources(Collection)` - which intention is to handle multiple OpenMRS data elements together. All existing implementations of `ToFhirTranslator` use default implementation of `toFhirResources(Collection)` that simple delegates to existing `toFhirResource(Data)`, with an exception of `LocationTranslator`. 

The general logic of getting FHIR Location **before** the change:
1. Read OpenMRS Locations according to specified query.
2. For each OpenMRS Location
    1. Read Location Contact Details.
    3. Read other properties.

The general logic of getting FHIR Location **after** the change:
1. Read OpenMRS Locations according to specified query.
2. Read Contact Details referenced by Locations from 1st point. 
3. For each OpenMRS Location
    1. Look-up Location Contact Details from preloaded collection.
    2. Read other properties.

The `Contact Details` has been selected as the property that loading had the most time cost - **67% of time spend on creation of FHIR Location was spent on Contact Details**.

The change provides **an overall speedup of 70-85%**.

See https://talk.openmrs.org/t/how-to-help-with-o3-performance/45157

## Issue I worked on
see https://openmrs.atlassian.net/browse/O3-4544

## Checklist: I completed these to help reviewers :)
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.
