### PR TITLE
FM2-126 (Updated) Add support for mapping OpenMRS attribute types to FHIR

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhir2/FhirConstants.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/FhirConstants.java
@@ -98,6 +98,12 @@ public final class FhirConstants {
 	
 	public static final String OPENMRS_FHIR_EXT_USER_IDENTIFIER = OPENMRS_FHIR_EXT_PREFIX + "/user/identifier";
 	
+	public static final String OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE = OPENMRS_FHIR_EXT_PREFIX + "/person-attribute";
+	
+	public static final String OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE_TYPE = OPENMRS_FHIR_EXT_PREFIX + "/person-attribute-type";
+	
+	public static final String OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE_VALUE = OPENMRS_FHIR_EXT_PREFIX + "/person-attribute-value";
+	
 	public static final String OPENMRS_FHIR_EXT_PROVIDER_IDENTIFIER = OPENMRS_FHIR_EXT_PREFIX + "/provider/identifier";
 	
 	public static final String OPENMRS_FHIR_EXT_LOCATION_TAG = OPENMRS_FHIR_EXT_PREFIX + "/location-tag";

--- a/api/src/main/java/org/openmrs/module/fhir2/api/translators/PersonAttributeTranslator.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/translators/PersonAttributeTranslator.java
@@ -1,0 +1,46 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.fhir2.api.translators;
+
+import javax.annotation.Nonnull;
+
+import org.hl7.fhir.r4.model.Extension;
+import org.openmrs.PersonAttribute;
+
+public interface PersonAttributeTranslator extends OpenmrsFhirUpdatableTranslator<org.openmrs.PersonAttribute, Extension> {
+	
+	/**
+	 * Maps a {@link PersonAttribute} to a {@link Extension}
+	 *
+	 * @param personAttribute the attribute to translate in extension
+	 * @return the corresponding FHIR Extension
+	 */
+	@Override
+	Extension toFhirResource(@Nonnull PersonAttribute personAttribute);
+	
+	/**
+	 * Maps a {@link Extension} to a {@link PersonAttribute}
+	 *
+	 * @param extension the extension with attribute information
+	 * @return the corresponding Person Attribute
+	 */
+	@Override
+	PersonAttribute toOpenmrsType(@Nonnull Extension extension);
+	
+	/**
+	 * Maps a {@link Extension} to an existing {@link PersonAttribute}
+	 *
+	 * @param personAttribute the attribute to update
+	 * @param extension the extension with attribute information
+	 * @return the updated Person Attribute
+	 */
+	@Override
+	PersonAttribute toOpenmrsType(@Nonnull PersonAttribute personAttribute, @Nonnull Extension extension);
+}

--- a/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/PatientTranslatorImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/PatientTranslatorImpl.java
@@ -15,18 +15,22 @@ import static org.openmrs.module.fhir2.api.translators.impl.FhirTranslatorUtils.
 
 import javax.annotation.Nonnull;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import lombok.AccessLevel;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.model.Address;
 import org.hl7.fhir.r4.model.BooleanType;
 import org.hl7.fhir.r4.model.ContactPoint;
 import org.hl7.fhir.r4.model.DateTimeType;
+import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.HumanName;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Patient;
@@ -48,6 +52,7 @@ import org.openmrs.module.fhir2.api.translators.TelecomTranslator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @Setter(AccessLevel.PACKAGE)
 public class PatientTranslatorImpl implements PatientTranslator {
@@ -75,6 +80,9 @@ public class PatientTranslatorImpl implements PatientTranslator {
 	
 	@Autowired
 	private TelecomTranslator<BaseOpenmrsData> telecomTranslator;
+	
+	@Autowired
+	private PersonAttributeTranslatorImpl personAttributeTranslator;
 	
 	@Override
 	public Patient toFhirResource(@Nonnull org.openmrs.Patient openmrsPatient) {
@@ -112,6 +120,10 @@ public class PatientTranslatorImpl implements PatientTranslator {
 			patient.addAddress(addressTranslator.toFhirResource(address));
 		}
 		
+		if (!openmrsPatient.getAttributes().isEmpty()) {
+			patient.setExtension(getPersonAttributeExtensions(openmrsPatient));
+		}
+		
 		patient.setTelecom(getPatientContactDetails(openmrsPatient));
 		patient.getMeta().setLastUpdated(getLastUpdated(openmrsPatient));
 		patient.getMeta().setVersionId(getVersionId(openmrsPatient));
@@ -129,6 +141,17 @@ public class PatientTranslatorImpl implements PatientTranslator {
 		
 		return fhirPersonDao.getActiveAttributesByPersonAndAttributeTypeUuid(patient, personContactAttributeType).stream()
 		        .map(telecomTranslator::toFhirResource).collect(Collectors.toList());
+	}
+	
+	public List<Extension> getPersonAttributeExtensions(@Nonnull org.openmrs.Patient openmrsPatient) {
+		List<Extension> personAttributeExtensions = new ArrayList<>();
+		Set<PersonAttribute> personAttributes = openmrsPatient.getAttributes();
+		
+		for (PersonAttribute personAttribute : personAttributes) {
+			personAttributeExtensions.add(personAttributeTranslator.toFhirResource(personAttribute));
+		}
+		
+		return personAttributeExtensions;
 	}
 	
 	@Override
@@ -196,6 +219,19 @@ public class PatientTranslatorImpl implements PatientTranslator {
 		patient.getTelecom().stream()
 		        .map(contactPoint -> (PersonAttribute) telecomTranslator.toOpenmrsType(new PersonAttribute(), contactPoint))
 		        .distinct().filter(Objects::nonNull).forEach(currentPatient::addAttribute);
+		
+		List<Extension> patientAttributeExtensions = patient.getExtension().stream()
+		        .filter(extension -> extension.getUrl().equals(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE))
+		        .collect(Collectors.toList());
+		
+		for (Extension patientAttributeExtension : patientAttributeExtensions) {
+			PersonAttribute personAttribute = personAttributeTranslator.toOpenmrsType(patientAttributeExtension);
+			if (personAttribute == null) {
+				log.warn("The patient has invalid PersonAttribute extension");
+			} else {
+				currentPatient.addAttribute(personAttribute);
+			}
+		}
 		
 		return currentPatient;
 	}

--- a/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/PersonAttributeTranslatorImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/PersonAttributeTranslatorImpl.java
@@ -1,0 +1,220 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.fhir2.api.translators.impl;
+
+import javax.annotation.Nonnull;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import lombok.extern.slf4j.Slf4j;
+import org.hl7.fhir.r4.model.BooleanType;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.StringType;
+import org.hl7.fhir.r4.model.Type;
+import org.hl7.fhir.r4.model.UriType;
+import org.openmrs.Concept;
+import org.openmrs.Location;
+import org.openmrs.PersonAttribute;
+import org.openmrs.PersonAttributeType;
+import org.openmrs.api.ConceptService;
+import org.openmrs.api.LocationService;
+import org.openmrs.api.PersonService;
+import org.openmrs.module.fhir2.FhirConstants;
+import org.openmrs.module.fhir2.api.translators.ConceptTranslator;
+import org.openmrs.module.fhir2.api.translators.PersonAttributeTranslator;
+import org.openmrs.module.fhir2.api.util.FhirUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class PersonAttributeTranslatorImpl implements PersonAttributeTranslator {
+	
+	private static final String JAVA_STRING_FORMAT = "java.lang.String";
+	
+	private static final String JAVA_BOOLEAN_FORMAT = "java.lang.Boolean";
+	
+	private static final String OPENMRS_LOCATION_FORMAT = "org.openmrs.Location";
+	
+	private static final String OPENMRS_CONCEPT_FORMAT = "org.openmrs.Concept";
+	
+	private static final String LOCATION_TYPE = "Location";
+	
+	@Autowired
+	private LocationService locationService;
+	
+	@Autowired
+	private PersonService personService;
+	
+	@Autowired
+	private ConceptService conceptService;
+	
+	@Autowired
+	private ConceptTranslator conceptTranslator;
+	
+	@Override
+	public Extension toFhirResource(@Nonnull PersonAttribute personAttribute) {
+		if (personAttribute == null || personAttribute.getAttributeType() == null) {
+			return null;
+		}
+		
+		return createPersonAttributeExtension(personAttribute);
+	}
+	
+	@Override
+	public PersonAttribute toOpenmrsType(@Nonnull Extension extension) {
+		if (extension == null) {
+			return null;
+		}
+		
+		return toOpenmrsType(new PersonAttribute(), extension);
+	}
+	
+	@Override
+	public PersonAttribute toOpenmrsType(@Nonnull PersonAttribute personAttribute,
+	        @Nonnull Extension personAttributeExtension) {
+		if (!isValidPatientAttributeExtension(personAttributeExtension)) {
+			return null;
+		}
+		
+		String attributeTypeName = extractAttributeTypeName(personAttributeExtension);
+		
+		try {
+			PersonAttributeType personAttributeType = personService.getPersonAttributeTypeByName(attributeTypeName);
+			if (personAttributeType != null) {
+				personAttribute.setAttributeType(personAttributeType);
+			}
+		}
+		catch (Exception e) {
+			log.warn("Error encountered while setting person attribute type for name: {}", attributeTypeName);
+		}
+		
+		Extension valueExtension = personAttributeExtension
+		        .getExtensionByUrl(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE_VALUE);
+		if (valueExtension.hasValue()) {
+			setPersonAttributeValue(personAttribute, valueExtension.getValue());
+		}
+		
+		return personAttribute;
+	}
+	
+	private Extension createPersonAttributeExtension(PersonAttribute personAttribute) {
+		PersonAttributeType attributeType = personAttribute.getAttributeType();
+		
+		//Type Extension
+		StringType personAttributeTypeValue = new StringType(attributeType.getName());
+		Extension personAttributeTypeExtension = new Extension(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE_TYPE);
+		personAttributeTypeExtension.setValue(personAttributeTypeValue);
+		
+		//Value Extension
+		Extension valueExtension = new Extension(new UriType(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE_VALUE));
+		setValueExtension(valueExtension, personAttribute);
+		
+		//Person Attribute Extension
+		Extension personAttributeExtension = new Extension(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE);
+		personAttributeExtension.setExtension(Arrays.asList(personAttributeTypeExtension, valueExtension));
+		return personAttributeExtension;
+	}
+	
+	private void setValueExtension(Extension valueExtension, PersonAttribute personAttribute) {
+		String format = personAttribute.getAttributeType().getFormat();
+		String value = personAttribute.getValue();
+		
+		switch (format) {
+			case JAVA_STRING_FORMAT:
+				valueExtension.setValue(new StringType(value));
+				break;
+			case JAVA_BOOLEAN_FORMAT:
+				valueExtension.setValue(new BooleanType(value));
+				break;
+			case OPENMRS_LOCATION_FORMAT:
+				handleLocationFormat(valueExtension, value);
+				break;
+			case OPENMRS_CONCEPT_FORMAT:
+				handleConceptFormat(valueExtension, value);
+				break;
+			default:
+				log.warn("extension has unsupported patient attribute type format: {}", format);
+				valueExtension.setValue(null);
+		}
+	}
+	
+	private void handleLocationFormat(Extension valueExtension, String locationId) {
+		if (locationId == null) {
+			return;
+		}
+		
+		Location openmrsLocation = locationService.getLocation(Integer.parseInt(locationId));
+		
+		if (openmrsLocation != null) {
+			String locationUUID = openmrsLocation.getUuid();
+			Reference locationReference = new Reference().setType(LOCATION_TYPE)
+			        .setReference(LOCATION_TYPE + "/" + locationUUID);
+			locationReference.setDisplay(openmrsLocation.getDisplayString());
+			valueExtension.setValue(locationReference);
+		}
+	}
+	
+	private void handleConceptFormat(Extension valueExtension, String conceptId) {
+		if (conceptId == null) {
+			return;
+		}
+		
+		Concept concept = conceptService.getConcept(conceptId);
+		if (concept != null) {
+			CodeableConcept codeableConcept = conceptTranslator.toFhirResource(concept);
+			valueExtension.setValue(codeableConcept);
+		}
+		
+	}
+	
+	private boolean isValidPatientAttributeExtension(Extension extension) {
+		return extension != null && extension.hasUrl()
+		        && extension.getUrl().equals(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE) && extension.hasExtension()
+		        && extension.getExtension().size() == 2
+		        && extension.getExtensionByUrl(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE_TYPE) != null
+		        && extension.getExtensionByUrl(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE_VALUE) != null
+		        && extension.getExtensionByUrl(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE_TYPE).hasValue()
+		        && extension.getExtensionByUrl(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE_VALUE).hasValue();
+	}
+	
+	private String extractAttributeTypeName(Extension personAttributeExtension) {
+		return personAttributeExtension.getExtensionByUrl(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE_TYPE).getValue()
+		        .toString();
+	}
+	
+	private void setPersonAttributeValue(PersonAttribute personAttribute, Type extensionValue) {
+		if (extensionValue instanceof BooleanType) {
+			personAttribute.setValue(((BooleanType) extensionValue).getValueAsString());
+		} else if (extensionValue instanceof StringType) {
+			personAttribute.setValue(((StringType) extensionValue).getValue());
+		} else if (extensionValue instanceof Reference) {
+			String reference = ((Reference) extensionValue).getReference();
+			Optional<String> locationUUID = FhirUtils.referenceToId(reference);
+			if (locationUUID.isPresent()) {
+				Location location = locationService.getLocationByUuid(locationUUID.get());
+				if (location != null) {
+					personAttribute.setValue(location.getId().toString());
+				}
+			}
+		} else if (extensionValue instanceof CodeableConcept) {
+			Concept concept = conceptTranslator.toOpenmrsType((CodeableConcept) extensionValue);
+			if (concept != null) {
+				personAttribute.setValue(concept.getConceptId().toString());
+			}
+		} else {
+			log.warn("Extension value type: {} is not supported for PersonAttribute value",
+			    extensionValue.getClass().getSimpleName());
+		}
+	}
+}

--- a/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/PersonAttributeTranslatorImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/PersonAttributeTranslatorImplTest.java
@@ -1,0 +1,299 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.fhir2.api.translators.impl;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.hl7.fhir.r4.model.BooleanType;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.StringType;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openmrs.Concept;
+import org.openmrs.Location;
+import org.openmrs.PersonAttribute;
+import org.openmrs.PersonAttributeType;
+import org.openmrs.api.ConceptService;
+import org.openmrs.api.LocationService;
+import org.openmrs.api.PersonService;
+import org.openmrs.module.fhir2.FhirConstants;
+import org.openmrs.module.fhir2.api.translators.ConceptTranslator;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PersonAttributeTranslatorImplTest {
+	
+	private static final String PERSON_ATTRIBUTE_UUID = "12o3et5kl3-2e323-23g23-232h3y343s";
+	
+	private static final String ATTRIBUTE_TYPE_UUID = "14d4f066-15f5-102d-96e4-000c29c2a5d7";
+	
+	private static final String ATTRIBUTE_TYPE_NAME = "Contact";
+	
+	private static final String STRING_ATTRIBUTE_VALUE = "254723723456";
+	
+	private static final String BOOLEAN_ATTRIBUTE_VALUE = "true";
+	
+	private static final String CONCEPT_ATTRIBUTE_VALUE = "1000";
+	
+	private static final Integer LOCATION_ATTRIBUTE_ID = 1;
+	
+	private static final String LOCATION_ATTRIBUTE_UUID_VALUE = "ae919697-60a2-4f72-834c-e7d9df3ecf62";
+	
+	private static final String LOCATION_NAME = "Test Location";
+	
+	@Mock
+	private LocationService locationService;
+	
+	@Mock
+	private PersonService personService;
+	
+	@Mock
+	private ConceptService conceptService;
+	
+	@Mock
+	private ConceptTranslator conceptTranslator;
+	
+	@InjectMocks
+	private PersonAttributeTranslatorImpl personAttributeTranslator;
+	
+	private PersonAttribute personAttribute;
+	
+	private PersonAttributeType personAttributeType;
+	
+	@Before
+	public void setup() {
+		personAttributeType = new PersonAttributeType();
+		personAttributeType.setUuid(ATTRIBUTE_TYPE_UUID);
+		personAttributeType.setName(ATTRIBUTE_TYPE_NAME);
+		personAttributeType.setFormat("java.lang.String");
+		
+		personAttribute = new PersonAttribute();
+		personAttribute.setUuid(PERSON_ATTRIBUTE_UUID);
+		personAttribute.setAttributeType(personAttributeType);
+		personAttribute.setValue(STRING_ATTRIBUTE_VALUE);
+		
+		when(personService.getPersonAttributeTypeByName(ATTRIBUTE_TYPE_NAME)).thenReturn(personAttributeType);
+	}
+	
+	@Test
+	public void shouldTranslatePersonAttributeToFhirExtension() {
+		Extension result = personAttributeTranslator.toFhirResource(personAttribute);
+		
+		assertThat(result, notNullValue());
+		assertTrue(result.hasUrl());
+		assertTrue(result.hasExtension());
+		assertThat(result.getUrl(), equalTo(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE));
+		assertThat(result.getExtensionByUrl(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE_TYPE), notNullValue());
+		assertThat(result.getExtensionByUrl(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE_VALUE), notNullValue());
+		assertThat(result.getExtensionByUrl(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE_TYPE).getValue().toString(),
+		    equalTo(ATTRIBUTE_TYPE_NAME));
+		assertThat(result.getExtensionByUrl(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE_VALUE).getValue().toString(),
+		    notNullValue());
+		assertThat(((StringType) result.getExtensionByUrl(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE_VALUE).getValue())
+		        .toString(),
+		    equalTo(STRING_ATTRIBUTE_VALUE));
+	}
+	
+	@Test
+	public void shouldTranslateStringPersonAttributeToFhirExtension() {
+		personAttributeType.setFormat("java.lang.String");
+		personAttribute.setValue(STRING_ATTRIBUTE_VALUE);
+		
+		Extension result = personAttributeTranslator.toFhirResource(personAttribute);
+		Extension valueExtension = result.getExtensionByUrl(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE_VALUE);
+		
+		assertThat(result, notNullValue());
+		assertThat(valueExtension.getValue() instanceof StringType, is(true));
+		assertThat(((StringType) valueExtension.getValue()).getValue(), equalTo(STRING_ATTRIBUTE_VALUE));
+	}
+	
+	@Test
+	public void shouldTranslateBooleanPersonAttributeToFhirExtension() {
+		personAttributeType.setFormat("java.lang.Boolean");
+		personAttribute.setValue(BOOLEAN_ATTRIBUTE_VALUE);
+		
+		Extension result = personAttributeTranslator.toFhirResource(personAttribute);
+		Extension valueExtension = result.getExtensionByUrl(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE_VALUE);
+		
+		assertThat(result, notNullValue());
+		assertThat(valueExtension.getValue() instanceof BooleanType, is(true));
+		assertThat(((BooleanType) valueExtension.getValue()).getValue(), is(true));
+	}
+	
+	@Test
+	public void shouldTranslateLocationPersonAttributeToFhirExtension() {
+		personAttributeType.setFormat("org.openmrs.Location");
+		personAttribute.setValue(LOCATION_ATTRIBUTE_ID.toString());
+		
+		Location location = new Location();
+		location.setName(LOCATION_NAME);
+		location.setUuid(LOCATION_ATTRIBUTE_UUID_VALUE);
+		when(locationService.getLocation(LOCATION_ATTRIBUTE_ID)).thenReturn(location);
+		
+		Extension result = personAttributeTranslator.toFhirResource(personAttribute);
+		Extension valueExtension = result.getExtensionByUrl(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE_VALUE);
+		
+		assertThat(result, notNullValue());
+		assertThat(valueExtension.getValue() instanceof Reference, is(true));
+		Reference reference = (Reference) valueExtension.getValue();
+		assertThat(reference.getReference(), not("Location/" + LOCATION_ATTRIBUTE_ID));
+		assertThat(reference.getReference(), equalTo("Location/" + LOCATION_ATTRIBUTE_UUID_VALUE));
+		assertThat(reference.getDisplay(), equalTo(LOCATION_NAME));
+		assertThat(reference.getType(), equalTo("Location"));
+	}
+	
+	@Test
+	public void shouldTranslateConceptPersonAttributeToFhirExtension() {
+		personAttributeType.setFormat("org.openmrs.Concept");
+		personAttribute.setValue(CONCEPT_ATTRIBUTE_VALUE);
+		
+		Concept concept = new Concept();
+		concept.setConceptId(Integer.parseInt(CONCEPT_ATTRIBUTE_VALUE));
+		when(conceptService.getConcept(CONCEPT_ATTRIBUTE_VALUE)).thenReturn(concept);
+		
+		CodeableConcept codeableConcept = new CodeableConcept();
+		when(conceptTranslator.toFhirResource(concept)).thenReturn(codeableConcept);
+		
+		Extension result = personAttributeTranslator.toFhirResource(personAttribute);
+		Extension valueExtension = result.getExtensionByUrl(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE_VALUE);
+		
+		assertThat(result, notNullValue());
+		assertThat(valueExtension.getValue() instanceof CodeableConcept, is(true));
+		verify(conceptTranslator).toFhirResource(concept);
+	}
+	
+	@Test
+	public void shouldReturnNullWhenExtensionIsInvalid() {
+		Extension extension = new Extension();
+		extension.setUrl("invalid-url");
+		
+		PersonAttribute result = personAttributeTranslator.toOpenmrsType(extension);
+		
+		assertThat(result, equalTo(null));
+	}
+	
+	@Test
+	public void shouldTranslateStringTypeExtensionToPersonAttribute() {
+		Extension personAttributeTypeExtension = new Extension();
+		personAttributeTypeExtension.setUrl(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE_TYPE);
+		personAttributeTypeExtension.setValue(new StringType(ATTRIBUTE_TYPE_NAME));
+		
+		Extension personAttributeValueExtension = new Extension();
+		personAttributeValueExtension.setUrl(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE_VALUE);
+		personAttributeValueExtension.setValue(new StringType(STRING_ATTRIBUTE_VALUE));
+		
+		Extension extension = new Extension();
+		extension.setUrl(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE);
+		extension.addExtension(personAttributeTypeExtension);
+		extension.addExtension(personAttributeValueExtension);
+		
+		PersonAttribute result = personAttributeTranslator.toOpenmrsType(extension);
+		
+		assertThat(result, notNullValue());
+		assertThat(result.getAttributeType(), equalTo(personAttributeType));
+		assertThat(result.getValue(), equalTo(STRING_ATTRIBUTE_VALUE));
+	}
+	
+	@Test
+	public void shouldTranslateBooleanTypeExtensionToPersonAttribute() {
+		Extension personAttributeTypeExtension = new Extension();
+		personAttributeTypeExtension.setUrl(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE_TYPE);
+		personAttributeTypeExtension.setValue(new StringType(ATTRIBUTE_TYPE_NAME));
+		
+		Extension personAttributeValueExtension = new Extension();
+		personAttributeValueExtension.setUrl(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE_VALUE);
+		personAttributeValueExtension.setValue(new BooleanType(true));
+		
+		Extension extension = new Extension();
+		extension.setUrl(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE);
+		extension.addExtension(personAttributeTypeExtension);
+		extension.addExtension(personAttributeValueExtension);
+		
+		PersonAttribute result = personAttributeTranslator.toOpenmrsType(extension);
+		
+		assertThat(result, notNullValue());
+		assertThat(result.getAttributeType(), equalTo(personAttributeType));
+		assertThat(result.getValue(), equalTo("true"));
+	}
+	
+	@Test
+	public void shouldTranslateReferenceTypeExtensionToPersonAttribute() {
+		Extension personAttributeTypeExtension = new Extension();
+		personAttributeTypeExtension.setUrl(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE_TYPE);
+		personAttributeTypeExtension.setValue(new StringType(ATTRIBUTE_TYPE_NAME));
+		
+		Extension personAttributeValueExtension = new Extension();
+		personAttributeValueExtension.setUrl(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE_VALUE);
+		
+		Reference reference = new Reference();
+		reference.setReference("Location/" + LOCATION_ATTRIBUTE_UUID_VALUE);
+		personAttributeValueExtension.setValue(reference);
+		
+		Extension extension = new Extension();
+		extension.setUrl(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE);
+		extension.addExtension(personAttributeTypeExtension);
+		extension.addExtension(personAttributeValueExtension);
+		
+		Location location = new Location();
+		location.setName(LOCATION_NAME);
+		location.setId(LOCATION_ATTRIBUTE_ID);
+		location.setUuid(LOCATION_ATTRIBUTE_UUID_VALUE);
+		
+		when(locationService.getLocationByUuid(LOCATION_ATTRIBUTE_UUID_VALUE)).thenReturn(location);
+		
+		PersonAttribute result = personAttributeTranslator.toOpenmrsType(extension);
+		
+		assertThat(result, notNullValue());
+		assertThat(result.getAttributeType(), equalTo(personAttributeType));
+		assertThat(result.getValue(), equalTo(LOCATION_ATTRIBUTE_ID.toString()));
+	}
+	
+	@Test
+	public void shouldTranslateCodeableConceptTypeExtensionToPersonAttribute() {
+		Extension personAttributeTypeExtension = new Extension();
+		personAttributeTypeExtension.setUrl(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE_TYPE);
+		personAttributeTypeExtension.setValue(new StringType(ATTRIBUTE_TYPE_NAME));
+		
+		Extension personAttributeValueExtension = new Extension();
+		personAttributeValueExtension.setUrl(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE_VALUE);
+		
+		CodeableConcept codeableConcept = new CodeableConcept();
+		codeableConcept.setText("Test");
+		personAttributeValueExtension.setValue(codeableConcept);
+		
+		Extension extension = new Extension();
+		extension.setUrl(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE);
+		extension.addExtension(personAttributeTypeExtension);
+		extension.addExtension(personAttributeValueExtension);
+		
+		Concept concept = new Concept();
+		concept.setConceptId(Integer.parseInt(CONCEPT_ATTRIBUTE_VALUE));
+		when(conceptTranslator.toOpenmrsType(codeableConcept)).thenReturn(concept);
+		
+		PersonAttribute result = personAttributeTranslator.toOpenmrsType(extension);
+		
+		assertThat(result, notNullValue());
+		assertThat(result.getAttributeType(), equalTo(personAttributeType));
+		assertThat(result.getValue(), equalTo(CONCEPT_ATTRIBUTE_VALUE));
+	}
+	
+}

--- a/integration-tests/src/test/java/org/openmrs/module/fhir2/providers/r3/PatientFhirResourceProviderIntegrationTest.java
+++ b/integration-tests/src/test/java/org/openmrs/module/fhir2/providers/r3/PatientFhirResourceProviderIntegrationTest.java
@@ -34,17 +34,20 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import lombok.AccessLevel;
 import lombok.Getter;
 import org.apache.commons.lang3.time.DateUtils;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Enumerations;
+import org.hl7.fhir.dstu3.model.Extension;
 import org.hl7.fhir.dstu3.model.OperationOutcome;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.dstu3.model.ResourceType;
 import org.junit.Before;
 import org.junit.Test;
+import org.openmrs.module.fhir2.FhirConstants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -871,5 +874,23 @@ public class PatientFhirResourceProviderIntegrationTest extends BaseFhirR3Integr
 		validTypes.add(ResourceType.ProcedureRequest);
 		
 		return validTypes;
+	}
+	
+	@Test
+	public void shouldReturnPersonAttributesAsExtensions() throws Exception {
+		MockHttpServletResponse response = get("/Patient/" + PATIENT_UUID).accept(FhirMediaTypes.JSON).go();
+		
+		assertThat(response, isOk());
+		assertThat(response.getContentType(), is(FhirMediaTypes.JSON.toString()));
+		assertThat(response.getContentAsString(), notNullValue());
+		
+		Patient patient = readResponse(response);
+		
+		//Filtering for extensions of PersonAttributes
+		List<Extension> personAttributeExtensions = patient.getExtension().stream()
+		        .filter(ext -> ext.getUrl().equals(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE))
+		        .collect(Collectors.toList());
+		
+		assertThat(personAttributeExtensions.size(), is(3));
 	}
 }

--- a/integration-tests/src/test/java/org/openmrs/module/fhir2/providers/r3/PersonFhirResourceProviderIntegrationTest.java
+++ b/integration-tests/src/test/java/org/openmrs/module/fhir2/providers/r3/PersonFhirResourceProviderIntegrationTest.java
@@ -30,16 +30,19 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import lombok.AccessLevel;
 import lombok.Getter;
 import org.apache.commons.lang3.time.DateUtils;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Enumerations;
+import org.hl7.fhir.dstu3.model.Extension;
 import org.hl7.fhir.dstu3.model.OperationOutcome;
 import org.hl7.fhir.dstu3.model.Person;
 import org.junit.Before;
 import org.junit.Test;
+import org.openmrs.module.fhir2.FhirConstants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -534,5 +537,23 @@ public class PersonFhirResourceProviderIntegrationTest extends BaseFhirR3Integra
 		
 		assertThat(response, isOk());
 		assertThat(response, statusEquals(HttpStatus.OK));
+	}
+	
+	@Test
+	public void shouldReturnPersonAttributesAsExtensions() throws Exception {
+		MockHttpServletResponse response = get("/Person/" + PERSON_UUID).accept(FhirMediaTypes.JSON).go();
+		
+		assertThat(response, isOk());
+		assertThat(response.getContentType(), is(FhirMediaTypes.JSON.toString()));
+		assertThat(response.getContentAsString(), notNullValue());
+		
+		Person person = readResponse(response);
+		
+		//Filtering for extensions of PersonAttributes
+		List<Extension> personAttributeExtensions = person.getExtension().stream()
+		        .filter(ext -> ext.getUrl().equals(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE))
+		        .collect(Collectors.toList());
+		
+		assertThat(personAttributeExtensions.size(), is(2));
 	}
 }

