### PR TITLE
Fix R3 Task.context mapped to R4 Task.focus instead of Task.encounter

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhir2/providers/util/TaskVersionConverter.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/providers/util/TaskVersionConverter.java
@@ -197,7 +197,7 @@ public class TaskVersionConverter {
 				tgt.setFor(convertReference(src.getFor()));
 			}
 			if (src.hasContext()) {
-				tgt.setFocus(convertReference(src.getContext()));
+				tgt.setEncounter(convertReference(src.getContext()));
 			}
 			if (src.hasExecutionPeriod()) {
 				tgt.setExecutionPeriod(convertPeriod(src.getExecutionPeriod()));

--- a/api/src/test/java/org/openmrs/module/fhir2/providers/util/TaskVersionConverterTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/providers/util/TaskVersionConverterTest.java
@@ -1,0 +1,58 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.fhir2.providers.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+import org.hl7.fhir.dstu3.model.Reference;
+import org.hl7.fhir.dstu3.model.Task;
+import org.hl7.fhir.exceptions.FHIRException;
+import org.junit.Test;
+
+public class TaskVersionConverterTest {
+	
+	@Test
+	public void convertTask_shouldMapDstu3FocusAndContextToR4FocusAndEncounterRespectively() throws FHIRException {
+		//given
+		Task src = new Task();
+		src.setStatus(Task.TaskStatus.REQUESTED);
+		src.setIntent(Task.TaskIntent.ORDER);
+		src.setFocus(new Reference("Observation/obs-uuid-1111"));
+		src.setContext(new Reference("Encounter/enc-uuid-2222"));
+		
+		//when
+		org.hl7.fhir.r4.model.Task result = TaskVersionConverter.convertTask(src);
+		
+		//then
+		assertThat(result.getFocus(), notNullValue());
+		assertThat(result.getFocus().getReference(), equalTo("Observation/obs-uuid-1111"));
+		assertThat(result.getEncounter(), notNullValue());
+		assertThat(result.getEncounter().getReference(), equalTo("Encounter/enc-uuid-2222"));
+	}
+	
+	@Test
+	public void convertTask_shouldMapDstu3ContextToR4EncounterWhenFocusIsAbsent() throws FHIRException {
+		//given
+		Task src = new Task();
+		src.setStatus(Task.TaskStatus.REQUESTED);
+		src.setIntent(Task.TaskIntent.ORDER);
+		src.setContext(new Reference("Encounter/enc-uuid-2222"));
+		
+		//when
+		org.hl7.fhir.r4.model.Task result = TaskVersionConverter.convertTask(src);
+		
+		//then
+		assertThat(result.hasFocus(), equalTo(false));
+		assertThat(result.getEncounter(), notNullValue());
+		assertThat(result.getEncounter().getReference(), equalTo("Encounter/enc-uuid-2222"));
+	}
+}

--- a/api/src/test/java/org/openmrs/module/fhir2/providers/util/TaskVersionConverterTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/providers/util/TaskVersionConverterTest.java
@@ -55,4 +55,23 @@ public class TaskVersionConverterTest {
 		assertThat(result.getEncounter(), notNullValue());
 		assertThat(result.getEncounter().getReference(), equalTo("Encounter/enc-uuid-2222"));
 	}
+	
+	@Test
+	public void convertTask_shouldMapR4FocusAndEncounterToDstu3FocusAndContextRespectively() throws FHIRException {
+		//given
+		org.hl7.fhir.r4.model.Task src = new org.hl7.fhir.r4.model.Task();
+		src.setStatus(org.hl7.fhir.r4.model.Task.TaskStatus.REQUESTED);
+		src.setIntent(org.hl7.fhir.r4.model.Task.TaskIntent.ORDER);
+		src.setFocus(new org.hl7.fhir.r4.model.Reference("Observation/obs-uuid-1111"));
+		src.setEncounter(new org.hl7.fhir.r4.model.Reference("Encounter/enc-uuid-2222"));
+		
+		//when
+		Task result = TaskVersionConverter.convertTask(src);
+		
+		//then
+		assertThat(result.getFocus(), notNullValue());
+		assertThat(result.getFocus().getReference(), equalTo("Observation/obs-uuid-1111"));
+		assertThat(result.getContext(), notNullValue());
+		assertThat(result.getContext().getReference(), equalTo("Encounter/enc-uuid-2222"));
+	}
 }


### PR DESCRIPTION
## Summary

- In `TaskVersionConverter.convertTask(dstu3.Task)`, `src.getContext()` (the encounter reference) was being written to `tgt.setFocus()` instead of `tgt.setEncounter()`.
- This meant a DSTU3 `POST`/`PUT /Task` carrying a `context` would overwrite `focusReference` on `fhir_task` with the Encounter reference, drop the client's real focus, and return the Encounter on a later R4 `GET Task.focus`.
- Also adds `TaskVersionConverterTest` asserting that a DSTU3 Task carrying both `focus` and `context` maps to R4 `focus` and `encounter` respectively, so any future cherry-pick that reverts this line fails visibly.

Identified during review of [PR #622](https://github.com/openmrs/openmrs-module-fhir2/pull/622) (2.5.1 backport).

## Test plan

- [ ] `TaskVersionConverterTest#convertTask_shouldMapDstu3FocusAndContextToR4FocusAndEncounterRespectively` — DSTU3 Task with both `focus` and `context` maps to R4 `focus` and `encounter`
- [ ] `TaskVersionConverterTest#convertTask_shouldMapDstu3ContextToR4EncounterWhenFocusIsAbsent` — DSTU3 Task with only `context` maps to R4 `encounter` without setting `focus`
- [ ] Existing R3 Task provider tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)