### PR TITLE
FM2-683 | Extend Fhir Task to have Draft and In Progress Task Statuses

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhir2/api/dao/impl/FhirTaskDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/dao/impl/FhirTaskDaoImpl.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.ReferenceParam;
 import ca.uhn.fhir.rest.param.TokenAndListParam;
+import org.hl7.fhir.r4.model.Task;
 import org.openmrs.api.db.DAOException;
 import org.openmrs.module.fhir2.FhirConstants;
 import org.openmrs.module.fhir2.api.dao.FhirTaskDao;
@@ -91,7 +92,7 @@ public class FhirTaskDaoImpl extends BaseFhirDao<FhirTask> implements FhirTaskDa
 			if (token.getValue() != null) {
 				try {
 					return Optional.of(criteriaContext.getCriteriaBuilder().equal(criteriaContext.getRoot().get("status"),
-					    FhirTask.TaskStatus.valueOf(token.getValue().toUpperCase())));
+					    FhirTask.TaskStatus.valueOf(Task.TaskStatus.fromCode(token.getValue()).name())));
 				}
 				catch (IllegalArgumentException e) {
 					return Optional.empty();

--- a/api/src/main/java/org/openmrs/module/fhir2/api/dao/impl/FhirTaskDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/dao/impl/FhirTaskDaoImpl.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import ca.uhn.fhir.rest.param.ReferenceAndListParam;
 import ca.uhn.fhir.rest.param.ReferenceParam;
 import ca.uhn.fhir.rest.param.TokenAndListParam;
+import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.r4.model.Task;
 import org.openmrs.api.db.DAOException;
 import org.openmrs.module.fhir2.FhirConstants;
@@ -92,9 +93,9 @@ public class FhirTaskDaoImpl extends BaseFhirDao<FhirTask> implements FhirTaskDa
 			if (token.getValue() != null) {
 				try {
 					return Optional.of(criteriaContext.getCriteriaBuilder().equal(criteriaContext.getRoot().get("status"),
-					    FhirTask.TaskStatus.valueOf(Task.TaskStatus.fromCode(token.getValue()).name())));
+					    FhirTask.TaskStatus.valueOf(Task.TaskStatus.fromCode(token.getValue().toLowerCase()).name())));
 				}
-				catch (IllegalArgumentException e) {
+				catch (IllegalArgumentException | FHIRException e) {
 					return Optional.empty();
 				}
 			}