--- a/integration-tests/src/test/java/org/openmrs/module/fhir2/providers/r4/PatientFhirResourceProviderIntegrationTest.java
+++ b/integration-tests/src/test/java/org/openmrs/module/fhir2/providers/r4/PatientFhirResourceProviderIntegrationTest.java
@@ -35,18 +35,21 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import lombok.AccessLevel;
 import lombok.Getter;
 import org.apache.commons.lang3.time.DateUtils;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Enumerations;
+import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.ResourceType;
 import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.module.fhir2.BaseFhirIntegrationTest;
+import org.openmrs.module.fhir2.FhirConstants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -956,5 +959,23 @@ public class PatientFhirResourceProviderIntegrationTest extends BaseFhirR4Integr
 		validTypes.add(ResourceType.ServiceRequest);
 		
 		return validTypes;
+	}
+	
+	@Test
+	public void shouldReturnPersonAttributesAsExtensions() throws Exception {
+		MockHttpServletResponse response = get("/Patient/" + PATIENT_UUID).accept(FhirMediaTypes.JSON).go();
+		
+		assertThat(response, isOk());
+		assertThat(response.getContentType(), is(FhirMediaTypes.JSON.toString()));
+		assertThat(response.getContentAsString(), notNullValue());
+		
+		Patient patient = readResponse(response);
+		
+		//Filtering for extensions of PersonAttributes
+		List<Extension> personAttributeExtensions = patient.getExtension().stream()
+		        .filter(ext -> ext.getUrl().equals(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE))
+		        .collect(Collectors.toList());
+		
+		assertThat(personAttributeExtensions.size(), is(3));
 	}
 }

