### PR TITLE
Fix the 2.5.x release configuration so release:perform can run

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <connection>scm:git:git@github.com:openmrs/openmrs-module-fhir2.git</connection>
         <developerConnection>scm:git:git@github.com:openmrs/openmrs-module-fhir2.git</developerConnection>
         <url>https://github.com/openmrs/openmrs-module-fhir2/</url>
-      <tag>2.5.0</tag>
+      <tag>HEAD</tag>
     </scm>
 
     <modules>
@@ -725,9 +725,8 @@
                     <artifactId>maven-release-plugin</artifactId>
                     <version>3.1.1</version>
                     <configuration>
-                        <useReleaseProfile>true</useReleaseProfile>
+                        <useReleaseProfile>false</useReleaseProfile>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
-                        <arguments>-Prelease</arguments>
                         <tagNameFormat>@{project.version}</tagNameFormat>
                         <allowTimestampedSnapshots>true</allowTimestampedSnapshots>
                     </configuration>


### PR DESCRIPTION
## Why

The 2.5.1 release ([run 32143717913](https://github.com/openmrs/openmrs-module-fhir2/actions/runs/32143717913)) got through `release:prepare` and then failed in `release:perform`:

```
--- source:3.3.1:jar-no-fork (attach-sources) @ fhir2-test-data ---
Building jar: fhir2-test-data-2.5.1-sources.jar
--- source:3.3.1:jar (attach-sources) @ fhir2-test-data ---
[ERROR] We have duplicated artifacts attached.
```

`<useReleaseProfile>true</useReleaseProfile>` makes the release plugin set `performRelease=true`, which activates the super POM's `release-profile`. That profile binds `source:jar-no-fork` under the execution id `attach-sources`, which is the id every module already uses for its own `source:jar` execution. Both run, the sources jar is attached twice, and the module fails. `master` does not hit this because it already sets `useReleaseProfile` to `false`.

## What changed

- `useReleaseProfile` -> `false`. This is the actual fix.
- Dropped `<arguments>-Prelease</arguments>`. There is no `release` profile on this branch, and the release script passes its own `-Darguments` on the command line anyway, so the value was never used.
- `<scm><tag>` -> `HEAD`. The branch never got a "prepare for next development iteration" commit after 2.5.0, so it has been sitting on `2.5.1-SNAPSHOT` while still claiming to be built from the `2.5.0` tag. `release:prepare` writes the real tag into the released pom and restores the previous value afterwards, so this does not fix itself.

## Verification

Reproduced and confirmed locally at `10b224cb`, Java 8:

- `mvn verify -DskipTests -DperformRelease=true` fails on `fhir2-test-data` with the same duplicate-artifact error as the release run, so the flag alone accounts for it.
- `mvn clean verify -DskipTests` without that flag builds green.

The released artifact set is unchanged. Sources jars come from each module's own `attach-sources` execution rather than from `release-profile`, and all five are still produced without it:

```
api/target/fhir2-api-2.5.1-SNAPSHOT-sources.jar
api-2.5/target/fhir2-api-2.5-2.5.1-SNAPSHOT-sources.jar
api-2.6/target/fhir2-api-2.6-2.5.1-SNAPSHOT-sources.jar
api-2.7/target/fhir2-api-2.7-2.5.1-SNAPSHOT-sources.jar
test-data/target/fhir2-test-data-2.5.1-SNAPSHOT-sources.jar
```

That matches what 2.5.0 published. No javadoc jar is lost either, since 2.5.0 did not publish one.

## Note on the failed release

The tag `2.5.1` and the two `[maven-release-plugin]` commits it pushed have been removed, and `2.5.x` is back at `10b224cb`. One artifact from that run is still published and needs deleting by someone with mavenrepo access before 2.5.1 is re-cut: `org/openmrs/module/fhir2/2.5.1/fhir2-2.5.1.pom`, along with regenerating `maven-metadata.xml`, which currently advertises `<release>2.5.1</release>`. The re-cut parent pom will differ from it, so it is not a harmless identical redeploy.