### PR TITLE
FHIR R4: normalize CodeableConcept codings and HL7 escapes; add tests

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,4 @@
+--add-opens=java.base/java.util=ALL-UNNAMED
+--add-opens=java.base/java.lang=ALL-UNNAMED
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+--add-opens=java.base/java.io=ALL-UNNAMED

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,4 +1,0 @@
---add-opens=java.base/java.util=ALL-UNNAMED
---add-opens=java.base/java.lang=ALL-UNNAMED
---add-opens=java.base/java.lang.reflect=ALL-UNNAMED
---add-opens=java.base/java.io=ALL-UNNAMED

--- a/api/src/main/java/org/openmrs/module/fhir2/api/util/FhirNormalizationUtils.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/util/FhirNormalizationUtils.java
@@ -1,0 +1,55 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+/*
+ * Rights Reserved, Unlicensed
+ */
+package org.openmrs.module.fhir2.api.util;
+
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+
+public class FhirNormalizationUtils {
+	
+	/**
+	 * Normalize a CodeableConcept by trimming code/system/display and decoding HL7 v2 escape sequences.
+	 */
+	public static void normalize(CodeableConcept concept) {
+		if (concept == null) {
+			return;
+		}
+		for (Coding coding : concept.getCoding()) {
+			if (coding.hasCode()) {
+				coding.setCode(clean(coding.getCode()));
+			}
+			if (coding.hasSystem()) {
+				coding.setSystem(clean(coding.getSystem()));
+			}
+			if (coding.hasDisplay()) {
+				coding.setDisplay(clean(coding.getDisplay()));
+			}
+		}
+	}
+	
+	private static String clean(String input) {
+		if (input == null) {
+			return null;
+		}
+		String trimmed = input.trim();
+		return decodeHl7Escapes(trimmed);
+	}
+	
+	/**
+	 * Simplified HL7 v2 escape decoding (handles \F\ | \S\ | \T\ | \R\ | \E\).
+	 */
+	private static String decodeHl7Escapes(String value) {
+		return value.replace("\\F\\", "|").replace("\\S\\", "^").replace("\\T\\", "&").replace("\\R\\", "~").replace("\\E\\",
+		    "\\");
+	}
+}

--- a/api/src/main/java/org/openmrs/module/fhir2/api/util/FhirNormalizationUtils.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/util/FhirNormalizationUtils.java
@@ -7,9 +7,6 @@
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */
-/*
- * Rights Reserved, Unlicensed
- */
 package org.openmrs.module.fhir2.api.util;
 
 import org.hl7.fhir.r4.model.CodeableConcept;

--- a/api/src/main/java/org/openmrs/module/fhir2/api/util/FhirNormalizationUtils.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/util/FhirNormalizationUtils.java
@@ -13,7 +13,10 @@ import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
 
 public class FhirNormalizationUtils {
-	
+
+	private FhirNormalizationUtils() {
+	}
+
 	/**
 	 * Normalize a CodeableConcept by trimming code/system/display and decoding HL7 v2 escape sequences.
 	 */

--- a/api/src/test/java/org/openmrs/module/fhir2/api/util/FhirNormalizationUtilsTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/util/FhirNormalizationUtilsTest.java
@@ -1,0 +1,36 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+/*
+ * Rights Reserved, Unlicensed
+ */
+package org.openmrs.module.fhir2.api.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.junit.jupiter.api.Test;
+
+public class FhirNormalizationUtilsTest {
+	
+	@Test
+	public void shouldTrimAndDecodeCodings() {
+		CodeableConcept concept = new CodeableConcept();
+		concept.addCoding(
+		    new Coding().setSystem("  http://loinc.org  ").setCode(" 1234-5 ").setDisplay("Blood Test \\F\\ Panel"));
+		
+		FhirNormalizationUtils.normalize(concept);
+		
+		Coding coding = concept.getCodingFirstRep();
+		assertEquals("http://loinc.org", coding.getSystem());
+		assertEquals("1234-5", coding.getCode());
+		assertEquals("Blood Test | Panel", coding.getDisplay());
+	}
+}

--- a/api/src/test/java/org/openmrs/module/fhir2/api/util/FhirNormalizationUtilsTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/util/FhirNormalizationUtilsTest.java
@@ -7,9 +7,6 @@
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */
-/*
- * Rights Reserved, Unlicensed
- */
 package org.openmrs.module.fhir2.api.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
## What I changed
- Added `FhirNormalizationUtils` to trim `CodeableConcept` codings and decode HL7 v2 escapes (\F\ → |, \S\ → ^, \T\ → &, \R\ → ~, \E\ → \).
- Added unit test `FhirNormalizationUtilsTest`.

## Why
- Prevents stray whitespace and HL7 escape sequences from leaking into FHIR R4 resources.

## Tests
- `FhirNormalizationUtilsTest` passes locally.

## Notes
- Java 17 used.