--- a/integration-tests/src/test/java/org/openmrs/module/fhir2/providers/r4/PersonFhirResourceProviderIntegrationTest.java
+++ b/integration-tests/src/test/java/org/openmrs/module/fhir2/providers/r4/PersonFhirResourceProviderIntegrationTest.java
@@ -30,16 +30,19 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import lombok.AccessLevel;
 import lombok.Getter;
 import org.apache.commons.lang3.time.DateUtils;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Enumerations;
+import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r4.model.Person;
 import org.junit.Before;
 import org.junit.Test;
+import org.openmrs.module.fhir2.FhirConstants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -612,5 +615,23 @@ public class PersonFhirResourceProviderIntegrationTest extends BaseFhirR4Integra
 		
 		assertThat(response, isOk());
 		assertThat(response, statusEquals(HttpStatus.OK));
+	}
+	
+	@Test
+	public void shouldReturnPersonAttributesAsExtensions() throws Exception {
+		MockHttpServletResponse response = get("/Person/" + PERSON_UUID).accept(FhirMediaTypes.JSON).go();
+		
+		assertThat(response, isOk());
+		assertThat(response.getContentType(), is(FhirMediaTypes.JSON.toString()));
+		assertThat(response.getContentAsString(), notNullValue());
+		
+		Person person = readResponse(response);
+		
+		//Filtering for extensions of PersonAttributes
+		List<Extension> personAttributeExtensions = person.getExtension().stream()
+		        .filter(ext -> ext.getUrl().equals(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE))
+		        .collect(Collectors.toList());
+		
+		assertThat(personAttributeExtensions.size(), is(2));
 	}
 }

