### PR TITLE
O3-5740: Fix 404 when updating a Condition created from a Visit Note diagnosis

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhir2/api/impl/FhirConditionServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/impl/FhirConditionServiceImpl.java
@@ -113,14 +113,12 @@ public class FhirConditionServiceImpl extends BaseFhirService<Condition, org.ope
 			throw new InvalidRequestException("Condition cannot be null");
 		}
 		
-		FhirUtils.OpenmrsConditionType result = FhirUtils.getOpenmrsConditionType(condition).orElse(null);
-		
-		if (result.equals(FhirUtils.OpenmrsConditionType.DIAGNOSIS)) {
-			return diagnosisService.update(uuid, condition);
-		} else {
+		try {
 			return super.update(uuid, condition);
 		}
-		
+		catch (ResourceNotFoundException e) {
+			return diagnosisService.update(uuid, condition);
+		}
 	}
 	
 	@Override


### PR DESCRIPTION
## Description of what I changed

`FhirConditionServiceImpl.update()` routed updates based on the `category` field in the incoming payload — but edit requests from the patient chart don't send `category`, so updates to Diagnosis-backed Conditions (`encounter-diagnosis`) always fell through to `super.update()`, which only checks the `conditions` table. Result: 404 "Resource of type Condition with ID ... is not known", even though `GET` on the same id returns 200.

Fix: mirror the existing `get()`/`delete()` pattern — try `super.update()` first, fall back to `diagnosisService.update()` on `ResourceNotFoundException`. Routes by where the resource actually lives, not by a field the client may omit.

```java
@Override
public Condition update(@Nonnull String uuid, @Nonnull Condition condition) {

	if (uuid == null) {
		throw new InvalidRequestException("Uuid cannot be null.");
	}

	if (condition == null) {
		throw new InvalidRequestException("Condition cannot be null");
	}

	try {
		return super.update(uuid, condition);
	}
	catch (ResourceNotFoundException e) {
		return diagnosisService.update(uuid, condition);
	}
}
```

**Verification:**
- Reproduced on test3.openmrs.org (Visit Note diagnosis → Conditions list → edit → 404).
- Confirmed `GET /Condition/{uuid}` returns 200 with `category: encounter-diagnosis` while `PUT` to the same URL returned 404.
- Full `fhir2-api` suite: 4314 tests, 0 failures.
- With fix applied locally: `PUT /Condition/{uuid}` returns 200, changes persist.
- Regression: editing a directly-created Condition still works via `super.update()` (fallback not triggered).

## Issue I worked on

see https://issues.openmrs.org/browse/O3-5740

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the [code style](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [ ] I have **added tests** to cover my changes.
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [ ] My pull request is **based on the latest changes** of the master branch.

## Anything else?

Doesn't verify whether `FhirDiagnosisServiceImpl.update()` correctly persists `clinicalStatus`/`onsetDate` onto `encounter_diagnosis` — may need a follow-up if those fields silently no-op.