### PR TITLE
FM2-697 | Add. Support for encounter filter and includes in Observation lastn operation

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhir2/providers/r3/ObservationFhirResourceProvider.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/providers/r3/ObservationFhirResourceProvider.java
@@ -15,6 +15,7 @@ import static lombok.AccessLevel.PROTECTED;
 import javax.annotation.Nonnull;
 
 import java.util.HashSet;
+import java.util.Set;
 
 import ca.uhn.fhir.model.api.Include;
 import ca.uhn.fhir.model.valueset.BundleTypeEnum;
@@ -136,6 +137,9 @@ public class ObservationFhirResourceProvider implements IResourceProvider {
 		        valueStringParam, date, code, category, id, lastUpdated, sort, includes, revIncludes)));
 	}
 	
+	// Note: @OperationParam has no chainWhitelist, so the encounter parameter accepts only a plain
+	// reference (e.g. encounter=<uuid>). Chained modifiers such as encounter.type are silently
+	// ignored by HAPI; use the @Search endpoint above for chained encounter filtering.
 	@Operation(name = "lastn", idempotent = true, type = Observation.class, bundleType = BundleTypeEnum.SEARCHSET)
 	public IBundleProvider getLastnObservations(@OperationParam(name = "max") NumberParam max,
 	        @OperationParam(name = Observation.SP_SUBJECT) ReferenceAndListParam subjectParam,
@@ -144,9 +148,9 @@ public class ObservationFhirResourceProvider implements IResourceProvider {
 	        @OperationParam(name = Observation.SP_CODE) TokenAndListParam code,
 	        @OperationParam(name = Observation.SP_ENCOUNTER) ReferenceAndListParam encounterParam,
 	        @IncludeParam(allow = { "Observation:" + Observation.SP_ENCOUNTER, "Observation:" + Observation.SP_PATIENT,
-	                "Observation:" + Observation.SP_RELATED_TYPE }) HashSet<Include> includes,
+	                "Observation:" + Observation.SP_RELATED_TYPE }) Set<Include> includes,
 	        @IncludeParam(reverse = true, allow = { "Observation:" + Observation.SP_RELATED_TYPE,
-	                "DiagnosticReport:" + DiagnosticReport.SP_RESULT }) HashSet<Include> revIncludes) {
+	                "DiagnosticReport:" + DiagnosticReport.SP_RESULT }) Set<Include> revIncludes) {
 		if (patientParam != null) {
 			subjectParam = patientParam;
 		}

--- a/api/src/main/java/org/openmrs/module/fhir2/providers/r3/ObservationFhirResourceProvider.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/providers/r3/ObservationFhirResourceProvider.java
@@ -151,21 +151,13 @@ public class ObservationFhirResourceProvider implements IResourceProvider {
 			subjectParam = patientParam;
 		}
 		
-		if (CollectionUtils.isEmpty(includes)) {
-			includes = null;
-		}
-		
-		if (CollectionUtils.isEmpty(revIncludes)) {
-			revIncludes = null;
-		}
-		
 		ObservationSearchParams searchParams = new ObservationSearchParams();
 		searchParams.setPatient(subjectParam);
 		searchParams.setCategory(category);
 		searchParams.setCode(code);
 		searchParams.setEncounter(encounterParam);
-		searchParams.setIncludes(includes);
-		searchParams.setRevIncludes(revIncludes);
+		searchParams.setIncludes(CollectionUtils.isEmpty(includes) ? null : includes);
+		searchParams.setRevIncludes(CollectionUtils.isEmpty(revIncludes) ? null : revIncludes);
 		
 		return new SearchQueryBundleProviderR3Wrapper(observationService.getLastnObservations(max, searchParams));
 	}

--- a/api/src/main/java/org/openmrs/module/fhir2/providers/r3/ObservationFhirResourceProvider.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/providers/r3/ObservationFhirResourceProvider.java
@@ -141,15 +141,31 @@ public class ObservationFhirResourceProvider implements IResourceProvider {
 	        @OperationParam(name = Observation.SP_SUBJECT) ReferenceAndListParam subjectParam,
 	        @OperationParam(name = Observation.SP_PATIENT) ReferenceAndListParam patientParam,
 	        @OperationParam(name = Observation.SP_CATEGORY) TokenAndListParam category,
-	        @OperationParam(name = Observation.SP_CODE) TokenAndListParam code) {
+	        @OperationParam(name = Observation.SP_CODE) TokenAndListParam code,
+	        @OperationParam(name = Observation.SP_ENCOUNTER) ReferenceAndListParam encounterParam,
+	        @IncludeParam(allow = { "Observation:" + Observation.SP_ENCOUNTER, "Observation:" + Observation.SP_PATIENT,
+	                "Observation:" + Observation.SP_RELATED_TYPE }) HashSet<Include> includes,
+	        @IncludeParam(reverse = true, allow = { "Observation:" + Observation.SP_RELATED_TYPE,
+	                "DiagnosticReport:" + DiagnosticReport.SP_RESULT }) HashSet<Include> revIncludes) {
 		if (patientParam != null) {
 			subjectParam = patientParam;
+		}
+		
+		if (CollectionUtils.isEmpty(includes)) {
+			includes = null;
+		}
+		
+		if (CollectionUtils.isEmpty(revIncludes)) {
+			revIncludes = null;
 		}
 		
 		ObservationSearchParams searchParams = new ObservationSearchParams();
 		searchParams.setPatient(subjectParam);
 		searchParams.setCategory(category);
 		searchParams.setCode(code);
+		searchParams.setEncounter(encounterParam);
+		searchParams.setIncludes(includes);
+		searchParams.setRevIncludes(revIncludes);
 		
 		return new SearchQueryBundleProviderR3Wrapper(observationService.getLastnObservations(max, searchParams));
 	}