--- a/test-data/src/main/resources/org/openmrs/module/fhir2/api/dao/impl/FhirPatientDaoImplTest_initial_data.xml
+++ b/test-data/src/main/resources/org/openmrs/module/fhir2/api/dao/impl/FhirPatientDaoImplTest_initial_data.xml
@@ -48,4 +48,10 @@
     <cohort_member cohort_member_id="3" cohort_id="1" patient_id="6" start_date="2000-04-16" end_date="2030-04-16" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="bfd66f72-d058-4493-9e73-e021f89bd2aa"/>
     <cohort_member cohort_member_id="4" cohort_id="1" patient_id="7" start_date="2000-04-16" end_date="2030-04-16" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="c9cb5447-1195-42f5-9dd7-421bf5d6ae82"/>
     <cohort_member cohort_member_id="5" cohort_id="3" patient_id="8" start_date="2000-04-16" end_date="2030-04-16" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="7c650865-59e0-4e8e-8334-ba22ff539c08"/>
+    <person_attribute_type person_attribute_type_id="4" name="test string" format="java.lang.String" searchable="false" creator="1" date_created="2008-08-15 15:53:36.0" retired="false" uuid="3b4a243d-4508-4ecf-aa05-d1260a78e196" sort_weight="2"/>
+    <person_attribute_type person_attribute_type_id="5" name="test boolean" format="java.lang.Boolean" searchable="false" creator="1" date_created="2008-08-15 15:53:36.0" retired="false" uuid="4973eeee-f193-4504-a67e-b8132a39c42a" sort_weight="2"/>
+    <person_attribute_type person_attribute_type_id="6" name="test location" format="org.openmrs.Location" searchable="false" creator="1" date_created="2008-08-15 15:53:36.0" retired="false" uuid="560683ca-1261-441d-89e2-d11faeacd8c9" sort_weight="2"/>
+    <person_attribute person_attribute_id="4" person_id="5" value="test@openmrs.org" person_attribute_type_id="4" creator="1" date_created="2008-08-18 12:25:57.0" voided="false" uuid="fbd82a27-56ec-46b4-8660-6442e832dc3e"/>
+    <person_attribute person_attribute_id="5" person_id="5" value="true" person_attribute_type_id="5" creator="1" date_created="2008-08-18 12:25:57.0" voided="false" uuid="a55f316e-29dd-4ad5-b954-62ef93723658"/>
+    <person_attribute person_attribute_id="6" person_id="5" value="1" person_attribute_type_id="6" creator="1" date_created="2008-08-18 12:25:57.0" voided="false" uuid="ad0f530d-aebf-4284-b7c1-c103986b1c2b"/>
 </dataset>

