### PR TITLE
O3-4765: Improved FHIR Get Lab Results endpoint performance

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhir2/api/translators/ConceptTranslator.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/translators/ConceptTranslator.java
@@ -11,6 +11,9 @@ package org.openmrs.module.fhir2.api.translators;
 
 import javax.annotation.Nonnull;
 
+import java.util.Collection;
+import java.util.List;
+
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.openmrs.Concept;
 
@@ -24,6 +27,15 @@ public interface ConceptTranslator extends OpenmrsFhirTranslator<Concept, Codeab
 	 */
 	@Override
 	CodeableConcept toFhirResource(@Nonnull Concept concept);
+	
+	/**
+	 * Maps a collection of {@link org.openmrs.Concept}s to a
+	 * {@link org.hl7.fhir.r4.model.CodeableConcept}
+	 *
+	 * @param openmrsConcepts the collection of OpenMRS concepts to translate
+	 * @return the mapping of OpenMRS concept to corresponding FHIR concept resource
+	 */
+	List<CodeableConcept> toFhirResources(Collection<Concept> openmrsConcepts);
 	
 	/**
 	 * Maps a FHIR resource to an OpenMRS data element

--- a/api/src/main/java/org/openmrs/module/fhir2/api/translators/OpenmrsFhirTranslator.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/translators/OpenmrsFhirTranslator.java
@@ -9,8 +9,12 @@
  */
 package org.openmrs.module.fhir2.api.translators;
 
+import static java.util.stream.Collectors.toMap;
+
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -29,5 +33,15 @@ public interface OpenmrsFhirTranslator<T, U> extends ToFhirTranslator<T, U>, ToO
 	 */
 	default List<U> toFhirResources(Collection<T> data) {
 		return data.stream().distinct().map(this::toFhirResource).collect(Collectors.toList());
+	}
+	
+	/**
+	 * Maps OpenMRS data elements to FHIR resource map.
+	 *
+	 * @param data the collection of OpenMRS data elements to translate
+	 * @return the mapping of OpenMRS data element to corresponding FHIR resource map
+	 */
+	default Map<T, U> toFhirResourcesMap(Collection<T> data) {
+		return data.stream().distinct().collect(toMap(Function.identity(), this::toFhirResource));
 	}
 }

--- a/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/ConceptTranslatorImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/ConceptTranslatorImpl.java
@@ -9,15 +9,21 @@
  */
 package org.openmrs.module.fhir2.api.translators.impl;
 
+import static java.util.stream.Collectors.toMap;
 import static lombok.AccessLevel.PROTECTED;
 
 import javax.annotation.Nonnull;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -28,9 +34,12 @@ import org.openmrs.ConceptMap;
 import org.openmrs.ConceptMapType;
 import org.openmrs.ConceptReferenceTerm;
 import org.openmrs.ConceptSource;
+import org.openmrs.Duration;
+import org.openmrs.module.fhir2.FhirConstants;
 import org.openmrs.module.fhir2.api.FhirConceptService;
 import org.openmrs.module.fhir2.api.FhirConceptSourceService;
 import org.openmrs.module.fhir2.api.translators.ConceptTranslator;