--- a/api/src/main/java/org/openmrs/module/fhir2/providers/r4/ObservationFhirResourceProvider.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/providers/r4/ObservationFhirResourceProvider.java
@@ -15,6 +15,7 @@ import static lombok.AccessLevel.PROTECTED;
 import javax.annotation.Nonnull;
 
 import java.util.HashSet;
+import java.util.Set;
 
 import ca.uhn.fhir.model.api.Include;
 import ca.uhn.fhir.model.valueset.BundleTypeEnum;
@@ -160,6 +161,9 @@ public class ObservationFhirResourceProvider implements IResourceProvider {
 		        id, lastUpdated, sort, includes, revIncludes));
 	}
 	
+	// Note: @OperationParam has no chainWhitelist, so the encounter parameter accepts only a plain
+	// reference (e.g. encounter=<uuid>). Chained modifiers such as encounter.type are silently
+	// ignored by HAPI; use the @Search endpoint above for chained encounter filtering.
 	@Operation(name = "lastn", idempotent = true, type = Observation.class, bundleType = BundleTypeEnum.SEARCHSET)
 	public IBundleProvider getLastnObservations(@OperationParam(name = "max") NumberParam max,
 	        @OperationParam(name = Observation.SP_SUBJECT) ReferenceAndListParam subjectParam,
@@ -168,9 +172,9 @@ public class ObservationFhirResourceProvider implements IResourceProvider {
 	        @OperationParam(name = Observation.SP_CODE) TokenAndListParam code,
 	        @OperationParam(name = Observation.SP_ENCOUNTER) ReferenceAndListParam encounterParam,
 	        @IncludeParam(allow = { "Observation:" + Observation.SP_ENCOUNTER, "Observation:" + Observation.SP_PATIENT,
-	                "Observation:" + Observation.SP_HAS_MEMBER }) HashSet<Include> includes,
+	                "Observation:" + Observation.SP_HAS_MEMBER }) Set<Include> includes,
 	        @IncludeParam(reverse = true, allow = { "Observation:" + Observation.SP_HAS_MEMBER,
-	                "DiagnosticReport:" + DiagnosticReport.SP_RESULT }) HashSet<Include> revIncludes) {
+	                "DiagnosticReport:" + DiagnosticReport.SP_RESULT }) Set<Include> revIncludes) {
 		if (patientParam != null) {
 			subjectParam = patientParam;
 		}

--- a/api/src/main/java/org/openmrs/module/fhir2/providers/r4/ObservationFhirResourceProvider.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/providers/r4/ObservationFhirResourceProvider.java
@@ -175,21 +175,13 @@ public class ObservationFhirResourceProvider implements IResourceProvider {
 			subjectParam = patientParam;
 		}
 		
-		if (CollectionUtils.isEmpty(includes)) {
-			includes = null;
-		}
-		
-		if (CollectionUtils.isEmpty(revIncludes)) {
-			revIncludes = null;
-		}
-		
 		ObservationSearchParams searchParams = new ObservationSearchParams();
 		searchParams.setPatient(subjectParam);
 		searchParams.setCategory(category);
 		searchParams.setCode(code);
 		searchParams.setEncounter(encounterParam);
-		searchParams.setIncludes(includes);
-		searchParams.setRevIncludes(revIncludes);
+		searchParams.setIncludes(CollectionUtils.isEmpty(includes) ? null : includes);
+		searchParams.setRevIncludes(CollectionUtils.isEmpty(revIncludes) ? null : revIncludes);
 		
 		return observationService.getLastnObservations(max, searchParams);
 	}

--- a/api/src/main/java/org/openmrs/module/fhir2/providers/r4/ObservationFhirResourceProvider.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/providers/r4/ObservationFhirResourceProvider.java
@@ -165,15 +165,31 @@ public class ObservationFhirResourceProvider implements IResourceProvider {
 	        @OperationParam(name = Observation.SP_SUBJECT) ReferenceAndListParam subjectParam,
 	        @OperationParam(name = Observation.SP_PATIENT) ReferenceAndListParam patientParam,
 	        @OperationParam(name = Observation.SP_CATEGORY) TokenAndListParam category,
-	        @OperationParam(name = Observation.SP_CODE) TokenAndListParam code) {
+	        @OperationParam(name = Observation.SP_CODE) TokenAndListParam code,
+	        @OperationParam(name = Observation.SP_ENCOUNTER) ReferenceAndListParam encounterParam,
+	        @IncludeParam(allow = { "Observation:" + Observation.SP_ENCOUNTER, "Observation:" + Observation.SP_PATIENT,
+	                "Observation:" + Observation.SP_HAS_MEMBER }) HashSet<Include> includes,
+	        @IncludeParam(reverse = true, allow = { "Observation:" + Observation.SP_HAS_MEMBER,
+	                "DiagnosticReport:" + DiagnosticReport.SP_RESULT }) HashSet<Include> revIncludes) {
 		if (patientParam != null) {
 			subjectParam = patientParam;
+		}
+		
+		if (CollectionUtils.isEmpty(includes)) {
+			includes = null;
+		}
+		
+		if (CollectionUtils.isEmpty(revIncludes)) {
+			revIncludes = null;
 		}
 		
 		ObservationSearchParams searchParams = new ObservationSearchParams();
 		searchParams.setPatient(subjectParam);
 		searchParams.setCategory(category);
 		searchParams.setCode(code);
+		searchParams.setEncounter(encounterParam);
+		searchParams.setIncludes(includes);
+		searchParams.setRevIncludes(revIncludes);
 		
 		return observationService.getLastnObservations(max, searchParams);
 	}