--- a/api/src/main/java/org/openmrs/module/fhir2/api/dao/impl/FhirTaskDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/dao/impl/FhirTaskDaoImpl.java
@@ -90,7 +90,7 @@ public class FhirTaskDaoImpl extends BaseFhirDao<FhirTask> implements FhirTaskDa
 	        TokenAndListParam tokenAndListParam) {
 		
 		return handleAndListParam(criteriaContext.getCriteriaBuilder(), tokenAndListParam, token -> {
-			if (token.getValue() != null) {
+			if (token.getValue() != null && !token.getValue().isEmpty()) {
 				try {
 					return Optional.of(criteriaContext.getCriteriaBuilder().equal(criteriaContext.getRoot().get("status"),
 					    FhirTask.TaskStatus.valueOf(Task.TaskStatus.fromCode(token.getValue().toLowerCase()).name())));

--- a/api/src/main/java/org/openmrs/module/fhir2/model/FhirTask.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/model/FhirTask.java
@@ -44,8 +44,10 @@ public class FhirTask extends BaseOpenmrsMetadata {
 	 * Based on <a href="https://www.hl7.org/fhir/task.html">...</a> v4.0.1
 	 */
 	public enum TaskStatus {
+		DRAFT,
 		REQUESTED,
 		READY,
+		INPROGRESS,
 		ONHOLD,
 		CANCELLED,
 		REJECTED,

--- a/api/src/main/java/org/openmrs/module/fhir2/model/FhirTask.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/model/FhirTask.java
@@ -46,13 +46,16 @@ public class FhirTask extends BaseOpenmrsMetadata {
 	public enum TaskStatus {
 		DRAFT,
 		REQUESTED,
+		RECEIVED,
+		ACCEPTED,
+		REJECTED,
 		READY,
+		CANCELLED,
 		INPROGRESS,
 		ONHOLD,
-		CANCELLED,
-		REJECTED,
-		ACCEPTED,
+		FAILED,
 		COMPLETED,
+		ENTEREDINERROR,
 		UNKNOWN
 	}
 	

--- a/api/src/test/java/org/openmrs/module/fhir2/api/dao/impl/FhirTaskDaoImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/dao/impl/FhirTaskDaoImplTest.java
@@ -23,7 +23,10 @@ import java.time.Month;
 import java.time.ZoneId;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 
+import ca.uhn.fhir.rest.param.TokenAndListParam;
+import ca.uhn.fhir.rest.param.TokenOrListParam;
 import org.hibernate.SessionFactory;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,6 +35,7 @@ import org.openmrs.api.ConceptService;
 import org.openmrs.api.db.hibernate.HibernateConceptDAO;
 import org.openmrs.module.fhir2.BaseFhirContextSensitiveTest;
 import org.openmrs.module.fhir2.FhirConstants;
+import org.openmrs.module.fhir2.api.search.param.SearchParameterMap;
 import org.openmrs.module.fhir2.model.FhirReference;
 import org.openmrs.module.fhir2.model.FhirTask;
 import org.openmrs.module.fhir2.model.FhirTaskInput;
@@ -379,6 +383,19 @@ public class FhirTaskDaoImplTest extends BaseFhirContextSensitiveTest {
 		assertThat(updatedOutput.getOutput(), hasItem(hasProperty("type", hasProperty("uuid", equalTo(CONCEPT_UUID)))));
 		assertThat(updatedOutput.getOutput(),
 		    hasItem(hasProperty("valueReference", hasProperty("reference", equalTo(DIAGNOSTIC_REPORT_UUID)))));
+	}
+	
+	@Test
+	public void searchForTasks_shouldReturnAllTasksForEmptyStatus() {
+		TokenAndListParam status = new TokenAndListParam()
+		        .addAnd(new TokenOrListParam().add(FhirConstants.TASK_STATUS_VALUE_SET_URI, ""));
+		
+		SearchParameterMap theParams = new SearchParameterMap().addParameter(FhirConstants.STATUS_SEARCH_HANDLER, status);
+		
+		List<FhirTask> results = dao.getSearchResults(theParams);
+		
+		assertThat(results, notNullValue());
+		assertThat(results, not(empty()));
 	}
 	
 	@Test

--- a/api/src/test/java/org/openmrs/module/fhir2/api/search/TaskSearchQueryTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/search/TaskSearchQueryTest.java
@@ -439,6 +439,21 @@ public class TaskSearchQueryTest extends BaseFhirContextSensitiveTest {
 	}
 	
 	@Test
+	public void searchForTasks_shouldReturnAllTasksForEmptyStatus() {
+		TokenAndListParam status = new TokenAndListParam()
+		        .addAnd(new TokenOrListParam().add(FhirConstants.TASK_STATUS_VALUE_SET_URI, ""));
+		
+		SearchParameterMap theParams = new SearchParameterMap().addParameter(FhirConstants.STATUS_SEARCH_HANDLER, status);
+		
+		IBundleProvider results = search(theParams);
+		
+		List<IBaseResource> resultList = get(results);
+		
+		assertThat(results, notNullValue());
+		assertThat(resultList, not(empty()));
+	}
+	
+	@Test
 	public void searchForTasks_shouldReturnEmptyTaskListByMultipleStatusAnd() {
 		TokenAndListParam status = new TokenAndListParam()
 		        .addAnd(

--- a/api/src/test/java/org/openmrs/module/fhir2/api/search/TaskSearchQueryTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/search/TaskSearchQueryTest.java
@@ -66,9 +66,9 @@ public class TaskSearchQueryTest extends BaseFhirContextSensitiveTest {
 	
 	private static final String INPROGRESS_TASK_UUID = "b3c9f4a7-44dc-4b29-adfd-a8b297a41f44";
 	
-	private static final String ONHOLD_TASK_UUID = "c4d0e5b8-55ed-4c30-beae-b9c308b52g55";
+	private static final String ONHOLD_TASK_UUID = "c4d0e5b8-55ed-4c30-beae-b9c308b520c5";
 	
-	private static final String ENTEREDINERROR_TASK_UUID = "f7g3h8e1-88hg-4f63-e1d1-e2f631e85j88";
+	private static final String ENTEREDINERROR_TASK_UUID = "f703b8e1-88f6-4f63-e1d1-e2f631e85388";
 	
 	private static final String BASED_ON_TASK_UUID = "3dc9f4a7-44dc-4b29-adfd-a8b297a41f33";
 	

--- a/api/src/test/java/org/openmrs/module/fhir2/api/search/TaskSearchQueryTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/search/TaskSearchQueryTest.java
@@ -424,6 +424,21 @@ public class TaskSearchQueryTest extends BaseFhirContextSensitiveTest {
 	}
 	
 	@Test
+	public void searchForTasks_shouldReturnAllTasksForUnrecognizedStatus() {
+		TokenAndListParam status = new TokenAndListParam()
+		        .addAnd(new TokenOrListParam().add(FhirConstants.TASK_STATUS_VALUE_SET_URI, "not-a-real-status"));
+		
+		SearchParameterMap theParams = new SearchParameterMap().addParameter(FhirConstants.STATUS_SEARCH_HANDLER, status);
+		
+		IBundleProvider results = search(theParams);
+		
+		List<IBaseResource> resultList = get(results);
+		
+		assertThat(results, notNullValue());
+		assertThat(resultList, not(empty()));
+	}
+	
+	@Test
 	public void searchForTasks_shouldReturnEmptyTaskListByMultipleStatusAnd() {
 		TokenAndListParam status = new TokenAndListParam()
 		        .addAnd(

--- a/api/src/test/java/org/openmrs/module/fhir2/api/search/TaskSearchQueryTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/search/TaskSearchQueryTest.java
@@ -64,6 +64,12 @@ public class TaskSearchQueryTest extends BaseFhirContextSensitiveTest {
 	
 	private static final String TASK_UUID = "d899333c-5bd4-45cc-b1e7-2f9542dbcbf6";
 	
+	private static final String INPROGRESS_TASK_UUID = "b3c9f4a7-44dc-4b29-adfd-a8b297a41f44";
+	
+	private static final String ONHOLD_TASK_UUID = "c4d0e5b8-55ed-4c30-beae-b9c308b52g55";
+	
+	private static final String ENTEREDINERROR_TASK_UUID = "f7g3h8e1-88hg-4f63-e1d1-e2f631e85j88";
+	
 	private static final String BASED_ON_TASK_UUID = "3dc9f4a7-44dc-4b29-adfd-a8b297a41f33";
 	
 	private static final String BASED_ON_ORDER_UUID = "7d96f25c-4949-4f72-9931-d808fbc226de";
@@ -432,6 +438,60 @@ public class TaskSearchQueryTest extends BaseFhirContextSensitiveTest {
 		
 		assertThat(results, notNullValue());
 		assertThat(resultList, empty());
+	}
+	
+	@Test
+	public void searchForTasks_shouldReturnTasksByWireCodeInProgress() {
+		TokenAndListParam status = new TokenAndListParam()
+		        .addAnd(new TokenOrListParam().add(FhirConstants.TASK_STATUS_VALUE_SET_URI, "in-progress"));
+		
+		SearchParameterMap theParams = new SearchParameterMap().addParameter(FhirConstants.STATUS_SEARCH_HANDLER, status);
+		
+		IBundleProvider results = search(theParams);
+		
+		List<IBaseResource> resultList = get(results);
+		
+		assertThat(results, notNullValue());
+		assertThat(resultList, not(empty()));
+		assertThat(resultList, hasSize(equalTo(1)));
+		assertThat(resultList, hasItem(hasProperty("id", equalTo(INPROGRESS_TASK_UUID))));
+		assertThat(resultList, everyItem(hasProperty("status", equalTo(Task.TaskStatus.INPROGRESS))));
+	}
+	
+	@Test
+	public void searchForTasks_shouldReturnTasksByWireCodeOnHold() {
+		TokenAndListParam status = new TokenAndListParam()
+		        .addAnd(new TokenOrListParam().add(FhirConstants.TASK_STATUS_VALUE_SET_URI, "on-hold"));
+		
+		SearchParameterMap theParams = new SearchParameterMap().addParameter(FhirConstants.STATUS_SEARCH_HANDLER, status);
+		
+		IBundleProvider results = search(theParams);
+		
+		List<IBaseResource> resultList = get(results);
+		
+		assertThat(results, notNullValue());
+		assertThat(resultList, not(empty()));
+		assertThat(resultList, hasSize(equalTo(1)));
+		assertThat(resultList, hasItem(hasProperty("id", equalTo(ONHOLD_TASK_UUID))));
+		assertThat(resultList, everyItem(hasProperty("status", equalTo(Task.TaskStatus.ONHOLD))));
+	}
+	
+	@Test
+	public void searchForTasks_shouldReturnTasksByWireCodeEnteredInError() {
+		TokenAndListParam status = new TokenAndListParam()
+		        .addAnd(new TokenOrListParam().add(FhirConstants.TASK_STATUS_VALUE_SET_URI, "entered-in-error"));
+		
+		SearchParameterMap theParams = new SearchParameterMap().addParameter(FhirConstants.STATUS_SEARCH_HANDLER, status);
+		
+		IBundleProvider results = search(theParams);
+		
+		List<IBaseResource> resultList = get(results);
+		
+		assertThat(results, notNullValue());
+		assertThat(resultList, not(empty()));
+		assertThat(resultList, hasSize(equalTo(1)));
+		assertThat(resultList, hasItem(hasProperty("id", equalTo(ENTEREDINERROR_TASK_UUID))));
+		assertThat(resultList, everyItem(hasProperty("status", equalTo(Task.TaskStatus.ENTEREDINERROR))));
 	}
 	
 	@Test

--- a/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/TaskTranslatorImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/TaskTranslatorImplTest.java
@@ -87,16 +87,24 @@ public class TaskTranslatorImplTest {
 	private static final FhirTask.TaskStatus OPENMRS_NEW_TASK_STATUS = FhirTask.TaskStatus.ACCEPTED;
 	
 	private static final Task.TaskStatus FHIR_TASK_STATUS_READY = Task.TaskStatus.READY;
-	
+
 	private static final Task.TaskStatus FHIR_TASK_STATUS_ONHOLD = Task.TaskStatus.ONHOLD;
-	
+
 	private static final Task.TaskStatus FHIR_TASK_STATUS_CANCELLED = Task.TaskStatus.CANCELLED;
-	
+
+	private static final Task.TaskStatus FHIR_TASK_STATUS_DRAFT = Task.TaskStatus.DRAFT;
+
+	private static final Task.TaskStatus FHIR_TASK_STATUS_INPROGRESS = Task.TaskStatus.INPROGRESS;
+
 	private static final FhirTask.TaskStatus OPENMRS_TASK_STATUS_READY = FhirTask.TaskStatus.READY;
-	
+
 	private static final FhirTask.TaskStatus OPENMRS_TASK_STATUS_ONHOLD = FhirTask.TaskStatus.ONHOLD;
-	
+
 	private static final FhirTask.TaskStatus OPENMRS_TASK_STATUS_CANCELLED = FhirTask.TaskStatus.CANCELLED;
+
+	private static final FhirTask.TaskStatus OPENMRS_TASK_STATUS_DRAFT = FhirTask.TaskStatus.DRAFT;
+
+	private static final FhirTask.TaskStatus OPENMRS_TASK_STATUS_INPROGRESS = FhirTask.TaskStatus.INPROGRESS;
 	
 	private static final Task.TaskIntent FHIR_TASK_INTENT = Task.TaskIntent.ORDER;
 	
@@ -253,26 +261,38 @@ public class TaskTranslatorImplTest {
 		
 		task.setStatus(OPENMRS_TASK_STATUS_CANCELLED);
 		assertThat(taskTranslator.toFhirResource(task).getStatus(), equalTo(FHIR_TASK_STATUS_CANCELLED));
+
+		task.setStatus(OPENMRS_TASK_STATUS_DRAFT);
+		assertThat(taskTranslator.toFhirResource(task).getStatus(), equalTo(FHIR_TASK_STATUS_DRAFT));
+
+		task.setStatus(OPENMRS_TASK_STATUS_INPROGRESS);
+		assertThat(taskTranslator.toFhirResource(task).getStatus(), equalTo(FHIR_TASK_STATUS_INPROGRESS));
 	}
-	
+
 	@Test
 	public void toOpenmrsType_shouldTranslateStatus() {
 		Task task = new Task();
 		task.setStatus(FHIR_TASK_STATUS);
-		
+
 		FhirTask result = taskTranslator.toOpenmrsType(task);
-		
+
 		assertThat(result, notNullValue());
 		assertThat(result.getStatus(), equalTo(OPENMRS_TASK_STATUS));
-		
+
 		task.setStatus(FHIR_TASK_STATUS_READY);
 		assertThat(taskTranslator.toOpenmrsType(task).getStatus(), equalTo(OPENMRS_TASK_STATUS_READY));
-		
+
 		task.setStatus(FHIR_TASK_STATUS_ONHOLD);
 		assertThat(taskTranslator.toOpenmrsType(task).getStatus(), equalTo(OPENMRS_TASK_STATUS_ONHOLD));
-		
+
 		task.setStatus(FHIR_TASK_STATUS_CANCELLED);
 		assertThat(taskTranslator.toOpenmrsType(task).getStatus(), equalTo(OPENMRS_TASK_STATUS_CANCELLED));
+
+		task.setStatus(FHIR_TASK_STATUS_DRAFT);
+		assertThat(taskTranslator.toOpenmrsType(task).getStatus(), equalTo(OPENMRS_TASK_STATUS_DRAFT));
+
+		task.setStatus(FHIR_TASK_STATUS_INPROGRESS);
+		assertThat(taskTranslator.toOpenmrsType(task).getStatus(), equalTo(OPENMRS_TASK_STATUS_INPROGRESS));
 	}
 	
 	@Test

--- a/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/TaskTranslatorImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/TaskTranslatorImplTest.java
@@ -87,24 +87,36 @@ public class TaskTranslatorImplTest {
 	private static final FhirTask.TaskStatus OPENMRS_NEW_TASK_STATUS = FhirTask.TaskStatus.ACCEPTED;
 	
 	private static final Task.TaskStatus FHIR_TASK_STATUS_READY = Task.TaskStatus.READY;
-
+	
 	private static final Task.TaskStatus FHIR_TASK_STATUS_ONHOLD = Task.TaskStatus.ONHOLD;
-
+	
 	private static final Task.TaskStatus FHIR_TASK_STATUS_CANCELLED = Task.TaskStatus.CANCELLED;
-
+	
 	private static final Task.TaskStatus FHIR_TASK_STATUS_DRAFT = Task.TaskStatus.DRAFT;
-
+	
 	private static final Task.TaskStatus FHIR_TASK_STATUS_INPROGRESS = Task.TaskStatus.INPROGRESS;
-
+	
+	private static final Task.TaskStatus FHIR_TASK_STATUS_RECEIVED = Task.TaskStatus.RECEIVED;
+	
+	private static final Task.TaskStatus FHIR_TASK_STATUS_FAILED = Task.TaskStatus.FAILED;
+	
+	private static final Task.TaskStatus FHIR_TASK_STATUS_ENTEREDINERROR = Task.TaskStatus.ENTEREDINERROR;
+	
 	private static final FhirTask.TaskStatus OPENMRS_TASK_STATUS_READY = FhirTask.TaskStatus.READY;
-
+	
 	private static final FhirTask.TaskStatus OPENMRS_TASK_STATUS_ONHOLD = FhirTask.TaskStatus.ONHOLD;
-
+	
 	private static final FhirTask.TaskStatus OPENMRS_TASK_STATUS_CANCELLED = FhirTask.TaskStatus.CANCELLED;
-
+	
 	private static final FhirTask.TaskStatus OPENMRS_TASK_STATUS_DRAFT = FhirTask.TaskStatus.DRAFT;
-
+	
 	private static final FhirTask.TaskStatus OPENMRS_TASK_STATUS_INPROGRESS = FhirTask.TaskStatus.INPROGRESS;
+	
+	private static final FhirTask.TaskStatus OPENMRS_TASK_STATUS_RECEIVED = FhirTask.TaskStatus.RECEIVED;
+	
+	private static final FhirTask.TaskStatus OPENMRS_TASK_STATUS_FAILED = FhirTask.TaskStatus.FAILED;
+	
+	private static final FhirTask.TaskStatus OPENMRS_TASK_STATUS_ENTEREDINERROR = FhirTask.TaskStatus.ENTEREDINERROR;
 	
 	private static final Task.TaskIntent FHIR_TASK_INTENT = Task.TaskIntent.ORDER;
 	
@@ -261,49 +273,56 @@ public class TaskTranslatorImplTest {
 		
 		task.setStatus(OPENMRS_TASK_STATUS_CANCELLED);
 		assertThat(taskTranslator.toFhirResource(task).getStatus(), equalTo(FHIR_TASK_STATUS_CANCELLED));
-
+		
 		task.setStatus(OPENMRS_TASK_STATUS_DRAFT);
 		assertThat(taskTranslator.toFhirResource(task).getStatus(), equalTo(FHIR_TASK_STATUS_DRAFT));
-
+		
 		task.setStatus(OPENMRS_TASK_STATUS_INPROGRESS);
 		assertThat(taskTranslator.toFhirResource(task).getStatus(), equalTo(FHIR_TASK_STATUS_INPROGRESS));
+		
+		task.setStatus(OPENMRS_TASK_STATUS_RECEIVED);
+		assertThat(taskTranslator.toFhirResource(task).getStatus(), equalTo(FHIR_TASK_STATUS_RECEIVED));
+		
+		task.setStatus(OPENMRS_TASK_STATUS_FAILED);
+		assertThat(taskTranslator.toFhirResource(task).getStatus(), equalTo(FHIR_TASK_STATUS_FAILED));
+		
+		task.setStatus(OPENMRS_TASK_STATUS_ENTEREDINERROR);
+		assertThat(taskTranslator.toFhirResource(task).getStatus(), equalTo(FHIR_TASK_STATUS_ENTEREDINERROR));
 	}
-
+	
 	@Test
 	public void toOpenmrsType_shouldTranslateStatus() {
 		Task task = new Task();
 		task.setStatus(FHIR_TASK_STATUS);
-
+		
 		FhirTask result = taskTranslator.toOpenmrsType(task);
-
+		
 		assertThat(result, notNullValue());
 		assertThat(result.getStatus(), equalTo(OPENMRS_TASK_STATUS));
-
+		
 		task.setStatus(FHIR_TASK_STATUS_READY);
 		assertThat(taskTranslator.toOpenmrsType(task).getStatus(), equalTo(OPENMRS_TASK_STATUS_READY));
-
+		
 		task.setStatus(FHIR_TASK_STATUS_ONHOLD);
 		assertThat(taskTranslator.toOpenmrsType(task).getStatus(), equalTo(OPENMRS_TASK_STATUS_ONHOLD));
-
+		
 		task.setStatus(FHIR_TASK_STATUS_CANCELLED);
 		assertThat(taskTranslator.toOpenmrsType(task).getStatus(), equalTo(OPENMRS_TASK_STATUS_CANCELLED));
-
+		
 		task.setStatus(FHIR_TASK_STATUS_DRAFT);
 		assertThat(taskTranslator.toOpenmrsType(task).getStatus(), equalTo(OPENMRS_TASK_STATUS_DRAFT));
-
+		
 		task.setStatus(FHIR_TASK_STATUS_INPROGRESS);
 		assertThat(taskTranslator.toOpenmrsType(task).getStatus(), equalTo(OPENMRS_TASK_STATUS_INPROGRESS));
-	}
-	
-	@Test
-	public void toOpenmrsType_shouldTranslateUnsupportedStatusToUnknown() {
-		Task task = new Task();
-		task.setStatus(Task.TaskStatus.ENTEREDINERROR);
 		
-		FhirTask result = taskTranslator.toOpenmrsType(task);
+		task.setStatus(FHIR_TASK_STATUS_RECEIVED);
+		assertThat(taskTranslator.toOpenmrsType(task).getStatus(), equalTo(OPENMRS_TASK_STATUS_RECEIVED));
 		
-		assertThat(result, notNullValue());
-		assertThat(result.getStatus(), equalTo(FhirTask.TaskStatus.UNKNOWN));
+		task.setStatus(FHIR_TASK_STATUS_FAILED);
+		assertThat(taskTranslator.toOpenmrsType(task).getStatus(), equalTo(OPENMRS_TASK_STATUS_FAILED));
+		
+		task.setStatus(FHIR_TASK_STATUS_ENTEREDINERROR);
+		assertThat(taskTranslator.toOpenmrsType(task).getStatus(), equalTo(OPENMRS_TASK_STATUS_ENTEREDINERROR));
 	}
 	
 	@Test

--- a/test-data/src/main/resources/org/openmrs/module/fhir2/api/dao/impl/FhirTaskDaoImplTest_initial_data.xml
+++ b/test-data/src/main/resources/org/openmrs/module/fhir2/api/dao/impl/FhirTaskDaoImplTest_initial_data.xml
@@ -84,8 +84,8 @@
 
 	<fhir_task task_id="10" name="Task with for reference and code " status="REQUESTED" task_code="5030" for_reference_id="5" intent="ORDER" creator="1" date_created="2024-04-07 00:00:00.0" date_changed="2024-04-07 00:00:00.0" retired="false" uuid="271a44b4-dbc8-4b83-8d3d-c794339d06e9"/>
 	<fhir_task task_id="11" name="In Progress Task" status="INPROGRESS" intent="ORDER" creator="1" date_created="2024-04-08 00:00:00.0" date_changed="2024-04-08 00:00:00.0" retired="false" uuid="b3c9f4a7-44dc-4b29-adfd-a8b297a41f44"/>
-	<fhir_task task_id="12" name="On Hold Task" status="ONHOLD" intent="ORDER" creator="1" date_created="2024-04-09 00:00:00.0" date_changed="2024-04-09 00:00:00.0" retired="false" uuid="c4d0e5b8-55ed-4c30-beae-b9c308b52g55"/>
-	<fhir_task task_id="13" name="Entered In Error Task" status="ENTEREDINERROR" intent="ORDER" creator="1" date_created="2024-04-10 00:00:00.0" date_changed="2024-04-10 00:00:00.0" retired="false" uuid="f7g3h8e1-88hg-4f63-e1d1-e2f631e85j88"/>
+	<fhir_task task_id="12" name="On Hold Task" status="ONHOLD" intent="ORDER" creator="1" date_created="2024-04-09 00:00:00.0" date_changed="2024-04-09 00:00:00.0" retired="false" uuid="c4d0e5b8-55ed-4c30-beae-b9c308b520c5"/>
+	<fhir_task task_id="13" name="Entered In Error Task" status="ENTEREDINERROR" intent="ORDER" creator="1" date_created="2024-04-10 00:00:00.0" date_changed="2024-04-10 00:00:00.0" retired="false" uuid="f703b8e1-88f6-4f63-e1d1-e2f631e85388"/>
 	<fhir_task task_id="14" name="Draft Task" status="DRAFT" intent="ORDER" creator="1" date_created="2024-04-11 00:00:00.0" date_changed="2024-04-11 00:00:00.0" retired="false" uuid="a1b2c3d4-11ab-4a11-aa11-a1b2c3d4e5f6"/>
 	<fhir_task task_id="15" name="Received Task" status="RECEIVED" intent="ORDER" creator="1" date_created="2024-04-12 00:00:00.0" date_changed="2024-04-12 00:00:00.0" retired="false" uuid="b2c3d4e5-22bc-4b22-bb22-b2c3d4e5f6a7"/>
 	<fhir_task task_id="16" name="Ready Task" status="READY" intent="ORDER" creator="1" date_created="2024-04-13 00:00:00.0" date_changed="2024-04-13 00:00:00.0" retired="false" uuid="c3d4e5f6-33cd-4c33-cc33-c3d4e5f6a7b8"/>

--- a/test-data/src/main/resources/org/openmrs/module/fhir2/api/dao/impl/FhirTaskDaoImplTest_initial_data.xml
+++ b/test-data/src/main/resources/org/openmrs/module/fhir2/api/dao/impl/FhirTaskDaoImplTest_initial_data.xml
@@ -83,5 +83,14 @@
 	<!--Task.for -->
 
 	<fhir_task task_id="10" name="Task with for reference and code " status="REQUESTED" task_code="5030" for_reference_id="5" intent="ORDER" creator="1" date_created="2024-04-07 00:00:00.0" date_changed="2024-04-07 00:00:00.0" retired="false" uuid="271a44b4-dbc8-4b83-8d3d-c794339d06e9"/>
+	<fhir_task task_id="11" name="In Progress Task" status="INPROGRESS" intent="ORDER" creator="1" date_created="2024-04-08 00:00:00.0" date_changed="2024-04-08 00:00:00.0" retired="false" uuid="b3c9f4a7-44dc-4b29-adfd-a8b297a41f44"/>
+	<fhir_task task_id="12" name="On Hold Task" status="ONHOLD" intent="ORDER" creator="1" date_created="2024-04-09 00:00:00.0" date_changed="2024-04-09 00:00:00.0" retired="false" uuid="c4d0e5b8-55ed-4c30-beae-b9c308b52g55"/>
+	<fhir_task task_id="13" name="Entered In Error Task" status="ENTEREDINERROR" intent="ORDER" creator="1" date_created="2024-04-10 00:00:00.0" date_changed="2024-04-10 00:00:00.0" retired="false" uuid="f7g3h8e1-88hg-4f63-e1d1-e2f631e85j88"/>
+	<fhir_task task_id="14" name="Draft Task" status="DRAFT" intent="ORDER" creator="1" date_created="2024-04-11 00:00:00.0" date_changed="2024-04-11 00:00:00.0" retired="false" uuid="a1b2c3d4-11ab-4a11-aa11-a1b2c3d4e5f6"/>
+	<fhir_task task_id="15" name="Received Task" status="RECEIVED" intent="ORDER" creator="1" date_created="2024-04-12 00:00:00.0" date_changed="2024-04-12 00:00:00.0" retired="false" uuid="b2c3d4e5-22bc-4b22-bb22-b2c3d4e5f6a7"/>
+	<fhir_task task_id="16" name="Ready Task" status="READY" intent="ORDER" creator="1" date_created="2024-04-13 00:00:00.0" date_changed="2024-04-13 00:00:00.0" retired="false" uuid="c3d4e5f6-33cd-4c33-cc33-c3d4e5f6a7b8"/>
+	<fhir_task task_id="17" name="Failed Task" status="FAILED" intent="ORDER" creator="1" date_created="2024-04-14 00:00:00.0" date_changed="2024-04-14 00:00:00.0" retired="false" uuid="d4e5f6a7-44de-4d44-dd44-d4e5f6a7b8c9"/>
+	<fhir_task task_id="18" name="Cancelled Task" status="CANCELLED" intent="ORDER" creator="1" date_created="2024-04-15 00:00:00.0" date_changed="2024-04-15 00:00:00.0" retired="false" uuid="e5f6a7b8-55ef-4e55-ee55-e5f6a7b8c9d0"/>
+	<fhir_task task_id="19" name="Completed Task" status="COMPLETED" intent="ORDER" creator="1" date_created="2024-04-16 00:00:00.0" date_changed="2024-04-16 00:00:00.0" retired="false" uuid="f6a7b8c9-66fa-4f66-ff66-f6a7b8c9d0e1"/>
 
 </dataset>


### PR DESCRIPTION
JIRA card: https://openmrs.atlassian.net/browse/FM2-683

Description of what I changed:
- Added the existing R4 Task statuses: DRAFT and IN PROGRESS to the TaskStatus enum of the FhirTask class.
- Added relevant tests.

Please review: @ibacher @dkayiwa 