+import org.openmrs.module.fhir2.model.FhirConceptSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -48,45 +57,22 @@ public class ConceptTranslatorImpl implements ConceptTranslator {
 	
 	@Override
 	public CodeableConcept toFhirResource(@Nonnull Concept concept) {
-		if (concept == null) {
-			return null;
-		}
+		return toFhirResources(Collections.singletonList(concept)).get(0);
+	}
+	
+	@Override
+	public List<CodeableConcept> toFhirResources(Collection<Concept> openmrsConcepts) {
+		ConceptTranslatorContext context = new ConceptTranslatorContext(getFhirConceptSourcesMap());
 		
-		CodeableConcept codeableConcept = new CodeableConcept();
-		codeableConcept.setText(concept.getDisplayString());
-		addConceptCoding(codeableConcept.addCoding(), null, concept.getUuid(), concept);
-		//map of <systemUrl ,<mapType , code>> ie { "http://loinc.org” : { "SAME-AS" : "108-5", "NARROWER-THAN": "108-8" }}
-		Map<String, Map<String, String>> systemUrlToCodeMap = new HashMap<>();
-		for (ConceptMap mapping : concept.getConceptMappings()) {
-			if (mapping.getConceptMapType() != null) {
-				ConceptMapType mapType = mapping.getConceptMapType();
-				boolean sameAs = mapType.getUuid() != null && mapType.getUuid().equals(ConceptMapType.SAME_AS_MAP_TYPE_UUID);
-				sameAs = sameAs || (mapType.getName() != null && mapType.getName().equalsIgnoreCase("SAME-AS"));
-				ConceptReferenceTerm crt = mapping.getConceptReferenceTerm();
-				String sourceUrl = conceptSourceService.getUrlForConceptSource(crt.getConceptSource());
-				if (sourceUrl != null) {
-					if (sameAs) {
-						addSystemToCodeMap(systemUrlToCodeMap, sourceUrl, "SAME-AS", crt.getCode());
-					} else {
-						addSystemToCodeMap(systemUrlToCodeMap, sourceUrl, mapType.getName(), crt.getCode());
-					}
-				}
-			}
-		}
+		return openmrsConcepts.stream().map(concept -> toFhirConcept(concept, context)).collect(Collectors.toList());
+	}
+	
+	@Override
+	public Map<Concept, CodeableConcept> toFhirResourcesMap(Collection<Concept> openmrsConcepts) {
+		ConceptTranslatorContext context = new ConceptTranslatorContext(getFhirConceptSourcesMap());
 		
-		for (String systemUrl : systemUrlToCodeMap.keySet()) {
-			Map<String, String> mapTypeToCodeMap = systemUrlToCodeMap.get(systemUrl);
-			if (mapTypeToCodeMap != null) {
-				if (mapTypeToCodeMap.size() == 1) {
-					for (String mapType : mapTypeToCodeMap.keySet()) {
-						addConceptCoding(codeableConcept.addCoding(), systemUrl, mapTypeToCodeMap.get(mapType), concept);
-					}
-				} else if (mapTypeToCodeMap.size() > 1 && mapTypeToCodeMap.containsKey("SAME-AS")) {
-					addConceptCoding(codeableConcept.addCoding(), systemUrl, mapTypeToCodeMap.get("SAME-AS"), concept);
-				}
-			}
-		}
-		return codeableConcept;
+		return openmrsConcepts.stream().distinct()
+		        .collect(toMap(Function.identity(), concept -> toFhirConcept(concept, context)));
 	}
 	
 	@Override
@@ -126,6 +112,53 @@ public class ConceptTranslatorImpl implements ConceptTranslator {
 		return null;
 	}
 	
+	private CodeableConcept toFhirConcept(Concept concept, ConceptTranslatorContext context) {
+		if (concept == null) {
+			return null;
+		}
+		
+		CodeableConcept codeableConcept = new CodeableConcept();
+		codeableConcept.setText(concept.getDisplayString());
+		addConceptCoding(codeableConcept.addCoding(), null, concept.getUuid(), concept);
+		
+		//map of <systemUrl ,<mapType , code>> ie { "http://loinc.org” : { "SAME-AS" : "108-5", "NARROWER-THAN": "108-8" }}
+		Map<String, Map<String, String>> systemUrlToCodeMap = new HashMap<>();
+		
+		for (ConceptMap mapping : concept.getConceptMappings()) {
+			if (mapping.getConceptMapType() != null) {
+				ConceptMapType mapType = mapping.getConceptMapType();
+				boolean sameAs = mapType.getUuid() != null && ConceptMapType.SAME_AS_MAP_TYPE_UUID.equals(mapType.getUuid());
+				sameAs = sameAs || (mapType.getName() != null && "SAME-AS".equalsIgnoreCase(mapType.getName()));
+				
+				ConceptReferenceTerm crt = mapping.getConceptReferenceTerm();
+				String sourceUrl = getSourceUrl(crt.getConceptSource(), context);
+				
+				if (sourceUrl != null) {
+					if (sameAs) {
+						addSystemToCodeMap(systemUrlToCodeMap, sourceUrl, "SAME-AS", crt.getCode());
+					} else {
+						addSystemToCodeMap(systemUrlToCodeMap, sourceUrl, mapType.getName(), crt.getCode());
+					}
+				}
+			}
+		}
+		
+		for (String systemUrl : systemUrlToCodeMap.keySet()) {
+			Map<String, String> mapTypeToCodeMap = systemUrlToCodeMap.get(systemUrl);
+			if (mapTypeToCodeMap != null) {
+				if (mapTypeToCodeMap.size() == 1) {
+					for (String mapType : mapTypeToCodeMap.keySet()) {
+						addConceptCoding(codeableConcept.addCoding(), systemUrl, mapTypeToCodeMap.get(mapType), concept);
+					}
+				} else if (mapTypeToCodeMap.size() > 1 && mapTypeToCodeMap.containsKey("SAME-AS")) {
+					addConceptCoding(codeableConcept.addCoding(), systemUrl, mapTypeToCodeMap.get("SAME-AS"), concept);
+				}
+			}
+		}
+		
+		return codeableConcept;
+	}
+	
 	private void addConceptCoding(Coding coding, String system, String code, Concept concept) {
 		coding.setSystem(system);
 		coding.setCode(code);
@@ -163,5 +196,32 @@ public class ConceptTranslatorImpl implements ConceptTranslator {
 				}
 			}
 		});