--- a/api/src/test/java/org/openmrs/module/fhir2/api/search/ObservationSearchQueryTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/search/ObservationSearchQueryTest.java
@@ -1645,7 +1645,142 @@ public class ObservationSearchQueryTest extends BaseFhirContextSensitiveTest {
 		assertThat(resultList, everyItem(anyOf(allOf(is(instanceOf(Observation.class))))));
 		assertThat(resultList, isSortedAndWithinMax(1));
 	}
-	
+
+	@Test
+	public void searchForLastnObs_shouldHandleEncounterRequest() {
+		ReferenceAndListParam referenceParam = new ReferenceAndListParam();
+		ReferenceParam patient = new ReferenceParam();
+
+		patient.setValue(PATIENT_UUID);
+
+		referenceParam.addValue(new ReferenceOrListParam().add(patient));
+
+		ReferenceAndListParam encounterReference = new ReferenceAndListParam()
+		        .addAnd(new ReferenceOrListParam().add(new ReferenceParam().setValue(ENCOUNTER_UUID)));
+
+		TokenAndListParam categories = new TokenAndListParam().addAnd(new TokenParam().setValue("laboratory"));
+
+		TokenAndListParam code = new TokenAndListParam().addAnd(
+		    new TokenParam().setSystem(FhirTestConstants.LOINC_SYSTEM_URL).setValue(LOINC_SYSTOLIC_BP),
+		    new TokenParam().setSystem(FhirTestConstants.CIEL_SYSTEM_URN).setValue(CIEL_DIASTOLIC_BP));
+
+		SearchParameterMap theParams = new SearchParameterMap().addParameter(FhirConstants.CODED_SEARCH_HANDLER, code)
+		        .addParameter(FhirConstants.CATEGORY_SEARCH_HANDLER, categories)
+		        .addParameter(FhirConstants.MAX_SEARCH_HANDLER, new NumberParam(2))
+		        .addParameter(FhirConstants.PATIENT_REFERENCE_SEARCH_HANDLER, referenceParam)
+		        .addParameter(FhirConstants.ENCOUNTER_REFERENCE_SEARCH_HANDLER, encounterReference)
+		        .addParameter(FhirConstants.LASTN_OBSERVATION_SEARCH_HANDLER, new StringParam());
+
+		IBundleProvider results = search(theParams);
+
+		assertThat(results, notNullValue());
+		List<IBaseResource> resultList = results.getAllResources();
+
+		assertThat(resultList.size(), equalTo(2));
+		assertThat(resultList, everyItem(anyOf(allOf(is(instanceOf(Observation.class))))));
+		assertThat(resultList, isSortedAndWithinMax(2));
+	}
+
+	@Test
+	public void searchForLastnObs_shouldReturnEmptyWhenEncounterNotFound() {
+		ReferenceAndListParam referenceParam = new ReferenceAndListParam();
+		ReferenceParam patient = new ReferenceParam();
+
+		patient.setValue(PATIENT_UUID);
+
+		referenceParam.addValue(new ReferenceOrListParam().add(patient));
+
+		ReferenceAndListParam encounterReference = new ReferenceAndListParam()
+		        .addAnd(new ReferenceOrListParam().add(new ReferenceParam().setValue(PATIENT_WRONG_UUID)));
+
+		TokenAndListParam categories = new TokenAndListParam().addAnd(new TokenParam().setValue("laboratory"));
+
+		TokenAndListParam code = new TokenAndListParam().addAnd(
+		    new TokenParam().setSystem(FhirTestConstants.LOINC_SYSTEM_URL).setValue(LOINC_SYSTOLIC_BP),
+		    new TokenParam().setSystem(FhirTestConstants.CIEL_SYSTEM_URN).setValue(CIEL_DIASTOLIC_BP));
+
+		SearchParameterMap theParams = new SearchParameterMap().addParameter(FhirConstants.CODED_SEARCH_HANDLER, code)
+		        .addParameter(FhirConstants.CATEGORY_SEARCH_HANDLER, categories)
+		        .addParameter(FhirConstants.MAX_SEARCH_HANDLER, new NumberParam(2))
+		        .addParameter(FhirConstants.PATIENT_REFERENCE_SEARCH_HANDLER, referenceParam)
+		        .addParameter(FhirConstants.ENCOUNTER_REFERENCE_SEARCH_HANDLER, encounterReference)
+		        .addParameter(FhirConstants.LASTN_OBSERVATION_SEARCH_HANDLER, new StringParam());
+
+		IBundleProvider results = search(theParams);
+
+		assertThat(results, notNullValue());
+		List<IBaseResource> resultList = results.getAllResources();
+
+		assertThat(resultList, empty());
+	}
+
+	@Test
+	public void searchForLastnObs_shouldAddEncounterToReturnedResults() {
+		ReferenceAndListParam referenceParam = new ReferenceAndListParam();
+		ReferenceParam patient = new ReferenceParam();
+
+		patient.setValue(PATIENT_UUID);
+
+		referenceParam.addValue(new ReferenceOrListParam().add(patient));
+
+		TokenAndListParam code = new TokenAndListParam().addAnd(
+		    new TokenParam().setSystem(FhirTestConstants.LOINC_SYSTEM_URL).setValue(LOINC_SYSTOLIC_BP),
+		    new TokenParam().setSystem(FhirTestConstants.CIEL_SYSTEM_URN).setValue(CIEL_DIASTOLIC_BP));
+
+		HashSet<Include> includes = new HashSet<>();
+		includes.add(new Include("Observation:encounter"));
+
+		SearchParameterMap theParams = new SearchParameterMap().addParameter(FhirConstants.CODED_SEARCH_HANDLER, code)
+		        .addParameter(FhirConstants.MAX_SEARCH_HANDLER, new NumberParam(2))
+		        .addParameter(FhirConstants.PATIENT_REFERENCE_SEARCH_HANDLER, referenceParam)
+		        .addParameter(FhirConstants.INCLUDE_SEARCH_HANDLER, includes)
+		        .addParameter(FhirConstants.LASTN_OBSERVATION_SEARCH_HANDLER, new StringParam());
+
+		IBundleProvider results = search(theParams);
+
+		assertThat(results.size(), equalTo(2));
+
+		List<IBaseResource> resultList = get(results);
+
+		assertThat(resultList, notNullValue());
+		assertThat(resultList.size(), equalTo(3)); // 2 observations + 1 included encounter
+
+		Observation returnedObservation = (Observation) resultList.iterator().next();
+		assertThat(resultList, hasItem(allOf(is(instanceOf(Encounter.class)),
+		    hasProperty("id", equalTo(returnedObservation.getEncounter().getReferenceElement().getIdPart())))));
+	}
+
+	@Test
+	public void searchForLastnObs_shouldAddDiagnosticReportToReturnedResults() {
+		ReferenceAndListParam referenceParam = new ReferenceAndListParam();
+		ReferenceParam patient = new ReferenceParam();
+
+		patient.setValue(PATIENT_UUID);
+
+		referenceParam.addValue(new ReferenceOrListParam().add(patient));
+
+		TokenAndListParam code = new TokenAndListParam()
+		        .addAnd(new TokenParam().setSystem(FhirTestConstants.CIEL_SYSTEM_URN).setValue(VALUE_CONCEPT_ID));
+
+		HashSet<Include> revIncludes = new HashSet<>();
+		revIncludes.add(new Include("DiagnosticReport:result"));
+
+		SearchParameterMap theParams = new SearchParameterMap().addParameter(FhirConstants.CODED_SEARCH_HANDLER, code)
+		        .addParameter(FhirConstants.MAX_SEARCH_HANDLER, new NumberParam(2))
+		        .addParameter(FhirConstants.PATIENT_REFERENCE_SEARCH_HANDLER, referenceParam)
+		        .addParameter(FhirConstants.REVERSE_INCLUDE_SEARCH_HANDLER, revIncludes)
+		        .addParameter(FhirConstants.LASTN_OBSERVATION_SEARCH_HANDLER, new StringParam());
+
+		IBundleProvider results = search(theParams);
+
+		assertThat(results.size(), greaterThan(0));
+
+		List<IBaseResource> resultList = get(results);
+
+		assertThat(resultList, notNullValue());
+		assertThat(resultList, hasItem(is(instanceOf(DiagnosticReport.class))));
+	}
+
 	@Test
 	public void searchForLastnEncountersObs_shouldHandleNormalRequest() {
 		ReferenceAndListParam referenceParam = new ReferenceAndListParam();

--- a/api/src/test/java/org/openmrs/module/fhir2/providers/r3/ObservationFhirResourceProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/providers/r3/ObservationFhirResourceProviderTest.java
@@ -328,7 +328,8 @@ public class ObservationFhirResourceProviderTest extends BaseFhirR3ProvenanceRes
 		when(observationService.getLastnObservations(max, searchParams))
 		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(observation), 10, 1));
 		
