### PR TITLE
Skip deployment of the test-only modules

### DIFF
--- a/e2e-tests/pom.xml
+++ b/e2e-tests/pom.xml
@@ -94,6 +94,13 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
             </plugin>
             <plugin>

--- a/integration-tests-2.6/pom.xml
+++ b/integration-tests-2.6/pom.xml
@@ -109,6 +109,13 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
             </plugin>
             <plugin>

--- a/integration-tests-2.7/pom.xml
+++ b/integration-tests-2.7/pom.xml
@@ -109,6 +109,13 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
             </plugin>
             <plugin>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -105,6 +105,13 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
             </plugin>
             <plugin>


### PR DESCRIPTION
## Why

The 2.5.1 release ([run 32148102245](https://github.com/openmrs/openmrs-module-fhir2/actions/runs/32148102245)) deployed all seven shipping modules and then failed at the end of the reactor:

```
maven-deploy-plugin:3.1.4:deploy on project fhir2-integration-tests:
The packaging plugin for project fhir2-integration-tests did not assign a main file
to the project but it has attachments. Change packaging to 'pom'.
```

`integration-tests`, `integration-tests-2.6`, `integration-tests-2.7` and `e2e-tests` have no main sources, so no main jar is produced, but each declares `maven-source-plugin`, which attaches a sources jar. `maven-deploy-plugin` 3.x rejects attachments without a main file.

They already skip `maven-install-plugin`. `master` skips `maven-deploy-plugin` on the same modules too; this brings 2.5.x into line.

## No change to what gets published

None of these four modules has ever been published. `fhir2-integration-tests` and `fhir2-e2e-tests` are 404 in the repository at 2.5.0, 2.5.1 and 4.2.0 alike. The deploy was failing rather than being skipped, which is the whole of the problem.

## Verification

I ran the release's own deploy against a `file://` repository at the `2.5.1` tag, Java 8, rather than inferring from the CI log. The branch's normal CI only runs `verify`, so nothing here exercises `deploy`, which is why both release attempts found their defect in production.

Before:

```
FHIR2 Integration Tests ...... FAILURE
FHIR2 Integration Tests 2.6 .. SKIPPED
FHIR2 Integration Tests 2.7 .. SKIPPED
BUILD FAILURE
```

After:

```
all 11 modules ............... SUCCESS
BUILD SUCCESS, 0 failing goals
```

and the repository received exactly the seven modules that should ship: `fhir2`, `fhir2-api`, `fhir2-api-2.5`, `fhir2-api-2.6`, `fhir2-api-2.7`, `fhir2-omod`, `fhir2-test-data`. The 2.6 and 2.7 modules were only *skipped* in the before-run because their dependency failed, so the after-run is what actually proves them.

`e2e-tests` passed deploy even before this change, so its skip is for consistency with master rather than a fix.

## Note on 2.5.1

2.5.1 is published and correct; the failure cost the workflow's exit code, the GitHub Release and the `2.5.2-SNAPSHOT` snapshot push, not any consumer-facing artifact. The [GitHub Release](https://github.com/openmrs/openmrs-module-fhir2/releases/tag/2.5.1) has since been created by hand. This PR is so that the next release off this branch exits clean.