+	}
+	
+	private Map<String, FhirConceptSource> getFhirConceptSourcesMap() {
+		return conceptSourceService.getFhirConceptSources().stream().filter(cs -> cs.getConceptSource() != null)
+		        .collect(Collectors.toMap(cs -> cs.getConceptSource().getUuid(), Function.identity()));
+	}
+	
+	private String getSourceUrl(ConceptSource conceptSource, ConceptTranslatorContext context) {
+		String sourceUrl = null;
+		if (conceptSource != null) {
+			FhirConceptSource fhirConceptSource = context.fhirConceptSourcesMap.get(conceptSource.getUuid());
+			if (fhirConceptSource != null && fhirConceptSource.getUrl() != null) {
+				sourceUrl = fhirConceptSource.getUrl();
+			} else {
+				sourceUrl = Duration.SNOMED_CT_CONCEPT_SOURCE_HL7_CODE.equals(conceptSource.getHl7Code())
+				        ? FhirConstants.SNOMED_SYSTEM_URI
+				        : null;
+			}
+		}
+		
+		return sourceUrl;
+	}
+	
+	@AllArgsConstructor
+	private static class ConceptTranslatorContext {
+		
+		Map<String, FhirConceptSource> fhirConceptSourcesMap;
 	}
 }

--- a/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/ObservationTranslatorImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/ObservationTranslatorImpl.java
@@ -17,12 +17,19 @@ import static org.openmrs.module.fhir2.api.translators.impl.ReferenceHandlingTra
 
 import javax.annotation.Nonnull;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.proxy.HibernateProxy;
+import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Reference;
 import org.openmrs.Concept;