-		IBundleProvider results = resourceProvider.getLastnObservations(max, referenceParam, null, categories, code);
+		IBundleProvider results = resourceProvider.getLastnObservations(max, referenceParam, null, categories, code, null,
+		    null, null);
 		
 		List<IBaseResource> resultList = get(results, 0, 10);
 		
@@ -363,7 +364,8 @@ public class ObservationFhirResourceProviderTest extends BaseFhirR3ProvenanceRes
 		when(observationService.getLastnObservations(null, searchParams))
 		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(observation), 10, 1));
 		
-		IBundleProvider results = resourceProvider.getLastnObservations(null, referenceParam, null, categories, code);
+		IBundleProvider results = resourceProvider.getLastnObservations(null, referenceParam, null, categories, code, null,
+		    null, null);
 		
 		List<IBaseResource> resultList = get(results, 0, 10);
 		
@@ -398,7 +400,8 @@ public class ObservationFhirResourceProviderTest extends BaseFhirR3ProvenanceRes
 		when(observationService.getLastnObservations(max, searchParams))
 		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(observation), 10, 1));
 		
-		IBundleProvider results = resourceProvider.getLastnObservations(max, null, referenceParam, categories, code);
+		IBundleProvider results = resourceProvider.getLastnObservations(max, null, referenceParam, categories, code, null,
+		    null, null);
 		
 		List<IBaseResource> resultList = get(results, 0, 10);
 		
@@ -426,7 +429,7 @@ public class ObservationFhirResourceProviderTest extends BaseFhirR3ProvenanceRes
 		when(observationService.getLastnObservations(max, searchParams))
 		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(observation), 10, 1));
 		
-		IBundleProvider results = resourceProvider.getLastnObservations(max, null, null, categories, code);
+		IBundleProvider results = resourceProvider.getLastnObservations(max, null, null, categories, code, null, null, null);
 		
 		List<IBaseResource> resultList = get(results, 0, 10);
 		
