### PR TITLE
  FM2-685: Map TestOrder.instructions to ServiceRequest.patientInstruction

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/ServiceRequestTranslatorImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/ServiceRequestTranslatorImpl.java
@@ -92,6 +92,8 @@ public class ServiceRequestTranslatorImpl implements ServiceRequestTranslator<Te
 		
 		serviceRequest.setIntent(ServiceRequest.ServiceRequestIntent.ORDER);
 		
+		serviceRequest.setPatientInstruction(order.getInstructions());
+		
 		serviceRequest.setSubject(patientReferenceTranslator.toFhirResource(order.getPatient()));
 		
 		serviceRequest.setEncounter(encounterReferenceTranslator.toFhirResource(order.getEncounter()));

--- a/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/ServiceRequestTranslatorImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/translators/impl/ServiceRequestTranslatorImpl.java
@@ -94,6 +94,8 @@ public class ServiceRequestTranslatorImpl implements ServiceRequestTranslator<Te
 		
 		serviceRequest.setIntent(ServiceRequest.ServiceRequestIntent.ORDER);
 		
+		serviceRequest.setPatientInstruction(order.getInstructions());
+		
 		serviceRequest.setSubject(patientReferenceTranslator.toFhirResource(order.getPatient()));
 		
 		serviceRequest.setEncounter(encounterReferenceTranslator.toFhirResource(order.getEncounter()));

