### PR TITLE
Require Orders privileges for FHIR Task resource access

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhir2/api/dao/FhirTaskDao.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/dao/FhirTaskDao.java
@@ -9,8 +9,39 @@
  */
 package org.openmrs.module.fhir2.api.dao;
 
+import javax.annotation.Nonnull;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.openmrs.annotation.Authorized;
+import org.openmrs.module.fhir2.api.search.param.SearchParameterMap;
 import org.openmrs.module.fhir2.model.FhirTask;
+import org.openmrs.util.PrivilegeConstants;
 
 public interface FhirTaskDao extends FhirDao<FhirTask> {
 	
+	@Override
+	@Authorized(PrivilegeConstants.GET_ORDERS)
+	FhirTask get(@Nonnull String uuid);
+	
+	@Override
+	@Authorized(PrivilegeConstants.GET_ORDERS)
+	List<FhirTask> get(@Nonnull Collection<String> uuids);
+	
+	@Override
+	@Authorized(PrivilegeConstants.GET_ORDERS)
+	List<FhirTask> getSearchResults(@Nonnull SearchParameterMap theParams);
+	
+	@Override
+	@Authorized(PrivilegeConstants.GET_ORDERS)
+	int getSearchResultsCount(@Nonnull SearchParameterMap theParams);
+	
+	@Override
+	@Authorized({ PrivilegeConstants.ADD_ORDERS, PrivilegeConstants.EDIT_ORDERS })
+	FhirTask createOrUpdate(@Nonnull FhirTask newEntry);
+	
+	@Override
+	@Authorized(PrivilegeConstants.DELETE_ORDERS)
+	FhirTask delete(@Nonnull String uuid);
 }

--- a/api/src/test/java/org/openmrs/module/fhir2/api/dao/impl/FhirTaskDaoImplTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/dao/impl/FhirTaskDaoImplTest.java
@@ -18,6 +18,8 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThrows;
+import static org.openmrs.util.PrivilegeConstants.GET_ORDERS;
 
 import java.time.LocalDateTime;
 import java.time.Month;
@@ -35,15 +37,19 @@ import org.hibernate.SessionFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.Concept;
+import org.openmrs.api.APIAuthenticationException;
 import org.openmrs.api.ConceptService;
+import org.openmrs.api.context.Context;
 import org.openmrs.api.db.hibernate.HibernateConceptDAO;
 import org.openmrs.module.fhir2.BaseFhirContextSensitiveTest;
 import org.openmrs.module.fhir2.FhirConstants;
+import org.openmrs.module.fhir2.api.dao.FhirTaskDao;
 import org.openmrs.module.fhir2.api.search.param.SearchParameterMap;
 import org.openmrs.module.fhir2.model.FhirReference;
 import org.openmrs.module.fhir2.model.FhirTask;
 import org.openmrs.module.fhir2.model.FhirTaskInput;
 import org.openmrs.module.fhir2.model.FhirTaskOutput;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class FhirTaskDaoImplTest extends BaseFhirContextSensitiveTest {
@@ -87,6 +93,9 @@ public class FhirTaskDaoImplTest extends BaseFhirContextSensitiveTest {
 	
 	@Autowired
 	private ConceptService conceptService;
+	
+	@Autowired
+	private ObjectProvider<FhirTaskDao> daoProvider;
 	
 	@Before
 	public void setup() throws Exception {
@@ -475,4 +484,36 @@ public class FhirTaskDaoImplTest extends BaseFhirContextSensitiveTest {
 		assertThat(results, hasItem(hasProperty("uuid", equalTo(TASK_UUID))));
 	}
 	
+	@Test
+	public void get_shouldRequireGetOrdersPrivilege() {
+		FhirTaskDao authorizedDao = daoProvider.getObject();
+		Context.logout();
+		
+		assertThrows(APIAuthenticationException.class, () -> authorizedDao.get(TASK_UUID));
+		
+		try {
+			Context.addProxyPrivilege(GET_ORDERS);
+			assertThat(authorizedDao.get(TASK_UUID), notNullValue());
+		}
+		finally {
+			Context.removeProxyPrivilege(GET_ORDERS);
+		}
+	}
+	
+	@Test
+	public void getSearchResults_shouldRequireGetOrdersPrivilege() {
+		FhirTaskDao authorizedDao = daoProvider.getObject();
+		SearchParameterMap theParams = new SearchParameterMap();
+		Context.logout();
+		
+		assertThrows(APIAuthenticationException.class, () -> authorizedDao.getSearchResults(theParams));
+		
+		try {
+			Context.addProxyPrivilege(GET_ORDERS);
+			assertThat(authorizedDao.getSearchResults(theParams), notNullValue());
+		}
+		finally {
+			Context.removeProxyPrivilege(GET_ORDERS);
+		}
+	}
 }


### PR DESCRIPTION
### Summary
`FhirTaskDao` is an empty interface, and neither it nor the base `FhirDao` declares any `@Authorized` privilege, so `AuthorizationAdvice` performs no privilege check at all for FHIR Task operations. Any authenticated user, including an account with no clinical privileges, can read, search, create, update and delete every FHIR Task via `/ws/fhir2/R4/Task` (and the R3 path). Every other FHIR2 DAO (Allergy, Observation, ServiceRequest, MedicationRequest, ...) annotates its `get`/`getSearchResults`/`createOrUpdate`/`delete` methods; Task was the one gap.

### Change
Override the inherited `FhirDao` methods on `FhirTaskDao` with `@Authorized`, mirroring the annotated fleet:
- reads (`get`, `get(Collection)`, `getSearchResults`, `getSearchResultsCount`) require `Get Orders`
- `createOrUpdate` requires `Add Orders`/`Edit Orders`
- `delete` requires `Delete Orders`

### Privilege choice (please confirm)
FHIR Task has no dedicated OpenMRS privilege. It represents order-fulfillment and clinical-workflow state and references based-on orders, so I mapped it to the Orders privileges, identical to `FhirServiceRequestDao`. If your Task workflows (for example lab integrations such as OpenELIS) run under a service account, that account will now need the Orders privileges to read or write Task. If you would rather introduce dedicated Task privileges, that can replace the constants here without changing the shape of the fix.

### Tests
Added `get_shouldRequireGetOrdersPrivilege` and `getSearchResults_shouldRequireGetOrdersPrivilege` to `FhirTaskDaoImplTest`, obtaining the AOP-proxied DAO so the annotations are actually exercised. All Task api tests pass: DAO 21, service 7, search 33, r3/r4 resource providers 10/15, translators unchanged.

Addresses GHSA-vm98-x99m-w327.