### PR TITLE
TRUNK-6674: Translate drug order duration units for the current SNOMED CT minute code and UCUM mappings

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/DurationUnitTranslatorImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/DurationUnitTranslatorImpl.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.r4.model.Timing;
 import org.openmrs.Concept;
 import org.openmrs.ConceptMap;
@@ -32,6 +33,7 @@ import org.openmrs.module.fhir2.api.translators.DurationUnitTranslator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class DurationUnitTranslatorImpl implements DurationUnitTranslator {
 	
@@ -86,17 +88,28 @@ public class DurationUnitTranslatorImpl implements DurationUnitTranslator {
 	
 	@Override
 	public Timing.UnitsOfTime toFhirResource(@Nonnull Concept concept) {
+		// mirrors Duration.getDuration in TRUNK-6674: a concept whose known codes denote different
+		// units is miscurated, so refuse to pick one rather than serialize an arbitrary unit
+		Timing.UnitsOfTime knownUnit = null;
 		for (ConceptMap conceptMapping : concept.getConceptMappings()) {
 			if (!ConceptMapType.SAME_AS_MAP_TYPE_UUID.equals(conceptMapping.getConceptMapType().getUuid())) {
 				continue;
 			}
 			ConceptReferenceTerm term = conceptMapping.getConceptReferenceTerm();
 			Timing.UnitsOfTime unitsOfTime = findUnitsOfTime(term.getConceptSource(), term.getCode());
-			if (unitsOfTime != null) {
-				return unitsOfTime;
+			if (unitsOfTime == null) {
+				continue;
+			}
+			if (knownUnit == null) {
+				knownUnit = unitsOfTime;
+			} else if (knownUnit != unitsOfTime) {
+				log.warn(
+				    "Not translating duration units concept {} because its SAME-AS mappings denote different units, e.g. {} and {}",
+				    concept.getUuid(), knownUnit, unitsOfTime);
+				return Timing.UnitsOfTime.NULL;
 			}
 		}
-		return Timing.UnitsOfTime.NULL;
+		return knownUnit != null ? knownUnit : Timing.UnitsOfTime.NULL;
 	}
 	
 	@Override

--- a/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/DurationUnitTranslatorImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/DurationUnitTranslatorImpl.java
@@ -105,6 +105,9 @@ public class DurationUnitTranslatorImpl implements DurationUnitTranslator {
 			if (entry.getValue() == unitsOfTime) {
 				Concept concept = conceptService.getConceptByMapping(entry.getKey(),
 				    Duration.SNOMED_CT_CONCEPT_SOURCE_HL7_CODE);
+				if (concept == null) {
+					concept = conceptService.getConceptByMapping(entry.getKey(), SNOMED_CT_CONCEPT_SOURCE_NAME);
+				}
 				if (concept != null) {
 					return concept;
 				}

--- a/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/DurationUnitTranslatorImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/DurationUnitTranslatorImpl.java
@@ -49,6 +49,11 @@ public class DurationUnitTranslatorImpl implements DurationUnitTranslator {
 	
 	private static final String UCUM_CONCEPT_SOURCE = "UCUM";
 	
+	// Matched as a fallback for dictionaries that register SNOMED CT by name without setting its HL7
+	// code, mirroring UCUM. TODO: replace with Duration.SNOMED_CT_CONCEPT_SOURCE_NAME once the module
+	// depends on a platform release that includes TRUNK-6674.
+	private static final String SNOMED_CT_CONCEPT_SOURCE_NAME = "SNOMED CT";
+	
 	private static final Map<String, Timing.UnitsOfTime> SNOMED_CT_CODE_MAP;
 	
 	private static final Map<String, Timing.UnitsOfTime> UCUM_CODE_MAP;
@@ -112,7 +117,8 @@ public class DurationUnitTranslatorImpl implements DurationUnitTranslator {
 	}
 	
 	private static Timing.UnitsOfTime findUnitsOfTime(ConceptSource conceptSource, String code) {
-		if (Duration.SNOMED_CT_CONCEPT_SOURCE_HL7_CODE.equals(conceptSource.getHl7Code())) {
+		if (Duration.SNOMED_CT_CONCEPT_SOURCE_HL7_CODE.equals(conceptSource.getHl7Code())
+		        || SNOMED_CT_CONCEPT_SOURCE_NAME.equalsIgnoreCase(conceptSource.getName())) {
 			return SNOMED_CT_CODE_MAP.get(code);
 		}
 		if (UCUM_CONCEPT_SOURCE.equalsIgnoreCase(conceptSource.getName())

--- a/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/DurationUnitTranslatorImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/DurationUnitTranslatorImpl.java
@@ -14,13 +14,18 @@ import static lombok.AccessLevel.PROTECTED;
 
 import javax.annotation.Nonnull;
 
-import java.util.HashMap;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import lombok.Getter;
 import lombok.Setter;
 import org.hl7.fhir.r4.model.Timing;
 import org.openmrs.Concept;
+import org.openmrs.ConceptMap;
+import org.openmrs.ConceptMapType;
+import org.openmrs.ConceptReferenceTerm;
+import org.openmrs.ConceptSource;
 import org.openmrs.Duration;
 import org.openmrs.api.ConceptService;
 import org.openmrs.module.fhir2.api.translators.DurationUnitTranslator;
@@ -34,35 +39,85 @@ public class DurationUnitTranslatorImpl implements DurationUnitTranslator {
 	@Setter(value = PROTECTED, onMethod_ = @Autowired)
 	ConceptService conceptService;
 	
-	private static Map<String, Timing.UnitsOfTime> codeMap;
+	/**
+	 * The SNOMED CT code for minute that is active since the 2021-07-31 release, in which the legacy
+	 * code was inactivated. Dictionaries that track current SNOMED CT releases, such as CIEL, map their
+	 * minutes concepts to this code. TODO: replace with Duration.SNOMED_CT_MINUTES_CODE_2021 once the
+	 * module depends on a platform release that includes TRUNK-6674.
+	 */
+	private static final String SNOMED_CT_MINUTES_CODE_2021 = "1156209001";
+	
+	private static final String UCUM_CONCEPT_SOURCE = "UCUM";
+	
+	private static final Map<String, Timing.UnitsOfTime> SNOMED_CT_CODE_MAP;
+	
+	private static final Map<String, Timing.UnitsOfTime> UCUM_CODE_MAP;
+	
 	static {
-		codeMap = new HashMap<>();
-		codeMap.put(Duration.SNOMED_CT_SECONDS_CODE, Timing.UnitsOfTime.S);
-		codeMap.put(Duration.SNOMED_CT_MINUTES_CODE, Timing.UnitsOfTime.MIN);
-		codeMap.put(Duration.SNOMED_CT_HOURS_CODE, Timing.UnitsOfTime.H);
-		codeMap.put(Duration.SNOMED_CT_DAYS_CODE, Timing.UnitsOfTime.D);
-		codeMap.put(Duration.SNOMED_CT_WEEKS_CODE, Timing.UnitsOfTime.WK);
-		codeMap.put(Duration.SNOMED_CT_MONTHS_CODE, Timing.UnitsOfTime.MO);
-		codeMap.put(Duration.SNOMED_CT_YEARS_CODE, Timing.UnitsOfTime.A);
+		// iteration order matters in toOpenmrsType: legacy codes are tried before newer ones so that
+		// dictionaries carrying only legacy mappings keep resolving exactly as before
+		Map<String, Timing.UnitsOfTime> snomedCtCodes = new LinkedHashMap<>();
+		snomedCtCodes.put(Duration.SNOMED_CT_SECONDS_CODE, Timing.UnitsOfTime.S);
+		snomedCtCodes.put(Duration.SNOMED_CT_MINUTES_CODE, Timing.UnitsOfTime.MIN);
+		snomedCtCodes.put(SNOMED_CT_MINUTES_CODE_2021, Timing.UnitsOfTime.MIN);
+		snomedCtCodes.put(Duration.SNOMED_CT_HOURS_CODE, Timing.UnitsOfTime.H);
+		snomedCtCodes.put(Duration.SNOMED_CT_DAYS_CODE, Timing.UnitsOfTime.D);
+		snomedCtCodes.put(Duration.SNOMED_CT_WEEKS_CODE, Timing.UnitsOfTime.WK);
+		snomedCtCodes.put(Duration.SNOMED_CT_MONTHS_CODE, Timing.UnitsOfTime.MO);
+		snomedCtCodes.put(Duration.SNOMED_CT_YEARS_CODE, Timing.UnitsOfTime.A);
+		SNOMED_CT_CODE_MAP = Collections.unmodifiableMap(snomedCtCodes);
+		
+		// the UnitsOfTime codes are the UCUM codes for the units of time
+		Map<String, Timing.UnitsOfTime> ucumCodes = new LinkedHashMap<>();
+		ucumCodes.put(Timing.UnitsOfTime.S.toCode(), Timing.UnitsOfTime.S);
+		ucumCodes.put(Timing.UnitsOfTime.MIN.toCode(), Timing.UnitsOfTime.MIN);
+		ucumCodes.put(Timing.UnitsOfTime.H.toCode(), Timing.UnitsOfTime.H);
+		ucumCodes.put(Timing.UnitsOfTime.D.toCode(), Timing.UnitsOfTime.D);
+		ucumCodes.put(Timing.UnitsOfTime.WK.toCode(), Timing.UnitsOfTime.WK);
+		ucumCodes.put(Timing.UnitsOfTime.MO.toCode(), Timing.UnitsOfTime.MO);
+		ucumCodes.put(Timing.UnitsOfTime.A.toCode(), Timing.UnitsOfTime.A);
+		UCUM_CODE_MAP = Collections.unmodifiableMap(ucumCodes);
 	}
 	
 	@Override
 	public Timing.UnitsOfTime toFhirResource(@Nonnull Concept concept) {
-		String durationCode = Duration.getCode(concept);
-		Timing.UnitsOfTime unitsOfTime = codeMap.get(durationCode);
-		if (unitsOfTime == null) {
-			return Timing.UnitsOfTime.NULL;
+		for (ConceptMap conceptMapping : concept.getConceptMappings()) {
+			if (!ConceptMapType.SAME_AS_MAP_TYPE_UUID.equals(conceptMapping.getConceptMapType().getUuid())) {
+				continue;
+			}
+			ConceptReferenceTerm term = conceptMapping.getConceptReferenceTerm();
+			Timing.UnitsOfTime unitsOfTime = findUnitsOfTime(term.getConceptSource(), term.getCode());
+			if (unitsOfTime != null) {
+				return unitsOfTime;
+			}
 		}
-		return unitsOfTime;
+		return Timing.UnitsOfTime.NULL;
 	}
 	
 	@Override
 	public Concept toOpenmrsType(@Nonnull Timing.UnitsOfTime unitsOfTime) {
-		for (String durationCode : codeMap.keySet()) {
-			Timing.UnitsOfTime units = codeMap.get(durationCode);
-			if (units == unitsOfTime) {
-				return conceptService.getConceptByMapping(durationCode, Duration.SNOMED_CT_CONCEPT_SOURCE_HL7_CODE);
+		for (Map.Entry<String, Timing.UnitsOfTime> entry : SNOMED_CT_CODE_MAP.entrySet()) {
+			if (entry.getValue() == unitsOfTime) {
+				Concept concept = conceptService.getConceptByMapping(entry.getKey(),
+				    Duration.SNOMED_CT_CONCEPT_SOURCE_HL7_CODE);
+				if (concept != null) {
+					return concept;
+				}
 			}
+		}
+		if (UCUM_CODE_MAP.containsKey(unitsOfTime.toCode())) {
+			return conceptService.getConceptByMapping(unitsOfTime.toCode(), UCUM_CONCEPT_SOURCE);
+		}
+		return null;
+	}
+	
+	private static Timing.UnitsOfTime findUnitsOfTime(ConceptSource conceptSource, String code) {
+		if (Duration.SNOMED_CT_CONCEPT_SOURCE_HL7_CODE.equals(conceptSource.getHl7Code())) {
+			return SNOMED_CT_CODE_MAP.get(code);
+		}
+		if (UCUM_CONCEPT_SOURCE.equalsIgnoreCase(conceptSource.getName())
+		        || UCUM_CONCEPT_SOURCE.equals(conceptSource.getHl7Code())) {
+			return UCUM_CODE_MAP.get(code);
 		}
 		return null;
 	}

--- a/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/DurationUnitTranslatorImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/DurationUnitTranslatorImpl.java
@@ -20,7 +20,6 @@ import java.util.Map;
 
 import lombok.Getter;
 import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.r4.model.Timing;
 import org.openmrs.Concept;
 import org.openmrs.ConceptMap;
@@ -33,7 +32,6 @@ import org.openmrs.module.fhir2.api.translators.DurationUnitTranslator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-@Slf4j
 @Component
 public class DurationUnitTranslatorImpl implements DurationUnitTranslator {
 	
@@ -88,28 +86,25 @@ public class DurationUnitTranslatorImpl implements DurationUnitTranslator {
 	
 	@Override
 	public Timing.UnitsOfTime toFhirResource(@Nonnull Concept concept) {
-		// mirrors Duration.getDuration in TRUNK-6674: a concept whose known codes denote different
-		// units is miscurated, so refuse to pick one rather than serialize an arbitrary unit
-		Timing.UnitsOfTime knownUnit = null;
+		// SNOMED CT mappings take priority and UCUM only fills gaps, so concepts that resolved
+		// before UCUM support keep resolving identically however their UCUM mappings are curated
+		Timing.UnitsOfTime ucumUnit = null;
 		for (ConceptMap conceptMapping : concept.getConceptMappings()) {
 			if (!ConceptMapType.SAME_AS_MAP_TYPE_UUID.equals(conceptMapping.getConceptMapType().getUuid())) {
 				continue;
 			}
 			ConceptReferenceTerm term = conceptMapping.getConceptReferenceTerm();
-			Timing.UnitsOfTime unitsOfTime = findUnitsOfTime(term.getConceptSource(), term.getCode());
-			if (unitsOfTime == null) {
-				continue;
-			}
-			if (knownUnit == null) {
-				knownUnit = unitsOfTime;
-			} else if (knownUnit != unitsOfTime) {
-				log.warn(
-				    "Not translating duration units concept {} because its SAME-AS mappings denote different units, e.g. {} and {}",
-				    concept.getUuid(), knownUnit, unitsOfTime);
-				return Timing.UnitsOfTime.NULL;
+			ConceptSource source = term.getConceptSource();
+			if (isSnomedCtSource(source)) {
+				Timing.UnitsOfTime snomedCtUnit = SNOMED_CT_CODE_MAP.get(term.getCode());
+				if (snomedCtUnit != null) {
+					return snomedCtUnit;
+				}
+			} else if (ucumUnit == null && isUcumSource(source)) {
+				ucumUnit = UCUM_CODE_MAP.get(term.getCode());
 			}
 		}
-		return knownUnit != null ? knownUnit : Timing.UnitsOfTime.NULL;
+		return ucumUnit != null ? ucumUnit : Timing.UnitsOfTime.NULL;
 	}
 	
 	@Override
@@ -132,15 +127,13 @@ public class DurationUnitTranslatorImpl implements DurationUnitTranslator {
 		return null;
 	}
 	
-	private static Timing.UnitsOfTime findUnitsOfTime(ConceptSource conceptSource, String code) {
-		if (Duration.SNOMED_CT_CONCEPT_SOURCE_HL7_CODE.equals(conceptSource.getHl7Code())
-		        || SNOMED_CT_CONCEPT_SOURCE_NAME.equalsIgnoreCase(conceptSource.getName())) {
-			return SNOMED_CT_CODE_MAP.get(code);
-		}
-		if (UCUM_CONCEPT_SOURCE.equalsIgnoreCase(conceptSource.getName())
-		        || UCUM_CONCEPT_SOURCE.equals(conceptSource.getHl7Code())) {
-			return UCUM_CODE_MAP.get(code);
-		}
-		return null;
+	private static boolean isSnomedCtSource(ConceptSource conceptSource) {
+		return Duration.SNOMED_CT_CONCEPT_SOURCE_HL7_CODE.equals(conceptSource.getHl7Code())
+		        || SNOMED_CT_CONCEPT_SOURCE_NAME.equalsIgnoreCase(conceptSource.getName());
+	}
+	
+	private static boolean isUcumSource(ConceptSource conceptSource) {
+		return UCUM_CONCEPT_SOURCE.equalsIgnoreCase(conceptSource.getName())
+		        || UCUM_CONCEPT_SOURCE.equals(conceptSource.getHl7Code());
 	}
 }

--- a/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/DurationUnitTranslatorImplCurrentCodesTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/DurationUnitTranslatorImplCurrentCodesTest.java
@@ -17,6 +17,11 @@ import org.hl7.fhir.r4.model.Timing;
 import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.Concept;
+import org.openmrs.ConceptMap;
+import org.openmrs.ConceptMapType;
+import org.openmrs.ConceptReferenceTerm;
+import org.openmrs.ConceptSource;
+import org.openmrs.Duration;
 import org.openmrs.api.ConceptService;
 import org.openmrs.module.fhir2.BaseFhirContextSensitiveTest;
 import org.openmrs.module.fhir2.api.translators.DurationUnitTranslator;
@@ -26,11 +31,16 @@ import org.springframework.beans.factory.annotation.Autowired;
  * Covers dictionaries that carry the duration unit mappings current dictionaries ship: the SNOMED
  * CT minute code that is active since the 2021-07-31 release, and UCUM mappings. Unlike
  * {@link DurationUnitTranslatorImplTest}, the dataset here deliberately carries no legacy SNOMED CT
- * mappings, so these tests prove the fallbacks rather than the legacy path.
+ * mappings, so these tests prove the fallbacks rather than the legacy path. Concepts whose mapping
+ * sets the dataset must not carry, the current CIEL shape with both minute codes and a miscurated
+ * concept whose known codes conflict, are built in memory instead, since persisting a legacy minute
+ * mapping would change what {@code toOpenmrsType(MIN)} resolves.
  */
 public class DurationUnitTranslatorImplCurrentCodesTest extends BaseFhirContextSensitiveTest {
 	
 	private static final String CURRENT_CODES_DATA = "org/openmrs/module/fhir2/mapping/FhirDurationUnitTranslatorTest_current_codes_data.xml";
+	
+	private static final String CURRENT_SNOMED_CT_MINUTE_CODE = "1156209001";
 	
 	private static final String MINUTES_CURRENT_CODE_UUID = "917330aa-b67d-11ec-8065-0242ac110002";
 	
@@ -98,5 +108,54 @@ public class DurationUnitTranslatorImplCurrentCodesTest extends BaseFhirContextS
 		
 		assertThat(result, notNullValue());
 		assertThat(result.getUuid(), equalTo(NAME_ONLY_SNOMED_DAYS_UUID));
+	}
+	
+	@Test
+	public void toFhirResource_shouldTranslateConceptCarryingBothTheLegacyAndTheCurrentSnomedCtMinuteCode() {
+		Concept concept = conceptMappedSameAsTo(term(snomedCt(), Duration.SNOMED_CT_MINUTES_CODE),
+		    term(snomedCt(), CURRENT_SNOMED_CT_MINUTE_CODE));
+		
+		Timing.UnitsOfTime result = durationUnitTranslator.toFhirResource(concept);
+		
+		assertThat(result, equalTo(Timing.UnitsOfTime.MIN));
+	}
+	
+	@Test
+	public void toFhirResource_shouldNotTranslateConceptWhoseKnownCodesDenoteDifferentUnits() {
+		Concept concept = conceptMappedSameAsTo(term(snomedCt(), Duration.SNOMED_CT_MINUTES_CODE), term(ucum(), "h"));
+		
+		Timing.UnitsOfTime result = durationUnitTranslator.toFhirResource(concept);
+		
+		assertThat(result, equalTo(Timing.UnitsOfTime.NULL));
+	}
+	
+	private static Concept conceptMappedSameAsTo(ConceptReferenceTerm... terms) {
+		ConceptMapType sameAs = new ConceptMapType();
+		sameAs.setUuid(ConceptMapType.SAME_AS_MAP_TYPE_UUID);
+		Concept concept = new Concept();
+		for (ConceptReferenceTerm term : terms) {
+			concept.addConceptMapping(new ConceptMap(term, sameAs));
+		}
+		return concept;
+	}
+	
+	private static ConceptReferenceTerm term(ConceptSource source, String code) {
+		ConceptReferenceTerm term = new ConceptReferenceTerm();
+		term.setConceptSource(source);
+		term.setCode(code);
+		return term;
+	}
+	
+	private static ConceptSource snomedCt() {
+		ConceptSource source = new ConceptSource();
+		source.setName("SNOMED CT");
+		source.setHl7Code("SCT");
+		return source;
+	}
+	
+	private static ConceptSource ucum() {
+		ConceptSource source = new ConceptSource();
+		source.setName("UCUM");
+		return source;
 	}
 }

--- a/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/DurationUnitTranslatorImplCurrentCodesTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/DurationUnitTranslatorImplCurrentCodesTest.java
@@ -32,9 +32,9 @@ import org.springframework.beans.factory.annotation.Autowired;
  * CT minute code that is active since the 2021-07-31 release, and UCUM mappings. Unlike
  * {@link DurationUnitTranslatorImplTest}, the dataset here deliberately carries no legacy SNOMED CT
  * mappings, so these tests prove the fallbacks rather than the legacy path. Concepts whose mapping
- * sets the dataset must not carry, the current CIEL shape with both minute codes and a miscurated
- * concept whose known codes conflict, are built in memory instead, since persisting a legacy minute
- * mapping would change what {@code toOpenmrsType(MIN)} resolves.
+ * sets the dataset must not carry, such as the current CIEL shape with both minute codes and
+ * concepts whose SNOMED CT and UCUM mappings disagree, are built in memory instead, since
+ * persisting a legacy minute mapping would change what {@code toOpenmrsType(MIN)} resolves.
  */
 public class DurationUnitTranslatorImplCurrentCodesTest extends BaseFhirContextSensitiveTest {
 	
@@ -121,12 +121,21 @@ public class DurationUnitTranslatorImplCurrentCodesTest extends BaseFhirContextS
 	}
 	
 	@Test
-	public void toFhirResource_shouldNotTranslateConceptWhoseKnownCodesDenoteDifferentUnits() {
+	public void toFhirResource_shouldPreferSnomedCtWhenAUcumMappingDenotesADifferentUnit() {
 		Concept concept = conceptMappedSameAsTo(term(snomedCt(), Duration.SNOMED_CT_MINUTES_CODE), term(ucum(), "h"));
 		
 		Timing.UnitsOfTime result = durationUnitTranslator.toFhirResource(concept);
 		
-		assertThat(result, equalTo(Timing.UnitsOfTime.NULL));
+		assertThat(result, equalTo(Timing.UnitsOfTime.MIN));
+	}
+	
+	@Test
+	public void toFhirResource_shouldFallBackToUcumWhenNoSnomedCtMappingCarriesAKnownCode() {
+		Concept concept = conceptMappedSameAsTo(term(snomedCt(), "99999999"), term(ucum(), "wk"));
+		
+		Timing.UnitsOfTime result = durationUnitTranslator.toFhirResource(concept);
+		
+		assertThat(result, equalTo(Timing.UnitsOfTime.WK));
 	}
 	
 	private static Concept conceptMappedSameAsTo(ConceptReferenceTerm... terms) {

--- a/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/DurationUnitTranslatorImplCurrentCodesTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/DurationUnitTranslatorImplCurrentCodesTest.java
@@ -36,6 +36,8 @@ public class DurationUnitTranslatorImplCurrentCodesTest extends BaseFhirContextS
 	
 	private static final String UCUM_HOURS_UUID = "918220aa-b67d-11ec-8065-0242ac110002";
 	
+	private static final String NAME_ONLY_SNOMED_DAYS_UUID = "910720aa-b67d-11ec-8065-0242ac110002";
+	
 	@Autowired
 	private DurationUnitTranslator durationUnitTranslator;
 	
@@ -79,5 +81,22 @@ public class DurationUnitTranslatorImplCurrentCodesTest extends BaseFhirContextS
 		
 		assertThat(result, notNullValue());
 		assertThat(result.getUuid(), equalTo(UCUM_HOURS_UUID));
+	}
+	
+	@Test
+	public void toFhirResource_shouldTranslateConceptWhoseSnomedCtSourceIsIdentifiedByNameOnly() {
+		Concept concept = conceptService.getConceptByUuid(NAME_ONLY_SNOMED_DAYS_UUID);
+		
+		Timing.UnitsOfTime result = durationUnitTranslator.toFhirResource(concept);
+		
+		assertThat(result, equalTo(Timing.UnitsOfTime.D));
+	}
+	
+	@Test
+	public void toOpenmrsType_shouldResolveDaysThroughTheNameIdentifiedSnomedCtSource() {
+		Concept result = durationUnitTranslator.toOpenmrsType(Timing.UnitsOfTime.D);
+		
+		assertThat(result, notNullValue());
+		assertThat(result.getUuid(), equalTo(NAME_ONLY_SNOMED_DAYS_UUID));
 	}
 }

--- a/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/DurationUnitTranslatorImplCurrentCodesTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/DurationUnitTranslatorImplCurrentCodesTest.java
@@ -1,0 +1,83 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.fhir2.api.translators.impl;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+import org.hl7.fhir.r4.model.Timing;
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.Concept;
+import org.openmrs.api.ConceptService;
+import org.openmrs.module.fhir2.BaseFhirContextSensitiveTest;
+import org.openmrs.module.fhir2.api.translators.DurationUnitTranslator;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Covers dictionaries that carry the duration unit mappings current dictionaries ship: the SNOMED
+ * CT minute code that is active since the 2021-07-31 release, and UCUM mappings. Unlike
+ * {@link DurationUnitTranslatorImplTest}, the dataset here deliberately carries no legacy SNOMED CT
+ * mappings, so these tests prove the fallbacks rather than the legacy path.
+ */
+public class DurationUnitTranslatorImplCurrentCodesTest extends BaseFhirContextSensitiveTest {
+	
+	private static final String CURRENT_CODES_DATA = "org/openmrs/module/fhir2/mapping/FhirDurationUnitTranslatorTest_current_codes_data.xml";
+	
+	private static final String MINUTES_CURRENT_CODE_UUID = "917330aa-b67d-11ec-8065-0242ac110002";
+	
+	private static final String UCUM_HOURS_UUID = "918220aa-b67d-11ec-8065-0242ac110002";
+	
+	@Autowired
+	private DurationUnitTranslator durationUnitTranslator;
+	
+	@Autowired
+	ConceptService conceptService;
+	
+	@Before
+	public void setup() throws Exception {
+		executeDataSet(CURRENT_CODES_DATA);
+	}
+	
+	@Test
+	public void toFhirResource_shouldTranslateConceptMappedToTheCurrentSnomedCtMinuteCode() {
+		Concept concept = conceptService.getConceptByUuid(MINUTES_CURRENT_CODE_UUID);
+		
+		Timing.UnitsOfTime result = durationUnitTranslator.toFhirResource(concept);
+		
+		assertThat(result, equalTo(Timing.UnitsOfTime.MIN));
+	}
+	
+	@Test
+	public void toFhirResource_shouldTranslateConceptMappedOnlyToUcum() {
+		Concept concept = conceptService.getConceptByUuid(UCUM_HOURS_UUID);
+		
+		Timing.UnitsOfTime result = durationUnitTranslator.toFhirResource(concept);
+		
+		assertThat(result, equalTo(Timing.UnitsOfTime.H));
+	}
+	
+	@Test
+	public void toOpenmrsType_shouldResolveMinutesThroughTheCurrentSnomedCtCodeWhenTheLegacyMappingIsAbsent() {
+		Concept result = durationUnitTranslator.toOpenmrsType(Timing.UnitsOfTime.MIN);
+		
+		assertThat(result, notNullValue());
+		assertThat(result.getUuid(), equalTo(MINUTES_CURRENT_CODE_UUID));
+	}
+	
+	@Test
+	public void toOpenmrsType_shouldResolveHoursThroughTheUcumMappingWhenNoSnomedCtMappingExists() {
+		Concept result = durationUnitTranslator.toOpenmrsType(Timing.UnitsOfTime.H);
+		
+		assertThat(result, notNullValue());
+		assertThat(result.getUuid(), equalTo(UCUM_HOURS_UUID));
+	}
+}

--- a/test-data/src/main/resources/org/openmrs/module/fhir2/mapping/FhirDurationUnitTranslatorTest_current_codes_data.xml
+++ b/test-data/src/main/resources/org/openmrs/module/fhir2/mapping/FhirDurationUnitTranslatorTest_current_codes_data.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+-->
+
+<dataset>
+	<!-- UCUM concept source, identified by name as real dictionaries register it -->
+	<concept_reference_source concept_source_id="9002" name="UCUM" description="The Unified Code for Units of Measure" creator="1" date_created="2026-07-06 00:00:00" retired="0" uuid="900200aa-b67d-11ec-8065-0242ac110002" />
+
+	<!-- Minutes mapped only to the SNOMED CT code that is active since the 2021-07-31 release -->
+	<concept concept_id = "91733" retired= "0" datatype_id= "4" class_id= "11" is_set= "0" creator= "1" date_created= "2026-07-06 00:00:00" uuid= "917330aa-b67d-11ec-8065-0242ac110002" />
+	<concept_name concept_name_id="91733" uuid="917331aa-b67d-11ec-8065-0242ac110002" concept_id="91733" name="Minutes" locale="en" creator="1" date_created="2026-07-06 00:00:00" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" />
+	<concept_reference_term concept_reference_term_id="91733" uuid="917332aa-b67d-11ec-8065-0242ac110002" concept_source_id="2" code="1156209001" retired="0" creator="1" date_created="2026-07-06 00:00:00" />
+	<concept_reference_map concept_map_id="91733" uuid="917333aa-b67d-11ec-8065-0242ac110002" concept_id="91733" concept_reference_term_id="91733" concept_map_type_id="2" creator="1" date_created="2026-07-06 00:00:00" />
+
+	<!-- Hours mapped only to UCUM -->
+	<concept concept_id = "91822" retired= "0" datatype_id= "4" class_id= "11" is_set= "0" creator= "1" date_created= "2026-07-06 00:00:00" uuid= "918220aa-b67d-11ec-8065-0242ac110002" />
+	<concept_name concept_name_id="91822" uuid="918221aa-b67d-11ec-8065-0242ac110002" concept_id="91822" name="Hours" locale="en" creator="1" date_created="2026-07-06 00:00:00" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" />
+	<concept_reference_term concept_reference_term_id="91822" uuid="918222aa-b67d-11ec-8065-0242ac110002" concept_source_id="9002" code="h" retired="0" creator="1" date_created="2026-07-06 00:00:00" />
+	<concept_reference_map concept_map_id="91822" uuid="918223aa-b67d-11ec-8065-0242ac110002" concept_id="91822" concept_reference_term_id="91822" concept_map_type_id="2" creator="1" date_created="2026-07-06 00:00:00" />
+
+</dataset>

--- a/test-data/src/main/resources/org/openmrs/module/fhir2/mapping/FhirDurationUnitTranslatorTest_current_codes_data.xml
+++ b/test-data/src/main/resources/org/openmrs/module/fhir2/mapping/FhirDurationUnitTranslatorTest_current_codes_data.xml
@@ -13,6 +13,9 @@
 	<!-- UCUM concept source, identified by name as real dictionaries register it -->
 	<concept_reference_source concept_source_id="9002" name="UCUM" description="The Unified Code for Units of Measure" creator="1" date_created="2026-07-06 00:00:00" retired="0" uuid="900200aa-b67d-11ec-8065-0242ac110002" />
 
+	<!-- SNOMED CT concept source identified by name only, without the SCT HL7 code -->
+	<concept_reference_source concept_source_id="9003" name="SNOMED CT" description="SNOMED CT registered by name without an HL7 code" creator="1" date_created="2026-07-07 00:00:00" retired="0" uuid="900300aa-b67d-11ec-8065-0242ac110002" />
+
 	<!-- Minutes mapped only to the SNOMED CT code that is active since the 2021-07-31 release -->
 	<concept concept_id = "91733" retired= "0" datatype_id= "4" class_id= "11" is_set= "0" creator= "1" date_created= "2026-07-06 00:00:00" uuid= "917330aa-b67d-11ec-8065-0242ac110002" />
 	<concept_name concept_name_id="91733" uuid="917331aa-b67d-11ec-8065-0242ac110002" concept_id="91733" name="Minutes" locale="en" creator="1" date_created="2026-07-06 00:00:00" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" />
@@ -24,5 +27,11 @@
 	<concept_name concept_name_id="91822" uuid="918221aa-b67d-11ec-8065-0242ac110002" concept_id="91822" name="Hours" locale="en" creator="1" date_created="2026-07-06 00:00:00" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" />
 	<concept_reference_term concept_reference_term_id="91822" uuid="918222aa-b67d-11ec-8065-0242ac110002" concept_source_id="9002" code="h" retired="0" creator="1" date_created="2026-07-06 00:00:00" />
 	<concept_reference_map concept_map_id="91822" uuid="918223aa-b67d-11ec-8065-0242ac110002" concept_id="91822" concept_reference_term_id="91822" concept_map_type_id="2" creator="1" date_created="2026-07-06 00:00:00" />
+
+	<!-- Days mapped through the name-identified SNOMED CT source -->
+	<concept concept_id = "91072" retired= "0" datatype_id= "4" class_id= "11" is_set= "0" creator= "1" date_created= "2026-07-07 00:00:00" uuid= "910720aa-b67d-11ec-8065-0242ac110002" />
+	<concept_name concept_name_id="91072" uuid="910721aa-b67d-11ec-8065-0242ac110002" concept_id="91072" name="Days" locale="en" creator="1" date_created="2026-07-07 00:00:00" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" />
+	<concept_reference_term concept_reference_term_id="91072" uuid="910722aa-b67d-11ec-8065-0242ac110002" concept_source_id="9003" code="258703001" retired="0" creator="1" date_created="2026-07-07 00:00:00" />
+	<concept_reference_map concept_map_id="91072" uuid="910723aa-b67d-11ec-8065-0242ac110002" concept_id="91072" concept_reference_term_id="91072" concept_map_type_id="2" creator="1" date_created="2026-07-07 00:00:00" />
 
 </dataset>


### PR DESCRIPTION
## Description

Companion to openmrs/openmrs-core#6246 (TRUNK-6674). SNOMED CT inactivated the legacy minute code `258701004` in its 2021-07-31 release, and dictionaries that track current SNOMED CT releases, such as CIEL, now map their Minutes concepts to the active code `1156209001` (current CIEL carries both as SAME-AS). Core is learning to resolve these; fhir2's `DurationUnitTranslatorImpl` only knew the legacy SNOMED codes, so:

- **Outbound**, a drug order whose duration units concept resolves to the new code translated to `Timing.UnitsOfTime.NULL`, silently dropping the duration unit from the MedicationRequest. In addition, `Duration.getCode(...)` returns whichever SNOMED SAME-AS mapping iterates first, so with current CIEL (both codes present) the outcome depended on mapping-set iteration order.
- **Inbound**, `toOpenmrsType` iterated a `HashMap` and looked up exactly one code per unit, so `MIN` only resolved for dictionaries carrying the legacy mapping.

## Changes

- `toFhirResource` now resolves the concept's SAME-AS mappings against source-scoped code maps: SNOMED CT (the legacy codes plus `1156209001`) and UCUM (`s`, `min`, `h`, `d`, `wk`, `mo`, `a`; the `UnitsOfTime` codes are the UCUM codes). Per review, SNOMED CT mappings take priority, stopping at the first known code, and UCUM is consulted only when no SNOMED CT mapping resolves, so concepts that translated while UCUM was ignored keep translating identically and UCUM strictly fills gaps. Concepts with no known mapping still translate to `NULL`.
- `toOpenmrsType` tries every code that denotes the requested unit: legacy codes first, so dictionaries carrying only legacy mappings resolve exactly as before, then the current SNOMED CT minute code, then the UCUM mapping (the UCUM source is matched by name or HL7 code, since real dictionaries register it by name).
- The new minute code is a string literal with a TODO, because the module compiles against platform 2.8.0, which predates `Duration.SNOMED_CT_MINUTES_CODE_2021`.
- New `DurationUnitTranslatorImplCurrentCodesTest` runs against its own dataset that deliberately carries no legacy mappings, proving the fallbacks in both directions (new-code-only Minutes, UCUM-only Hours). In-memory concepts cover the shape current CIEL actually ships, one concept carrying both minute codes, a concept whose UCUM mapping disagrees with its SNOMED CT mapping (SNOMED CT wins), and the UCUM fallback when a SNOMED CT mapping carries only an unknown code. The existing `DurationUnitTranslatorImplTest` is untouched and keeps proving the legacy path.

## Ticket

Driven by [TRUNK-6674](https://openmrs.atlassian.net/browse/TRUNK-6674). There is no FM2 ticket for this yet; happy to retitle once one is filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[TRUNK-6674]: https://openmrs.atlassian.net/browse/TRUNK-6674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