--- a/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/ServiceRequestTranslatorImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/ServiceRequestTranslatorImplTest.java
@@ -73,6 +73,8 @@ public class ServiceRequestTranslatorImplTest {
 	
 	private static final String LOINC_CODE = "1000-1";
 	
+	private static final String INSTRUCTIONS = "collect before 9am";
+	
 	private static final String PATIENT_UUID = "14d4f066-15f5-102d-96e4-000c29c2a5d7";
 	
 	private static final String ENCOUNTER_UUID = "y403fafb-e5e4-42d0-9d11-4f52e89d123r";
@@ -390,6 +392,20 @@ public class ServiceRequestTranslatorImplTest {
 		assertThat(result.getCoding(), notNullValue());
 		assertThat(result.getCoding(), hasItem(hasProperty("system", equalTo(FhirTestConstants.LOINC_SYSTEM_URL))));
 		assertThat(result.getCoding(), hasItem(hasProperty("code", equalTo(LOINC_CODE))));
+	}
+	
+	@Test
+	public void toFhirResource_shouldTranslateInstructionsToPatientInstruction() {
+		TestOrder order = new TestOrder();
+		order.setInstructions(INSTRUCTIONS);
+		
+		when(taskService.searchForTasks(any()))
+		        .thenReturn(new MockIBundleProvider<>(Collections.emptyList(), PREFERRED_PAGE_SIZE, COUNT));
+		
+		ServiceRequest result = translator.toFhirResource(order);
+		
+		assertThat(result, notNullValue());
+		assertThat(result.getPatientInstruction(), equalTo(INSTRUCTIONS));
 	}
 	
 	@Test

--- a/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/ServiceRequestTranslatorImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/ServiceRequestTranslatorImplTest.java
@@ -398,26 +398,26 @@ public class ServiceRequestTranslatorImplTest {
 	public void toFhirResource_shouldTranslateOrderNumberToIdentifier() throws Exception {
 		TestOrder order = new TestOrder();
 		setOrderNumberByReflection(order, TEST_ORDER_NUMBER);
-
+		
 		when(taskService.searchForTasks(any()))
 		        .thenReturn(new MockIBundleProvider<>(Collections.emptyList(), PREFERRED_PAGE_SIZE, COUNT));
-
+		
 		ServiceRequest result = translator.toFhirResource(order);
-
+		
 		assertThat(result.getIdentifier(), hasSize(1));
 		assertThat(result.getIdentifierFirstRep().getValue(), equalTo(TEST_ORDER_NUMBER));
 	}
-
+	
 	@Test
 	public void toFhirResource_shouldTranslateInstructionsToPatientInstruction() {
 		TestOrder order = new TestOrder();
 		order.setInstructions(INSTRUCTIONS);
-
+		
 		when(taskService.searchForTasks(any()))
 		        .thenReturn(new MockIBundleProvider<>(Collections.emptyList(), PREFERRED_PAGE_SIZE, COUNT));
-
+		
 		ServiceRequest result = translator.toFhirResource(order);
-
+		
 		assertThat(result, notNullValue());
 		assertThat(result.getPatientInstruction(), equalTo(INSTRUCTIONS));
 	}

--- a/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/ServiceRequestTranslatorImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/translators/impl/ServiceRequestTranslatorImplTest.java
@@ -73,6 +73,8 @@ public class ServiceRequestTranslatorImplTest {
 	
 	private static final String LOINC_CODE = "1000-1";
 	
+	private static final String INSTRUCTIONS = "collect before 9am";
+	
 	private static final String PATIENT_UUID = "14d4f066-15f5-102d-96e4-000c29c2a5d7";
 	
 	private static final String ENCOUNTER_UUID = "y403fafb-e5e4-42d0-9d11-4f52e89d123r";
@@ -396,14 +398,28 @@ public class ServiceRequestTranslatorImplTest {
 	public void toFhirResource_shouldTranslateOrderNumberToIdentifier() throws Exception {
 		TestOrder order = new TestOrder();
 		setOrderNumberByReflection(order, TEST_ORDER_NUMBER);
-		
+
 		when(taskService.searchForTasks(any()))
 		        .thenReturn(new MockIBundleProvider<>(Collections.emptyList(), PREFERRED_PAGE_SIZE, COUNT));
-		
+
 		ServiceRequest result = translator.toFhirResource(order);
-		
+
 		assertThat(result.getIdentifier(), hasSize(1));
 		assertThat(result.getIdentifierFirstRep().getValue(), equalTo(TEST_ORDER_NUMBER));
+	}
+
+	@Test
+	public void toFhirResource_shouldTranslateInstructionsToPatientInstruction() {
+		TestOrder order = new TestOrder();
+		order.setInstructions(INSTRUCTIONS);
+
+		when(taskService.searchForTasks(any()))
+		        .thenReturn(new MockIBundleProvider<>(Collections.emptyList(), PREFERRED_PAGE_SIZE, COUNT));
+
+		ServiceRequest result = translator.toFhirResource(order);
+
+		assertThat(result, notNullValue());
+		assertThat(result.getPatientInstruction(), equalTo(INSTRUCTIONS));
 	}
 	
 	@Test


### PR DESCRIPTION

## Description of what I changed
`ServiceRequestTranslatorImpl.toFhirResource()` never translated `TestOrder.instructions` - it was silently dropped when converting an order to a FHIR `ServiceRequest`, even though the OpenMRS O3 lab order form has a dedicated "Additional instructions" field for it, right next to Priority.

  This maps it to `ServiceRequest.patientInstruction`, matching how the same inherited `Order.instructions` field is already handled for `DrugOrder`: `DosageTranslatorImpl` puts it into `Dosage.additionalInstruction`, which FHIR R4 defines as explicitly patient-facing ("Supplemental instructions to the patient..."). Using the same intent for `ServiceRequest` keeps the two order types consistent, and is a different field from (and shouldn't be confused with) `commentToFulfiller`, a separate, fulfiller authored field already mapped to `note` for `MedicationRequest`.

Added `toFhirResource_shouldTranslateInstructionsToPatientInstruction` to `ServiceRequestTranslatorImplTest`, following the same Given/When/Then structure as the existing `toFhirResource_shouldTranslateCommentToFulFillerToNote` test in `MedicationRequestTranslatorImplTest`.


## Issue I worked on
see https://openmrs.atlassian.net/browse/FM2-685

## Checklist: I completed these to help reviewers :)
 - [x] My pull request only contains **ONE single commit**.
  - [x] My IDE is configured to follow the code style of this project.
  - [x] I have **added tests** to cover my changes.
  - [x] I ran `mvn clean package` right before creating this pull request and
    added all formatting changes to my commit. 
  - [x] All new and existing **tests passed**.
  - [x] My pull request is **based on the latest changes** of the master branch.

## Anything else?