--- a/test-data/src/main/resources/org/openmrs/module/fhir2/api/dao/impl/FhirPersonDaoImplTest_initial_data.xml
+++ b/test-data/src/main/resources/org/openmrs/module/fhir2/api/dao/impl/FhirPersonDaoImplTest_initial_data.xml
@@ -20,4 +20,9 @@
     <person_address person_address_id="4" preferred="true" person_id="4" city_village="Edison" state_province="NJ" postal_code="08817" country="FakeC" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="da5932f2-67b7-11ea-bc55-0242ac130003"/>
     <person_address person_address_id="5" preferred="true" person_id="5" city_village="Santa Cruz" state_province="CA" postal_code="95060" country="FakeD" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="da5933ce-67b7-11ea-bc55-0242ac130003"/>
     <person_address person_address_id="7" preferred="true" person_id="7" city_village="Peabody" state_province="MA" postal_code="01960" country="FakeAB" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="da593572-67b7-11ea-bc55-0242ac130003"/>
+    <person_attribute_type person_attribute_type_id="2" name="email" format="java.lang.String" searchable="false" creator="1" date_created="2008-08-15 15:53:36.0" retired="false" uuid="5a8c170b-178a-4b8f-908e-279b67854d84" sort_weight="2"/>
+    <person_attribute_type person_attribute_type_id="3" name="test patient" format="java.lang.Boolean" searchable="false" creator="1" date_created="2008-08-15 15:53:36.0" retired="false" uuid="e34d1404-5633-4e5b-9db3-930f31086557" sort_weight="2"/>
+    <person_attribute person_attribute_id="2" person_id="3" value="test@openmrs.org" person_attribute_type_id="2" creator="1" date_created="2008-08-18 12:25:57.0" voided="false" uuid="9cc62c8d-5817-4c21-8205-266c5ff344db"/>
+    <person_attribute person_attribute_id="3" person_id="3" value="true" person_attribute_type_id="3" creator="1" date_created="2008-08-18 12:25:57.0" voided="false" uuid="bcced38f-dad5-4c71-a436-8a486e4288d9"/>
+
 </dataset>