@@ -97,60 +104,17 @@ public class ObservationTranslatorImpl implements ObservationTranslator {
 	
 	@Override
 	public Observation toFhirResource(@Nonnull Obs observation) {
-		notNull(observation, "The Obs object should not be null");
+		return toFhirResources(Collections.singletonList(observation)).get(0);
+	}
+	
+	@Override
+	public List<Observation> toFhirResources(Collection<Obs> openmrsObservations) {
+		List<Concept> obsConcepts = openmrsObservations.stream().map(Obs::getConcept).collect(Collectors.toList());
+		Map<Concept, CodeableConcept> conceptMap = conceptTranslator.toFhirResourcesMap(obsConcepts);
 		
-		Observation obs = new Observation();
-		obs.setId(observation.getUuid());
-		obs.setStatus(observationStatusTranslator.toFhirResource(observation));
+		ObservationTranslatorContext context = new ObservationTranslatorContext(conceptMap);
 		
-		obs.setEncounter(encounterReferenceTranslator.toFhirResource(observation.getEncounter()));
-		
-		Person obsPerson = observation.getPerson();
-		if (obsPerson != null) {
-			if (obsPerson instanceof HibernateProxy) {
-				obsPerson = HibernateUtil.getRealObjectFromProxy(obsPerson);
-			}
-			
-			if (obsPerson instanceof Patient) {
-				obs.setSubject(patientReferenceTranslator.toFhirResource((Patient) obsPerson));
-			}
-		}
-		
-		obs.setCode(conceptTranslator.toFhirResource(observation.getConcept()));
-		obs.addCategory(categoryTranslator.toFhirResource(observation.getConcept()));
-		
-		if (observation.isObsGrouping()) {
-			for (Obs groupObs : observation.getGroupMembers()) {
-				if (!groupObs.getVoided()) {
-					obs.addHasMember(observationReferenceTranslator.toFhirResource(groupObs));
-				}
-			}
-		}
-		
-		obs.setValue(observationValueTranslator.toFhirResource(observation));
-		
-		obs.addInterpretation(interpretationTranslator.toFhirResource(observation));
-		
-		if (observation.getValueNumeric() != null) {
-			Concept concept = observation.getConcept();
-			if (concept instanceof ConceptNumeric) {
-				obs.setReferenceRange(referenceRangeTranslator.toFhirResource(observation));
-			}
-		}
-		
-		if (observation.getValueText() != null && StringUtils.equals(observation.getComment(), "org.openmrs.Location")) {
-			obs.addExtension(FhirConstants.OPENMRS_FHIR_EXT_OBS_LOCATION_VALUE,
-			    createLocationReferenceByUuid(observation.getValueText()));
-		}
-		
-		obs.setIssued(observation.getDateCreated());
-		obs.setEffective(datetimeTranslator.toFhirResource(observation));
-		obs.addBasedOn(basedOnReferenceTranslator.toFhirResource(observation.getOrder()));
-		
-		obs.getMeta().setLastUpdated(getLastUpdated(observation));
-		obs.getMeta().setVersionId(getVersionId(observation));
-		
-		return obs;
+		return openmrsObservations.stream().map(obs -> toFhirObservation(obs, context)).collect(Collectors.toList());
 	}
 	
 	@Override
@@ -188,5 +152,68 @@ public class ObservationTranslatorImpl implements ObservationTranslator {
 		}
 		
 		return existingObs;
+	}
+	
+	private Observation toFhirObservation(Obs observation, ObservationTranslatorContext context) {
+		notNull(observation, "The Obs object should not be null");
+		
+		Observation obs = new Observation();
+		obs.setId(observation.getUuid());
+		obs.setStatus(observationStatusTranslator.toFhirResource(observation));
+		
+		obs.setEncounter(encounterReferenceTranslator.toFhirResource(observation.getEncounter()));
+		
+		Person obsPerson = observation.getPerson();
+		if (obsPerson != null) {
+			if (obsPerson instanceof HibernateProxy) {
+				obsPerson = HibernateUtil.getRealObjectFromProxy(obsPerson);
+			}
+			
+			if (obsPerson instanceof Patient) {
+				obs.setSubject(patientReferenceTranslator.toFhirResource((Patient) obsPerson));
+			}
+		}
+		
+		obs.setCode(context.conceptToCodeableConceptMap.get(observation.getConcept()));
+		obs.addCategory(categoryTranslator.toFhirResource(observation.getConcept()));
+		
+		if (observation.isObsGrouping()) {
+			for (Obs groupObs : observation.getGroupMembers()) {
+				if (!groupObs.getVoided()) {
+					obs.addHasMember(observationReferenceTranslator.toFhirResource(groupObs));
+				}
+			}
+		}
+		
+		obs.setValue(observationValueTranslator.toFhirResource(observation));
+		obs.addInterpretation(interpretationTranslator.toFhirResource(observation));
+		
+		if (observation.getValueNumeric() != null) {
+			Concept concept = observation.getConcept();
+			if (concept instanceof ConceptNumeric) {
+				obs.setReferenceRange(referenceRangeTranslator.toFhirResource(observation));
+			}
+		}
+		
+		if (observation.getValueText() != null && StringUtils.equals(observation.getComment(), "org.openmrs.Location")) {
+			obs.addExtension(FhirConstants.OPENMRS_FHIR_EXT_OBS_LOCATION_VALUE,
+			    createLocationReferenceByUuid(observation.getValueText()));
+		}
+		
+		obs.setIssued(observation.getDateCreated());
+		obs.setEffective(datetimeTranslator.toFhirResource(observation));
+		
+		obs.addBasedOn(basedOnReferenceTranslator.toFhirResource(observation.getOrder()));
+		
+		obs.getMeta().setLastUpdated(getLastUpdated(observation));
+		obs.getMeta().setVersionId(getVersionId(observation));
+		
+		return obs;
+	}
+	
+	@AllArgsConstructor
+	private static class ObservationTranslatorContext {
+		
+		Map<Concept, CodeableConcept> conceptToCodeableConceptMap;
 	}
 }