@@ -458,7 +461,8 @@ public class ObservationFhirResourceProviderTest extends BaseFhirR3ProvenanceRes
 		when(observationService.getLastnObservations(max, searchParams))
 		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(observation), 10, 1));
 		
-		IBundleProvider results = resourceProvider.getLastnObservations(max, referenceParam, null, null, code);
+		IBundleProvider results = resourceProvider.getLastnObservations(max, referenceParam, null, null, code, null, null,
+		    null);
 		
 		List<IBaseResource> resultList = get(results, 0, 10);
 		
@@ -488,7 +492,8 @@ public class ObservationFhirResourceProviderTest extends BaseFhirR3ProvenanceRes
 		when(observationService.getLastnObservations(max, searchParams))
 		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(observation), 10, 1));
 		
-		IBundleProvider results = resourceProvider.getLastnObservations(max, referenceParam, null, categories, null);
+		IBundleProvider results = resourceProvider.getLastnObservations(max, referenceParam, null, categories, null, null,
+		    null, null);
 		
 		List<IBaseResource> resultList = get(results, 0, 10);
 		
@@ -515,7 +520,8 @@ public class ObservationFhirResourceProviderTest extends BaseFhirR3ProvenanceRes
 		when(observationService.getLastnObservations(max, searchParams))
 		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(observation), 10, 1));
 		
-		IBundleProvider results = resourceProvider.getLastnObservations(max, referenceParam, null, null, null);
+		IBundleProvider results = resourceProvider.getLastnObservations(max, referenceParam, null, null, null, null, null,
+		    null);
 		
 		List<IBaseResource> resultList = get(results, 0, 10);
 		

--- a/api/src/test/java/org/openmrs/module/fhir2/providers/r4/ObservationFhirResourceProviderTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/providers/r4/ObservationFhirResourceProviderTest.java
@@ -358,7 +358,8 @@ public class ObservationFhirResourceProviderTest extends BaseFhirProvenanceResou
 		when(observationService.getLastnObservations(max, searchParams))
 		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(observation), 10, 1));
 		
-		IBundleProvider results = resourceProvider.getLastnObservations(max, referenceParam, null, categories, code);
+		IBundleProvider results = resourceProvider.getLastnObservations(max, referenceParam, null, categories, code, null,
+		    null, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -393,7 +394,8 @@ public class ObservationFhirResourceProviderTest extends BaseFhirProvenanceResou
 		when(observationService.getLastnObservations(null, searchParams))
 		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(observation), 10, 1));
 		
-		IBundleProvider results = resourceProvider.getLastnObservations(null, referenceParam, null, categories, code);
+		IBundleProvider results = resourceProvider.getLastnObservations(null, referenceParam, null, categories, code, null,
+		    null, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -428,7 +430,8 @@ public class ObservationFhirResourceProviderTest extends BaseFhirProvenanceResou
 		when(observationService.getLastnObservations(max, searchParams))
 		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(observation), 10, 1));
 		
-		IBundleProvider results = resourceProvider.getLastnObservations(max, null, referenceParam, categories, code);
+		IBundleProvider results = resourceProvider.getLastnObservations(max, null, referenceParam, categories, code, null,
+		    null, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -456,7 +459,7 @@ public class ObservationFhirResourceProviderTest extends BaseFhirProvenanceResou
 		when(observationService.getLastnObservations(max, searchParams))
 		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(observation), 10, 1));
 		
-		IBundleProvider results = resourceProvider.getLastnObservations(max, null, null, categories, code);
+		IBundleProvider results = resourceProvider.getLastnObservations(max, null, null, categories, code, null, null, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -488,7 +491,8 @@ public class ObservationFhirResourceProviderTest extends BaseFhirProvenanceResou
 		when(observationService.getLastnObservations(max, searchParams))
 		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(observation), 10, 1));
 		
-		IBundleProvider results = resourceProvider.getLastnObservations(max, referenceParam, null, null, code);
+		IBundleProvider results = resourceProvider.getLastnObservations(max, referenceParam, null, null, code, null, null,
+		    null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -518,7 +522,8 @@ public class ObservationFhirResourceProviderTest extends BaseFhirProvenanceResou
 		when(observationService.getLastnObservations(max, searchParams))
 		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(observation), 10, 1));
 		
-		IBundleProvider results = resourceProvider.getLastnObservations(max, referenceParam, null, categories, null);
+		IBundleProvider results = resourceProvider.getLastnObservations(max, referenceParam, null, categories, null, null,
+		    null, null);
 		
 		List<IBaseResource> resultList = get(results);
 		
@@ -545,7 +550,8 @@ public class ObservationFhirResourceProviderTest extends BaseFhirProvenanceResou
 		when(observationService.getLastnObservations(max, searchParams))
 		        .thenReturn(new MockIBundleProvider<>(Collections.singletonList(observation), 10, 1));
 		
-		IBundleProvider results = resourceProvider.getLastnObservations(max, referenceParam, null, null, null);
+		IBundleProvider results = resourceProvider.getLastnObservations(max, referenceParam, null, null, null, null, null,
+		    null);
 		
 		List<IBaseResource> resultList = get(results);
 		

--- a/integration-tests/src/test/java/org/openmrs/module/fhir2/providers/r3/ObservationFhirResourceProviderIntegrationTest.java
+++ b/integration-tests/src/test/java/org/openmrs/module/fhir2/providers/r3/ObservationFhirResourceProviderIntegrationTest.java
@@ -960,6 +960,49 @@ public class ObservationFhirResourceProviderIntegrationTest extends BaseFhirR3In
 	}
 	
 	@Test