### PR DESCRIPTION
# FM2-456: (Updated) Add Person Attribute Extensions Support to Patient Translator

## Description of what I changed

Added support for handling person attributes as FHIR extensions in the Patient resource. Person attributes in OpenMRS can now be properly translated to and from FHIR extensions (Currently supporting String, Boolean, Concept & Location).

The implementation:
1. Adds a dependency on `PersonAttributeTranslatorImpl` for translation
2. Creates `getPersonAttributeExtensions` method to convert attributes to extensions
3. Updates `toFhirResource` to add extensions to the Patient resource
4. Updates `toOpenmrsType` to convert extensions back to OpenMRS person attributes

The implementation expects person attribute extensions to follow this nested structure:
```json
{
   "url": "http://fhir.openmrs.org/person-attribute",
   "extension": [{
     "url": "http://fhir.openmrs.org/person-attribute-type",
     "value": "Birthplace"
   }, {
     "url": "http://fhir.openmrs.org/person-attribute-value",
     "value": "Lisbon"
   }]
}
```

Where:
- Outer extension with URL `http://fhir.openmrs.org/person-attribute` serves as a container
- Inner extensions represent individual attributes with type & attribute values

## Issue I worked on

see https://openmrs.atlassian.net/browse/FM2-126

## Checklist: I completed these to help reviewers :)
- [x] My IDE is configured to follow the [**[code style](https://wiki.openmrs.org/display/docs/Java+Conventions)**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.

cc: @icrc-jofrancisco , @icrc-fdeniger ,  @ibacher 