### PR TITLE
FM2-680: Always set priorPrescription when previousOrder is set

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/MedicationRequestTranslatorImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/MedicationRequestTranslatorImpl.java
@@ -17,8 +17,6 @@ import static org.openmrs.module.fhir2.api.translators.impl.FhirTranslatorUtils.
 
 import javax.annotation.Nonnull;
 
-import java.util.Collections;
-
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
@@ -128,15 +126,10 @@ public class MedicationRequestTranslatorImpl implements MedicationRequestTransla
 		
 		medicationRequest.setDispenseRequest(medicationRequestDispenseRequestComponentTranslator.toFhirResource(drugOrder));
 		
-		if (drugOrder.getPreviousOrder() != null
-		        && (drugOrder.getAction() == Order.Action.DISCONTINUE || drugOrder.getAction() == Order.Action.REVISE)) {
+		if (drugOrder.getPreviousOrder() != null) {
 			medicationRequest.setPriorPrescription(
 			    medicationRequestReferenceTranslator.toFhirResource((DrugOrder) drugOrder.getPreviousOrder())
 			            .setIdentifier(orderIdentifierTranslator.toFhirResource(drugOrder.getPreviousOrder())));
-		} else if (drugOrder.getPreviousOrder() != null && drugOrder.getAction() == Order.Action.RENEW) {
-			medicationRequest.setBasedOn(Collections.singletonList(
-			    medicationRequestReferenceTranslator.toFhirResource((DrugOrder) drugOrder.getPreviousOrder())
-			            .setIdentifier(orderIdentifierTranslator.toFhirResource(drugOrder.getPreviousOrder()))));
 		}
 		
 		if (drugOrder.getFulfillerStatus() != null) {

--- a/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/MedicationRequestTranslatorImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/MedicationRequestTranslatorImplTest.java
@@ -220,7 +220,7 @@ public class MedicationRequestTranslatorImplTest {
 	}
 	
 	@Test
-	public void toFhirResource_shouldTranslateToFhirResourceWithBasedOnFieldGivenRenewOrder() {
+	public void toFhirResource_shouldTranslateToFhirResourceWithPriorPrescriptionGivenRenewOrder() {
 		discontinuedDrugOrder.setAction(Order.Action.RENEW);
 		
 		MedicationRequest result = medicationRequestTranslator.toFhirResource(discontinuedDrugOrder);
@@ -228,8 +228,21 @@ public class MedicationRequestTranslatorImplTest {
 		assertThat(result, notNullValue());
 		assertThat(result.getId(), notNullValue());
 		assertThat(result.getId(), equalTo(DISCONTINUED_DRUG_ORDER_UUID));
-		assertThat(result.getBasedOn().get(0).getReference(), equalTo(PRIOR_MEDICATION_REQUEST_REFERENCE));
-		assertThat(result.getBasedOn().get(0).getIdentifier().getValue(), equalTo(DRUG_ORDER_NUMBER));
+		assertThat(result.getPriorPrescription().getReference(), equalTo(PRIOR_MEDICATION_REQUEST_REFERENCE));
+		assertThat(result.getPriorPrescription().getIdentifier().getValue(), equalTo(DRUG_ORDER_NUMBER));
+	}
+	
+	@Test
+	public void toFhirResource_shouldTranslateToFhirResourceWithPriorPrescriptionGivenNewOrderWithPreviousOrder() {
+		discontinuedDrugOrder.setAction(Order.Action.NEW);
+		
+		MedicationRequest result = medicationRequestTranslator.toFhirResource(discontinuedDrugOrder);
+		
+		assertThat(result, notNullValue());
+		assertThat(result.getId(), notNullValue());
+		assertThat(result.getId(), equalTo(DISCONTINUED_DRUG_ORDER_UUID));
+		assertThat(result.getPriorPrescription().getReference(), equalTo(PRIOR_MEDICATION_REQUEST_REFERENCE));
+		assertThat(result.getPriorPrescription().getIdentifier().getValue(), equalTo(DRUG_ORDER_NUMBER));
 	}
 	
 	@Test(expected = NullPointerException.class)


### PR DESCRIPTION
## Description of what I changed
<!--- Describe your changes in detail -->
  - Collapse the action-discriminated branch in MedicationRequestTranslatorImpl to a single previousOrder != null check that always sets
  priorPrescription.
  - Drop the basedOn branch previously used for RENEW.
  - Fixes O3 renewals (placed as action = NEW with previous_order_id set) returning null priorPrescription, which broke continuity-of-care and refill
   analytics.
  - priorPrescription is the FHIR R4 field for prescription chains; basedOn is for plan/proposal fulfillment (wrong semantics).
  - Update RENEW test to assert priorPrescription; add new test for action = NEW with previousOrder set.

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/FM2-680

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

## Anything else?