+	public void shouldReturnLastnObservationsFilteredByEncounterAsJson() throws Exception {
+		MockHttpServletResponse response = get(
+		    "Observation/$lastn?max=5&patient=" + OBS_PATIENT_UUID + "&encounter=" + OBS_ENCOUNTER_UUID)
+		            .accept(FhirMediaTypes.JSON).go();
+
+		assertThat(response, isOk());
+		assertThat(response.getContentType(), startsWith(FhirMediaTypes.JSON.toString()));
+		assertThat(response.getContentAsString(), notNullValue());
+
+		Bundle results = readBundleResponse(response);
+
+		assertThat(results, notNullValue());
+		assertThat(results.getType(), equalTo(Bundle.BundleType.SEARCHSET));
+		assertThat(results.hasEntry(), is(true));
+
+		List<Bundle.BundleEntryComponent> entries = results.getEntry();
+
+		assertThat(entries, everyItem(hasProperty("fullUrl", startsWith("http://localhost/ws/fhir2/R3/Observation/"))));
+		assertThat(entries, everyItem(hasResource(instanceOf(Observation.class))));
+		assertThat(entries, everyItem(hasResource(validResource())));
+		assertThat(entries, everyItem(hasResource(hasProperty("context",
+		    hasProperty("reference", endsWith("/" + OBS_ENCOUNTER_UUID))))));
+		assertThat(entries, isSortedAndWithinMax(5));
+	}
+
+	@Test
+	public void shouldReturnEmptyLastnObservationsWhenEncounterNotFoundAsJson() throws Exception {
+		MockHttpServletResponse response = get(
+		    "Observation/$lastn?max=5&patient=" + OBS_PATIENT_UUID + "&encounter=" + WRONG_OBS_UUID)
+		            .accept(FhirMediaTypes.JSON).go();
+
+		assertThat(response, isOk());
+		assertThat(response.getContentType(), startsWith(FhirMediaTypes.JSON.toString()));
+		assertThat(response.getContentAsString(), notNullValue());
+
+		Bundle results = readBundleResponse(response);
+
+		assertThat(results, notNullValue());
+		assertThat(results.getType(), equalTo(Bundle.BundleType.SEARCHSET));
+		assertThat(results.hasEntry(), is(false));
+	}
+
+	@Test
 	public void shouldReturnLastnEncountersObservationsAsJson() throws Exception {
 		MockHttpServletResponse response = get(
 		    "Observation/$lastn-encounters?max=2&subject=" + OBS_PATIENT_UUID + "&category=laboratory&code=5089")

--- a/integration-tests/src/test/java/org/openmrs/module/fhir2/providers/r4/ObservationFhirResourceProviderIntegrationTest.java
+++ b/integration-tests/src/test/java/org/openmrs/module/fhir2/providers/r4/ObservationFhirResourceProviderIntegrationTest.java
@@ -971,6 +971,49 @@ public class ObservationFhirResourceProviderIntegrationTest extends BaseFhirR4In
 	}
 	
 	@Test
+	public void shouldReturnLastnObservationsFilteredByEncounterAsJson() throws Exception {
+		MockHttpServletResponse response = get(
+		    "Observation/$lastn?max=5&patient=" + OBS_PATIENT_UUID + "&encounter=" + OBS_ENCOUNTER_UUID)
+		            .accept(FhirMediaTypes.JSON).go();
+
+		assertThat(response, isOk());
+		assertThat(response.getContentType(), startsWith(FhirMediaTypes.JSON.toString()));
+		assertThat(response.getContentAsString(), notNullValue());
+
+		Bundle results = readBundleResponse(response);
+
+		assertThat(results, notNullValue());
+		assertThat(results.getType(), equalTo(Bundle.BundleType.SEARCHSET));
+		assertThat(results.hasEntry(), is(true));
+
+		List<Bundle.BundleEntryComponent> entries = results.getEntry();
+
+		assertThat(entries, everyItem(hasProperty("fullUrl", startsWith("http://localhost/ws/fhir2/R4/Observation/"))));
+		assertThat(entries, everyItem(hasResource(instanceOf(Observation.class))));
+		assertThat(entries, everyItem(hasResource(validResource())));
+		assertThat(entries, everyItem(hasResource(hasProperty("encounter",
+		    hasProperty("reference", endsWith("/" + OBS_ENCOUNTER_UUID))))));
+		assertThat(entries, isSortedAndWithinMax(5));
+	}
+
+	@Test
+	public void shouldReturnEmptyLastnObservationsWhenEncounterNotFoundAsJson() throws Exception {
+		MockHttpServletResponse response = get(
+		    "Observation/$lastn?max=5&patient=" + OBS_PATIENT_UUID + "&encounter=" + WRONG_OBS_UUID)
+		            .accept(FhirMediaTypes.JSON).go();
+
+		assertThat(response, isOk());
+		assertThat(response.getContentType(), startsWith(FhirMediaTypes.JSON.toString()));
+		assertThat(response.getContentAsString(), notNullValue());
+
+		Bundle results = readBundleResponse(response);
+
+		assertThat(results, notNullValue());
+		assertThat(results.getType(), equalTo(Bundle.BundleType.SEARCHSET));
+		assertThat(results.hasEntry(), is(false));
+	}
+
+	@Test
 	public void shouldReturnLastnEncountersObservationsAsJson() throws Exception {
 		MockHttpServletResponse response = get(
 		    "Observation/$lastn-encounters?max=2&subject=" + OBS_PATIENT_UUID + "&category=laboratory&code=5089")

--- a/omod/src/test/java/org/openmrs/module/fhir2/providers/r3/ObservationFhirResourceProviderWebTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/providers/r3/ObservationFhirResourceProviderWebTest.java
@@ -884,6 +884,83 @@ public class ObservationFhirResourceProviderWebTest extends BaseFhirR3ResourcePr
 	}
 	
 	@Test