--- a/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/PersonTranslatorImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/PersonTranslatorImpl.java
@@ -163,7 +163,7 @@ public class PersonTranslatorImpl implements PersonTranslator {
 		List<Extension> personAttributeExtensions = person.getExtension().stream()
 		        .filter(extension -> extension.getUrl().equals(FhirConstants.OPENMRS_FHIR_EXT_PERSON_ATTRIBUTE))
 		        .collect(Collectors.toList());
-
+		
 		for (Extension extension : personAttributeExtensions) {
 			PersonAttribute personAttribute = personAttributeTranslator.toOpenmrsType(extension);
 			if (personAttribute != null) {

--- a/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/ConceptTranslatorImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/ConceptTranslatorImplTest.java
@@ -19,12 +19,16 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 
 import org.hl7.fhir.r4.model.CodeableConcept;
@@ -43,6 +47,8 @@ import org.openmrs.ConceptSource;
 import org.openmrs.module.fhir2.FhirTestConstants;
 import org.openmrs.module.fhir2.api.FhirConceptService;
 import org.openmrs.module.fhir2.api.FhirConceptSourceService;
+import org.openmrs.module.fhir2.api.translators.ConceptTranslator;
+import org.openmrs.module.fhir2.api.translators.OpenmrsFhirTranslator;
 import org.openmrs.module.fhir2.model.FhirConceptSource;
 import org.openmrs.util.LocaleUtility;
 
@@ -110,13 +116,13 @@ public class ConceptTranslatorImplTest {
 		fhirLoinc.setConceptSource(loinc);
 		fhirLoinc.setUrl(FhirTestConstants.LOINC_SYSTEM_URL);
 		when(conceptSourceService.getConceptSourceByUrl(FhirTestConstants.LOINC_SYSTEM_URL)).thenReturn(Optional.of(loinc));
-		when(conceptSourceService.getUrlForConceptSource(loinc)).thenReturn(FhirTestConstants.LOINC_SYSTEM_URL);
 		
-		FhirConceptSource fhirCiel = new FhirConceptSource();
+		fhirCiel = new FhirConceptSource();
 		fhirCiel.setConceptSource(ciel);
 		fhirCiel.setUrl(FhirTestConstants.CIEL_SYSTEM_URN);
 		when(conceptSourceService.getConceptSourceByUrl(FhirTestConstants.CIEL_SYSTEM_URN)).thenReturn(Optional.of(ciel));
-		when(conceptSourceService.getUrlForConceptSource(ciel)).thenReturn(FhirTestConstants.CIEL_SYSTEM_URN);
+		
+		when(conceptSourceService.getFhirConceptSources()).thenReturn(Arrays.asList(fhirLoinc, fhirCiel));
 	}
 	
 	@Test
@@ -427,5 +433,33 @@ public class ConceptTranslatorImplTest {
 		m.setConcept(concept);
 		m.setConceptReferenceTerm(new ConceptReferenceTerm(conceptSource, code, code));
 		concept.addConceptMapping(m);
+	}
+	
+	@Test
+	public void shouldTranslateConceptListToConceptCodeableMap() {
+		Map<Concept, CodeableConcept> result = conceptTranslator.toFhirResourcesMap(Collections.singletonList(concept));
+		CodeableConcept codeableConcept = result.get(concept);
+		assertThat(result, notNullValue());
+		assertThat(result.size(), equalTo(1));
+		assertThat(codeableConcept, notNullValue());
+		assertThat(codeableConcept.getCoding(), not(empty()));
+		assertThat(codeableConcept.getCoding().get(0).getSystem(), nullValue());
+		assertThat(codeableConcept.getCoding().get(0).getCode(), equalTo(CONCEPT_UUID));
+		assertThat(codeableConcept.getCoding().get(0).getDisplay(), equalTo(CONCEPT_NAME));
+	}
+	
+	@Test
+	public void shouldTranslateConceptListToConceptCodeableMapUsingDefaultTranslator() {
+		OpenmrsFhirTranslator<Concept, CodeableConcept> translator = mock(ConceptTranslator.class);
+		when(translator.toFhirResourcesMap(anyCollection())).thenCallRealMethod();
+		when(translator.toFhirResource(concept)).thenReturn(new CodeableConcept().addCoding(new Coding().setCode("xyz")));
+		
+		Map<Concept, CodeableConcept> result = translator.toFhirResourcesMap(Collections.singletonList(concept));
+		CodeableConcept codeableConcept = result.get(concept);
+		
+		assertThat(result, notNullValue());
+		assertThat(result.size(), equalTo(1));
+		assertThat(codeableConcept, notNullValue());
+		assertThat(codeableConcept.getCoding().get(0).getCode(), equalTo("xyz"));
 	}
 }

--- a/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/ObservationTranslatorImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/ObservationTranslatorImplTest.java
@@ -26,7 +26,9 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.exparity.hamcrest.date.DateMatchers;
 import org.hl7.fhir.r4.model.CodeableConcept;
@@ -245,7 +247,9 @@ public class ObservationTranslatorImplTest {
 		observation.setConcept(concept);
 		CodeableConcept codeableConcept = new CodeableConcept();
 		codeableConcept.setId(CONCEPT_UUID);
-		when(conceptTranslator.toFhirResource(concept)).thenReturn(codeableConcept);
+		Map<Concept, CodeableConcept> conceptMap = new HashMap<>();
+		conceptMap.put(concept, codeableConcept);
+		when(conceptTranslator.toFhirResourcesMap(any())).thenReturn(conceptMap);
 		
 		Observation result = observationTranslator.toFhirResource(observation);
 		

--- a/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/ObservationValueTranslatorImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/ObservationValueTranslatorImplTest.java
@@ -38,11 +38,11 @@ import org.openmrs.Concept;
 import org.openmrs.ConceptNumeric;
 import org.openmrs.Obs;
 import org.openmrs.api.ConceptService;
+import org.openmrs.module.fhir2.api.FhirConceptSourceService;
 import org.openmrs.module.fhir2.api.dao.FhirConceptSourceDao;
 import org.openmrs.module.fhir2.api.dao.impl.FhirConceptDaoImpl;
 import org.openmrs.module.fhir2.api.dao.impl.FhirConceptSourceDaoImpl;
 import org.openmrs.module.fhir2.api.impl.FhirConceptServiceImpl;
-import org.openmrs.module.fhir2.api.impl.FhirConceptSourceServiceImpl;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ObservationValueTranslatorImplTest {
@@ -55,6 +55,9 @@ public class ObservationValueTranslatorImplTest {
 	
 	@Mock
 	private ObservationQuantityCodingTranslatorImpl quantityCodingTranslator;
+	
+	@Mock
+	private FhirConceptSourceService fhirConceptSourceServiceMock;
 	
 	@Mock
 	ConceptService conceptService;
@@ -70,11 +73,9 @@ public class ObservationValueTranslatorImplTest {
 		FhirConceptServiceImpl fhirConceptService = new FhirConceptServiceImpl();
 		fhirConceptService.setDao(fhirConceptDao);
 		FhirConceptSourceDao fhirConceptSourceDao = new FhirConceptSourceDaoImpl();
-		FhirConceptSourceServiceImpl fhirConceptSourceService = new FhirConceptSourceServiceImpl();
-		fhirConceptSourceService.setDao(fhirConceptSourceDao);
 		conceptTranslator = new ConceptTranslatorImpl();
 		conceptTranslator.setConceptService(fhirConceptService);
-		conceptTranslator.setConceptSourceService(fhirConceptSourceService);
+		conceptTranslator.setConceptSourceService(fhirConceptSourceServiceMock);
 		obsValueTranslator = new ObservationValueTranslatorImpl() {
 			
 			@Override


### PR DESCRIPTION
## Description of what I changed
This is a performance improvement for Get Lab Results endpoint which is mainly related to fetching observations/concepts. Main idea of this solution is to reduce number of database queries which gives us a significant increase in performance. 

The general logic of fetching Observations before the changes looked like:

1. Get results (obses) from database.
2. For each obs convert to FHIR obs, which consists of:

- convert Obs to FHIR Observation, which consists of: 

- for each concept mapping search for concept source url -> separate db query performed

First introduced improvement was fetchin fhir concept sources once before loop, and inside loop just read these values. This increased the efficiency significantly, around 50%. But still fetching all concept sources was performed for each obs so idea is to use existing service method oFhirResources(Collection data) - and in Obs implementation of this method collect all mappings between Concept and CodeableConcept. For this, new method has been created Map<T, U> toFhirResourcesMap(Collection<T> data).

To sum up, main things that have been changed are loading mappings between Concept and ConceptCodeable and FhirSources once and read these values from preloaded collections - we read from memory instead of database each time. 

The above mentioned changes allowed to obtain an **increase in efficiency of around 70%.**

See https://talk.openmrs.org/t/how-to-help-with-o3-performance/45157
More detailed results can be found [here](https://docs.google.com/document/d/1b5Zr_yp1CX63UfKlwy4dDasry9FXUYHpMkovC17zuC0/edit?usp=drive_link)
and also in attached file in [ticket](https://openmrs.atlassian.net/browse/O3-4765)

## Issue I worked on
See https://openmrs.atlassian.net/browse/O3-4765

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.