+	public void lastn_shouldHandleRequestWithEncounterReference() throws Exception {
+		verifyLastnOperation("/Observation/$lastn?encounter=c4aa5682-90cf-48e8-87c9-a6066ffd3a3f");
+		verify(observationService).getLastnObservations(isNull(), searchParamsCaptor.capture());
+		
+		ReferenceAndListParam encounter = searchParamsCaptor.getValue().getEncounter();
+		ReferenceParam referenceParam = encounter.getValuesAsQueryTokens().get(0).getValuesAsQueryTokens().get(0);
+		
+		assertThat(encounter, notNullValue());
+		assertThat(referenceParam.getIdPart(), equalTo("c4aa5682-90cf-48e8-87c9-a6066ffd3a3f"));
+	}
+	
+	@Test
+	public void lastn_shouldIncludeEncounterWithReturnedObservations() throws Exception {
+		verifyLastnOperation("/Observation/$lastn?_include=Observation:encounter");
+		verify(observationService).getLastnObservations(isNull(), searchParamsCaptor.capture());
+		
+		Set<Include> includes = searchParamsCaptor.getValue().getIncludes();
+		
+		assertThat(includes, notNullValue());
+		assertThat(includes.size(), equalTo(1));
+		assertThat(includes.iterator().next().getParamName(), equalTo(FhirConstants.INCLUDE_ENCOUNTER_PARAM));
+		assertThat(includes.iterator().next().getParamType(), equalTo(FhirConstants.OBSERVATION));
+	}
+	
+	@Test
+	public void lastn_shouldIncludePatientWithReturnedObservations() throws Exception {
+		verifyLastnOperation("/Observation/$lastn?_include=Observation:patient");
+		verify(observationService).getLastnObservations(isNull(), searchParamsCaptor.capture());
+		
+		Set<Include> includes = searchParamsCaptor.getValue().getIncludes();
+		
+		assertThat(includes, notNullValue());
+		assertThat(includes.size(), equalTo(1));
+		assertThat(includes.iterator().next().getParamName(), equalTo(FhirConstants.INCLUDE_PATIENT_PARAM));
+		assertThat(includes.iterator().next().getParamType(), equalTo(FhirConstants.OBSERVATION));
+	}
+	
+	@Test
+	public void lastn_shouldIncludeObservationGroupMembersWithReturnedObservations() throws Exception {
+		verifyLastnOperation("/Observation/$lastn?_include=Observation:related-type");
+		verify(observationService).getLastnObservations(isNull(), searchParamsCaptor.capture());
+		
+		Set<Include> includes = searchParamsCaptor.getValue().getIncludes();
+		
+		assertThat(includes, notNullValue());
+		assertThat(includes.size(), equalTo(1));
+		assertThat(includes.iterator().next().getParamName(), equalTo(FhirConstants.INCLUDE_RELATED_TYPE_PARAM));
+		assertThat(includes.iterator().next().getParamType(), equalTo(FhirConstants.OBSERVATION));
+	}
+	
+	@Test
+	public void lastn_shouldReverseIncludeObservationsWithReturnedObservations() throws Exception {
+		verifyLastnOperation("/Observation/$lastn?_revinclude=Observation:related-type");
+		verify(observationService).getLastnObservations(isNull(), searchParamsCaptor.capture());
+		
+		Set<Include> revIncludes = searchParamsCaptor.getValue().getRevIncludes();
+		
+		assertThat(revIncludes, notNullValue());
+		assertThat(revIncludes.size(), equalTo(1));
+		assertThat(revIncludes.iterator().next().getParamName(), equalTo(FhirConstants.INCLUDE_RELATED_TYPE_PARAM));
+		assertThat(revIncludes.iterator().next().getParamType(), equalTo(FhirConstants.OBSERVATION));
+	}
+	
+	@Test
+	public void lastn_shouldReverseIncludeDiagnosticReportsWithReturnedObservations() throws Exception {
+		verifyLastnOperation("/Observation/$lastn?_revinclude=DiagnosticReport:result");
+		verify(observationService).getLastnObservations(isNull(), searchParamsCaptor.capture());
+		
+		Set<Include> revIncludes = searchParamsCaptor.getValue().getRevIncludes();
+		
+		assertThat(revIncludes, notNullValue());
+		assertThat(revIncludes.size(), equalTo(1));
+		assertThat(revIncludes.iterator().next().getParamName(), equalTo(FhirConstants.INCLUDE_RESULT_PARAM));
+		assertThat(revIncludes.iterator().next().getParamType(), equalTo(FhirConstants.DIAGNOSTIC_REPORT));
+	}
+	
+	@Test
 	public void lastnEncounters_shouldHandleRequestWithMaxParameter() throws Exception {
 		verifyLastnEncountersOperation("/Observation/$lastn-encounters?max=3");
 		verify(observationService).getLastnEncountersObservations(maxCaptor.capture(), searchParamsCaptor.capture());

--- a/omod/src/test/java/org/openmrs/module/fhir2/providers/r4/ObservationFhirResourceProviderWebTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/providers/r4/ObservationFhirResourceProviderWebTest.java
@@ -889,6 +889,83 @@ public class ObservationFhirResourceProviderWebTest extends BaseFhirR4ResourcePr
 	}
 	
 	@Test
+	public void lastn_shouldHandleRequestWithEncounterReference() throws Exception {
+		verifyLastnOperation("/Observation/$lastn?encounter=c4aa5682-90cf-48e8-87c9-a6066ffd3a3f");
+		verify(observationService).getLastnObservations(isNull(), searchParamsCaptor.capture());
+		
+		ReferenceAndListParam encounter = searchParamsCaptor.getValue().getEncounter();
+		ReferenceParam referenceParam = encounter.getValuesAsQueryTokens().get(0).getValuesAsQueryTokens().get(0);
+		
+		assertThat(encounter, notNullValue());
+		assertThat(referenceParam.getIdPart(), equalTo("c4aa5682-90cf-48e8-87c9-a6066ffd3a3f"));
+	}
+	
+	@Test
+	public void lastn_shouldIncludeEncounterWithReturnedObservations() throws Exception {
+		verifyLastnOperation("/Observation/$lastn?_include=Observation:encounter");
+		verify(observationService).getLastnObservations(isNull(), searchParamsCaptor.capture());
+		
+		Set<Include> includes = searchParamsCaptor.getValue().getIncludes();
+		
+		assertThat(includes, notNullValue());
+		assertThat(includes.size(), equalTo(1));
+		assertThat(includes.iterator().next().getParamName(), equalTo(FhirConstants.INCLUDE_ENCOUNTER_PARAM));
+		assertThat(includes.iterator().next().getParamType(), equalTo(FhirConstants.OBSERVATION));
+	}
+	
+	@Test
+	public void lastn_shouldIncludePatientWithReturnedObservations() throws Exception {
+		verifyLastnOperation("/Observation/$lastn?_include=Observation:patient");
+		verify(observationService).getLastnObservations(isNull(), searchParamsCaptor.capture());
+		
+		Set<Include> includes = searchParamsCaptor.getValue().getIncludes();
+		
+		assertThat(includes, notNullValue());
+		assertThat(includes.size(), equalTo(1));
+		assertThat(includes.iterator().next().getParamName(), equalTo(FhirConstants.INCLUDE_PATIENT_PARAM));
+		assertThat(includes.iterator().next().getParamType(), equalTo(FhirConstants.OBSERVATION));
+	}
+	
+	@Test
+	public void lastn_shouldIncludeObservationGroupMembersWithReturnedObservations() throws Exception {
+		verifyLastnOperation("/Observation/$lastn?_include=Observation:has-member");
+		verify(observationService).getLastnObservations(isNull(), searchParamsCaptor.capture());
+		
+		Set<Include> includes = searchParamsCaptor.getValue().getIncludes();
+		
+		assertThat(includes, notNullValue());
+		assertThat(includes.size(), equalTo(1));
+		assertThat(includes.iterator().next().getParamName(), equalTo(FhirConstants.INCLUDE_HAS_MEMBER_PARAM));
+		assertThat(includes.iterator().next().getParamType(), equalTo(FhirConstants.OBSERVATION));
+	}
+	
+	@Test
+	public void lastn_shouldReverseIncludeObservationsWithReturnedObservations() throws Exception {
+		verifyLastnOperation("/Observation/$lastn?_revinclude=Observation:has-member");
+		verify(observationService).getLastnObservations(isNull(), searchParamsCaptor.capture());
+		
+		Set<Include> revIncludes = searchParamsCaptor.getValue().getRevIncludes();
+		
+		assertThat(revIncludes, notNullValue());
+		assertThat(revIncludes.size(), equalTo(1));
+		assertThat(revIncludes.iterator().next().getParamName(), equalTo(FhirConstants.INCLUDE_HAS_MEMBER_PARAM));
+		assertThat(revIncludes.iterator().next().getParamType(), equalTo(FhirConstants.OBSERVATION));
+	}
+	
+	@Test
+	public void lastn_shouldReverseIncludeDiagnosticReportsWithReturnedObservations() throws Exception {
+		verifyLastnOperation("/Observation/$lastn?_revinclude=DiagnosticReport:result");
+		verify(observationService).getLastnObservations(isNull(), searchParamsCaptor.capture());
+		
+		Set<Include> revIncludes = searchParamsCaptor.getValue().getRevIncludes();
+		
+		assertThat(revIncludes, notNullValue());
+		assertThat(revIncludes.size(), equalTo(1));
+		assertThat(revIncludes.iterator().next().getParamName(), equalTo(FhirConstants.INCLUDE_RESULT_PARAM));
+		assertThat(revIncludes.iterator().next().getParamType(), equalTo(FhirConstants.DIAGNOSTIC_REPORT));
+	}
+	
+	@Test
 	public void lastnEncounters_shouldHandleRequestWithMaxParameter() throws Exception {
 		verifyLastnEncountersOperation("/Observation/$lastn-encounters?max=3");
 		verify(observationService).getLastnEncountersObservations(maxCaptor.capture(), searchParamsCaptor.capture());


### PR DESCRIPTION
## Description of what I changed
This PR enhances the `lastn` operation in ObservationResource providers to support filtering of lastest Observation by a list of encounters.

This enhancement is needed to efficiently leverage the `lastn` operation to fetch the latest observations that are captured in a specific visit/episode. This will help clients to query for the latest of observations that are captured during a visit/episode without running extensive filters on the consuming side.

A few common examples:
- Query for the latest vitals signs in a visit
- Query for the latest BMI during an episode

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/FM2-697

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

## Anything else?
