### PR TITLE
FM2-698: Add support for externally configured interceptors

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhir2/FhirActivator.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/FhirActivator.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.WeakHashMap;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import ca.uhn.fhir.context.FhirContext;
@@ -73,12 +74,12 @@ public class FhirActivator extends BaseModuleActivator implements ApplicationCon
 		started = true;
 		log.info("Started FHIR");
 		
-		lifecycleListeners.forEach(ModuleLifecycleListener::started);
+		notifyListeners("started", ModuleLifecycleListener::started);
 	}
 	
 	@Override
 	public void willRefreshContext() {
-		lifecycleListeners.forEach(ModuleLifecycleListener::willRefresh);
+		notifyListeners("willRefresh", ModuleLifecycleListener::willRefresh);
 		unloadModules();
 	}
 	
@@ -98,12 +99,12 @@ public class FhirActivator extends BaseModuleActivator implements ApplicationCon
 		applicationContext.getBean("fhirR4", FhirContext.class).registerCustomType(GroupMember.class);
 		loadModules();
 		
-		lifecycleListeners.forEach(ModuleLifecycleListener::refreshed);
+		notifyListeners("refreshed", ModuleLifecycleListener::refreshed);
 	}
 	
 	@Override
 	public void willStop() {
-		lifecycleListeners.forEach(ModuleLifecycleListener::willStop);
+		notifyListeners("willStop", ModuleLifecycleListener::willStop);
 		
 		if (globalPropertyHolder != null) {
 			Context.getAdministrationService().removeGlobalPropertyListener(globalPropertyHolder);
@@ -112,12 +113,27 @@ public class FhirActivator extends BaseModuleActivator implements ApplicationCon
 	
 	@Override
 	public void stopped() {
-		lifecycleListeners.forEach(ModuleLifecycleListener::stopped);
+		notifyListeners("stopped", ModuleLifecycleListener::stopped);
 		unloadModules();
 		
 		globalPropertyHolder = null;
 		started = false;
 		log.info("Shutdown FHIR");
+	}
+	
+	/**
+	 * Notifies every listener even if an earlier one throws. Both FHIR servlets register here, so one
+	 * failing must not leave the other holding a context that has been closed.
+	 */
+	private void notifyListeners(String event, Consumer<ModuleLifecycleListener> notification) {
+		for (ModuleLifecycleListener listener : lifecycleListeners) {
+			try {
+				notification.accept(listener);
+			}
+			catch (Exception e) {
+				log.error("FHIR2 lifecycle listener {} failed on {}", listener.getClass().getName(), event, e);
+			}
+		}
 	}
 	
 	public void addModuleLifecycleListener(@Nonnull ModuleLifecycleListener lifecycleListener) {

--- a/api/src/main/java/org/openmrs/module/fhir2/FhirActivator.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/FhirActivator.java
@@ -13,7 +13,6 @@ import static org.openmrs.module.fhir2.FhirConstants.FHIR2_MODULE_ID;
 
 import javax.annotation.Nonnull;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -21,6 +20,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.WeakHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
@@ -60,7 +60,7 @@ public class FhirActivator extends BaseModuleActivator implements ApplicationCon
 	
 	private final Map<String, Set<Class<?>>> services = new HashMap<>();
 	
-	private final List<ModuleLifecycleListener> lifecycleListeners = new ArrayList<>();
+	private final List<ModuleLifecycleListener> lifecycleListeners = new CopyOnWriteArrayList<>();
 	
 	private boolean started = false;
 	
@@ -124,14 +124,20 @@ public class FhirActivator extends BaseModuleActivator implements ApplicationCon
 	/**
 	 * Notifies every listener even if an earlier one throws. Both FHIR servlets register here, so one
 	 * failing must not leave the other holding a context that has been closed.
+	 * <p>
+	 * Catches {@link Throwable} rather than {@link Exception} because the failure this is guarding
+	 * against is a refresh that swaps module classloaders, and a listener touching a class from a
+	 * half-unloaded module raises {@link LinkageError} rather than an exception.
 	 */
 	private void notifyListeners(String event, Consumer<ModuleLifecycleListener> notification) {
 		for (ModuleLifecycleListener listener : lifecycleListeners) {
 			try {
 				notification.accept(listener);
 			}
-			catch (Exception e) {
-				log.error("FHIR2 lifecycle listener {} failed on {}", listener.getClass().getName(), event, e);
+			catch (Throwable t) {
+				log.error("FHIR2 lifecycle listener {} failed on {}; it may serve stale providers or interceptors until the "
+				        + "next context refresh",
+				    listener.getClass().getName(), event, t);
 			}
 		}
 	}

--- a/api/src/main/java/org/openmrs/module/fhir2/FhirConstants.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/FhirConstants.java
@@ -18,6 +18,21 @@ public final class FhirConstants {
 	
 	public static final String FHIR2_MODULE_ID = "fhir2";
 	
+	/**
+	 * The HAPI interceptor order this module uses for its own interceptors, so that they dispatch ahead
+	 * of anything at {@code Interceptor.DEFAULT_ORDER} however late this module registers them. A bean
+	 * contributed with {@code org.openmrs.module.fhir2.api.annotations.FhirInterceptor} is held at or
+	 * above the default order, so it cannot precede them.
+	 * <p>
+	 * This is a convention, not a barrier: only beans that arrive through {@code FhirInterceptor} are
+	 * checked. Code that registers an interceptor on the servlet directly can still declare a lower
+	 * order and run first.
+	 * <p>
+	 * Deliberately a small magnitude rather than {@code Integer.MIN_VALUE}: HAPI compares two orders
+	 * with {@code a - b}, which overflows and inverts the comparison near the extremes of int.
+	 */
+	public static final int BUILT_IN_INTERCEPTOR_ORDER = -1000;
+	
 	public static final String OPENMRS_FHIR_SERVER_NAME = "OpenMRS FHIR Server";
 	
 	public static final String HL7_FHIR_CODE_SYSTEM_PREFIX = "http://terminology.hl7.org/CodeSystem";

--- a/api/src/main/java/org/openmrs/module/fhir2/api/annotations/FhirInterceptor.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/annotations/FhirInterceptor.java
@@ -18,24 +18,13 @@ import java.lang.annotation.Target;
 import org.springframework.beans.factory.annotation.Qualifier;
 
 /**
- * Marks a Spring bean as a HAPI interceptor the FHIR REST servlets should register, so a module
- * other than this one can add a cross-cutting concern -- authorization, audit, consent -- in the
- * way {@link R4Provider} marks a resource provider.
+ * Marks a Spring bean as a HAPI interceptor every FHIR REST servlet registers, the way
+ * {@link R4Provider} marks a resource provider.
  * <p>
- * The bean must carry at least one {@code Hook} method: HAPI logs "Interceptor registered with no
- * valid hooks" and drops one that does not, so it is absent from the request path with only a
- * warning to say so.
+ * Carry at least one {@code Hook} method; HAPI drops an interceptor without one.
  * <p>
- * Registration order is only HAPI's tie-break -- it sorts each hook by {@code Interceptor(order)},
- * which a non-zero {@code Hook(order)} overrides per method. This module's own interceptors all
- * leave that at 0, so a contributed bean with a negative order runs ahead of them, authentication
- * included.
- * <p>
- * Every version-specific servlet registers it, so one meant for a single FHIR version must work out
- * which it is serving: {@code getFhirContext().getVersion().getVersion()} on a hook handed
- * {@code RequestDetails}, and on {@code Pointcut.SERVER_INCOMING_REQUEST_PRE_PROCESSED}, which is
- * passed only the request and the response,
- * {@code org.openmrs.module.fhir2.web.util.FhirVersionUtils.getFhirVersion(request)}.
+ * On a hook handed no {@code RequestDetails}, read the FHIR version from
+ * {@code FhirVersionUtils.getFhirVersion(request)} rather than the servlet path.
  */
 @Target({ ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/org/openmrs/module/fhir2/api/annotations/FhirInterceptor.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/annotations/FhirInterceptor.java
@@ -18,25 +18,23 @@ import java.lang.annotation.Target;
 import org.springframework.beans.factory.annotation.Qualifier;
 
 /**
- * Marks a Spring bean as a HAPI interceptor the FHIR REST servlets should register, so that a
- * module other than this one can add a cross-cutting concern to the FHIR API -- authorization,
- * audit, consent. The bean carries HAPI's own {@code Hook} methods; this annotation only says it
- * should be picked up, in the way {@link R4Provider} says so for a resource provider.
+ * Marks a Spring bean as a HAPI interceptor the FHIR REST servlets should register, so a module
+ * other than this one can add a cross-cutting concern -- authorization, audit, consent -- in the
+ * way {@link R4Provider} marks a resource provider.
  * <p>
- * The bean must carry at least one {@code Hook} method. HAPI refuses one that does not, logging
- * "Interceptor registered with no valid hooks" and continuing, so an annotated bean without hooks
- * is absent from the request path with nothing but a warning to say so.
+ * The bean must carry at least one {@code Hook} method: HAPI logs "Interceptor registered with no
+ * valid hooks" and drops one that does not, so it is absent from the request path with only a
+ * warning to say so.
  * <p>
- * Registration order is only HAPI's tie-break: on each hook it sorts by
- * {@code Interceptor(order = ...)}, which {@code Hook(order = ...)} overrides per method when
- * non-zero. Every interceptor this module owns leaves that at the default 0, so a contributed bean
- * with a negative order runs ahead of them -- authentication included.
+ * Registration order is only HAPI's tie-break -- it sorts each hook by {@code Interceptor(order)},
+ * which a non-zero {@code Hook(order)} overrides per method. This module's own interceptors all
+ * leave that at 0, so a contributed bean with a negative order runs ahead of them, authentication
+ * included.
  * <p>
- * They are registered on every version-specific servlet, so an interceptor meant for one FHIR
- * version has to work out which it is serving. On a hook handed {@code RequestDetails} that is
- * {@code getFhirContext().getVersion().getVersion()}. On
- * {@code Pointcut.SERVER_INCOMING_REQUEST_PRE_PROCESSED} there is no such handle -- it is passed
- * only the request and the response -- so the servlet path is the only discriminator.
+ * Every version-specific servlet registers it, so one meant for a single FHIR version must work out
+ * which it is serving: {@code getFhirContext().getVersion().getVersion()} on a hook handed
+ * {@code RequestDetails}, and on {@code Pointcut.SERVER_INCOMING_REQUEST_PRE_PROCESSED}, which is
+ * passed only the request and the response, the servlet path.
  */
 @Target({ ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/org/openmrs/module/fhir2/api/annotations/FhirInterceptor.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/annotations/FhirInterceptor.java
@@ -29,8 +29,8 @@ import org.springframework.beans.factory.annotation.Qualifier;
  * silently stopped.
  * <p>
  * The bean must carry at least one {@code Hook} method. HAPI refuses one that does not, logging
- * "Interceptor registered with no valid hooks" and continuing, so an annotated bean without hooks is
- * absent from the request path with nothing but a warning to say so.
+ * "Interceptor registered with no valid hooks" and continuing, so an annotated bean without hooks
+ * is absent from the request path with nothing but a warning to say so.
  * <p>
  * Beans found here are registered after the interceptors this module owns, so authentication has
  * already run. Order among contributed interceptors is HAPI's own, from

--- a/api/src/main/java/org/openmrs/module/fhir2/api/annotations/FhirInterceptor.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/annotations/FhirInterceptor.java
@@ -18,13 +18,9 @@ import java.lang.annotation.Target;
 import org.springframework.beans.factory.annotation.Qualifier;
 
 /**
- * Marks a Spring bean as a HAPI interceptor every FHIR REST servlet registers, the way
- * {@link R4Provider} marks a resource provider.
- * <p>
- * Carry at least one {@code Hook} method; HAPI drops an interceptor without one.
- * <p>
- * On a hook handed no {@code RequestDetails}, read the FHIR version from
- * {@code FhirVersionUtils.getFhirVersion(request)} rather than the servlet path.
+ * Marks a Spring bean as a HAPI interceptor the FHIR REST servlets should register, so a module
+ * other than this one can add a cross-cutting concern -- authorization, audit, consent. It must
+ * declare a {@code Hook} method or HAPI drops it.
  */
 @Target({ ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/org/openmrs/module/fhir2/api/annotations/FhirInterceptor.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/annotations/FhirInterceptor.java
@@ -25,18 +25,26 @@ import org.springframework.beans.factory.annotation.Qualifier;
  * <p>
  * Registering one from outside used not to last. The servlet unregisters every interceptor when the
  * module context refreshes, and that happens whenever any OpenMRS module starts or stops, so an
- * interceptor added at runtime worked until the next module event and then silently stopped.
+ * interceptor added from a Spring bean or from a module's {@code started()} worked until the next
+ * module event and then silently stopped. A module that re-registered from its own
+ * {@code contextRefreshed()} did survive, being called after this one's.
  * <p>
  * The bean must carry at least one {@code Hook} method. HAPI refuses one that does not, logging
  * "Interceptor registered with no valid hooks" and continuing, so an annotated bean without hooks
  * is absent from the request path with nothing but a warning to say so.
  * <p>
  * Beans found here are registered after the interceptors this module owns, but registration order
- * is only HAPI's tie-break. On any one hook it sorts by {@code Interceptor(order = ...)} first, and
- * every interceptor this module owns leaves that at its default of 0 -- so a contributed bean
- * declaring a negative order runs before them on the hooks it shares with them, authentication
- * among those. They are registered on every version-specific servlet, so an interceptor meant for
- * one FHIR version should check the version it is handed.
+ * is only HAPI's tie-break. On any one hook it sorts by {@code Interceptor(order = ...)} first --
+ * or {@code Hook(order = ...)}, which overrides it per method -- and every interceptor this module
+ * owns leaves that at its default of 0, so a contributed bean declaring a negative order runs
+ * before them on the hooks it shares with them, authentication among those.
+ * <p>
+ * They are registered on every version-specific servlet, so an interceptor meant for one FHIR
+ * version has to work out which it is serving. On a hook handed {@code RequestDetails} that is
+ * {@code getFhirContext().getVersion().getVersion()}. On
+ * {@code Pointcut.SERVER_INCOMING_REQUEST_PRE_PROCESSED} -- the earliest, and the one this module's
+ * own authentication interceptor uses -- there is no such handle: it is passed only the request and
+ * the response, so the servlet path is the only discriminator.
  */
 @Target({ ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/org/openmrs/module/fhir2/api/annotations/FhirInterceptor.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/annotations/FhirInterceptor.java
@@ -23,28 +23,20 @@ import org.springframework.beans.factory.annotation.Qualifier;
  * audit, consent. The bean carries HAPI's own {@code Hook} methods; this annotation only says it
  * should be picked up, in the way {@link R4Provider} says so for a resource provider.
  * <p>
- * Registering one from outside used not to last. The servlet unregisters every interceptor when the
- * module context refreshes, and that happens whenever any OpenMRS module starts or stops, so an
- * interceptor added from a Spring bean or from a module's {@code started()} worked until the next
- * module event and then silently stopped. A module that re-registered from its own
- * {@code contextRefreshed()} did survive, being called after this one's.
- * <p>
  * The bean must carry at least one {@code Hook} method. HAPI refuses one that does not, logging
  * "Interceptor registered with no valid hooks" and continuing, so an annotated bean without hooks
  * is absent from the request path with nothing but a warning to say so.
  * <p>
- * Beans found here are registered after the interceptors this module owns, but registration order
- * is only HAPI's tie-break. On any one hook it sorts by {@code Interceptor(order = ...)} first --
- * or {@code Hook(order = ...)}, which overrides it per method -- and every interceptor this module
- * owns leaves that at its default of 0, so a contributed bean declaring a negative order runs
- * before them on the hooks it shares with them, authentication among those.
+ * Registration order is only HAPI's tie-break: on each hook it sorts by
+ * {@code Interceptor(order = ...)}, which {@code Hook(order = ...)} overrides per method when
+ * non-zero. Every interceptor this module owns leaves that at the default 0, so a contributed bean
+ * with a negative order runs ahead of them -- authentication included.
  * <p>
  * They are registered on every version-specific servlet, so an interceptor meant for one FHIR
  * version has to work out which it is serving. On a hook handed {@code RequestDetails} that is
  * {@code getFhirContext().getVersion().getVersion()}. On
- * {@code Pointcut.SERVER_INCOMING_REQUEST_PRE_PROCESSED} -- the earliest, and the one this module's
- * own authentication interceptor uses -- there is no such handle: it is passed only the request and
- * the response, so the servlet path is the only discriminator.
+ * {@code Pointcut.SERVER_INCOMING_REQUEST_PRE_PROCESSED} there is no such handle -- it is passed
+ * only the request and the response -- so the servlet path is the only discriminator.
  */
 @Target({ ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/org/openmrs/module/fhir2/api/annotations/FhirInterceptor.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/annotations/FhirInterceptor.java
@@ -34,7 +34,8 @@ import org.springframework.beans.factory.annotation.Qualifier;
  * Every version-specific servlet registers it, so one meant for a single FHIR version must work out
  * which it is serving: {@code getFhirContext().getVersion().getVersion()} on a hook handed
  * {@code RequestDetails}, and on {@code Pointcut.SERVER_INCOMING_REQUEST_PRE_PROCESSED}, which is
- * passed only the request and the response, the servlet path.
+ * passed only the request and the response,
+ * {@code org.openmrs.module.fhir2.web.util.FhirVersionUtils.getFhirVersion(request)}.
  */
 @Target({ ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/org/openmrs/module/fhir2/api/annotations/FhirInterceptor.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/annotations/FhirInterceptor.java
@@ -20,6 +20,20 @@ import org.springframework.beans.factory.annotation.Qualifier;
 /**
  * Marks a Spring bean as a HAPI interceptor contributed by another module. It is registered on both
  * the R3 and the R4 servlet, and HAPI drops it unless it declares a {@code Hook} method.
+ * <p>
+ * A bean registered through this annotation runs after this module's own interceptors,
+ * authentication included. This module's interceptors hold
+ * {@link org.openmrs.module.fhir2.FhirConstants#BUILT_IN_INTERCEPTOR_ORDER}, and a contributed bean
+ * has to stay at or above {@code Interceptor.DEFAULT_ORDER} to stay behind them: one whose
+ * {@code Interceptor} or {@code Hook} declares a lower order is reported and left unregistered.
+ * Order contributed interceptors against each other with positive values.
+ * <p>
+ * That check covers this annotation only. It is not a guarantee about the servlet as a whole -
+ * other code can register an interceptor on it directly, at any order it likes.
+ * <p>
+ * The bean must be a class HAPI can scan: annotate a concrete class and keep it clear of
+ * interface-based Spring AOP, which hides the hook methods behind a proxy. A bean HAPI finds no
+ * hooks on is reported and does not run.
  */
 @Target({ ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/org/openmrs/module/fhir2/api/annotations/FhirInterceptor.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/annotations/FhirInterceptor.java
@@ -32,10 +32,12 @@ import org.springframework.beans.factory.annotation.Qualifier;
  * "Interceptor registered with no valid hooks" and continuing, so an annotated bean without hooks
  * is absent from the request path with nothing but a warning to say so.
  * <p>
- * Beans found here are registered after the interceptors this module owns, so authentication has
- * already run. Order among contributed interceptors is HAPI's own, from
- * {@code Interceptor(order = ...)}. They are registered on every version-specific servlet, so an
- * interceptor meant for one FHIR version should check the version it is handed.
+ * Beans found here are registered after the interceptors this module owns, but registration order
+ * is only HAPI's tie-break. On any one hook it sorts by {@code Interceptor(order = ...)} first, and
+ * every interceptor this module owns leaves that at its default of 0 -- so a contributed bean
+ * declaring a negative order runs before them on the hooks it shares with them, authentication
+ * among those. They are registered on every version-specific servlet, so an interceptor meant for
+ * one FHIR version should check the version it is handed.
  */
 @Target({ ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/org/openmrs/module/fhir2/api/annotations/FhirInterceptor.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/annotations/FhirInterceptor.java
@@ -23,10 +23,9 @@ import org.springframework.beans.factory.annotation.Qualifier;
  * audit, consent. The bean carries HAPI's own {@code Hook} methods; this annotation only says it
  * should be picked up, in the way {@link R4Provider} says so for a resource provider.
  * <p>
- * Registering one from outside was not previously possible. The servlet unregisters every
- * interceptor when the module context refreshes, and that happens whenever any OpenMRS module
- * starts or stops, so an interceptor added at runtime worked until the next module event and then
- * silently stopped.
+ * Registering one from outside used not to last. The servlet unregisters every interceptor when the
+ * module context refreshes, and that happens whenever any OpenMRS module starts or stops, so an
+ * interceptor added at runtime worked until the next module event and then silently stopped.
  * <p>
  * The bean must carry at least one {@code Hook} method. HAPI refuses one that does not, logging
  * "Interceptor registered with no valid hooks" and continuing, so an annotated bean without hooks

--- a/api/src/main/java/org/openmrs/module/fhir2/api/annotations/FhirInterceptor.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/annotations/FhirInterceptor.java
@@ -18,9 +18,8 @@ import java.lang.annotation.Target;
 import org.springframework.beans.factory.annotation.Qualifier;
 
 /**
- * Marks a Spring bean as a HAPI interceptor the FHIR REST servlets should register, so a module
- * other than this one can add a cross-cutting concern -- authorization, audit, consent. It must
- * declare a {@code Hook} method or HAPI drops it.
+ * Marks a Spring bean as a HAPI interceptor contributed by another module. It is registered on both
+ * the R3 and the R4 servlet, and HAPI drops it unless it declares a {@code Hook} method.
  */
 @Target({ ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/org/openmrs/module/fhir2/api/annotations/FhirInterceptor.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/annotations/FhirInterceptor.java
@@ -1,0 +1,46 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.fhir2.api.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+
+/**
+ * Marks a Spring bean as a HAPI interceptor the FHIR REST servlets should register, so that a
+ * module other than this one can add a cross-cutting concern to the FHIR API -- authorization,
+ * audit, consent. The bean carries HAPI's own {@code Hook} methods; this annotation only says it
+ * should be picked up, in the way {@link R4Provider} says so for a resource provider.
+ * <p>
+ * Registering one from outside was not previously possible. The servlet unregisters every
+ * interceptor when the module context refreshes, and that happens whenever any OpenMRS module
+ * starts or stops, so an interceptor added at runtime worked until the next module event and then
+ * silently stopped.
+ * <p>
+ * The bean must carry at least one {@code Hook} method. HAPI refuses one that does not, logging
+ * "Interceptor registered with no valid hooks" and continuing, so an annotated bean without hooks is
+ * absent from the request path with nothing but a warning to say so.
+ * <p>
+ * Beans found here are registered after the interceptors this module owns, so authentication has
+ * already run. Order among contributed interceptors is HAPI's own, from
+ * {@code Interceptor(order = ...)}. They are registered on every version-specific servlet, so an
+ * interceptor meant for one FHIR version should check the version it is handed.
+ */
+@Target({ ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Qualifier
+public @interface FhirInterceptor {
+	
+}

--- a/api/src/test/java/org/openmrs/module/fhir2/FhirActivatorTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/FhirActivatorTest.java
@@ -1,0 +1,46 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.fhir2;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.Test;
+import org.openmrs.module.fhir2.api.spi.ModuleLifecycleListener;
+
+public class FhirActivatorTest {
+	
+	@Test
+	public void willRefreshContext_shouldNotifyEveryListenerWhenOneThrows() {
+		FhirActivator activator = new FhirActivator();
+		boolean[] reached = new boolean[1];
+		
+		activator.addModuleLifecycleListener(new ModuleLifecycleListener() {
+			
+			@Override
+			public void willRefresh() {
+				throw new IllegalStateException("a contributed bean could not be supplied");
+			}
+		});
+		activator.addModuleLifecycleListener(new ModuleLifecycleListener() {
+			
+			@Override
+			public void willRefresh() {
+				reached[0] = true;
+			}
+		});
+		
+		activator.willRefreshContext();
+		
+		// both FHIR servlets register as listeners, so one failing must not leave the other bound to a
+		// context that has been closed
+		assertThat(reached[0], is(true));
+	}
+}

--- a/api/src/test/java/org/openmrs/module/fhir2/FhirActivatorTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/FhirActivatorTest.java
@@ -10,7 +10,11 @@
 package org.openmrs.module.fhir2;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.Test;
 import org.openmrs.module.fhir2.api.spi.ModuleLifecycleListener;
@@ -27,6 +31,90 @@ public class FhirActivatorTest {
 			@Override
 			public void willRefresh() {
 				throw new IllegalStateException("a contributed bean could not be supplied");
+			}
+		});
+		activator.addModuleLifecycleListener(new ModuleLifecycleListener() {
+			
+			@Override
+			public void willRefresh() {
+				reached[0] = true;
+			}
+		});
+		
+		activator.willRefreshContext();
+		
+		assertThat(reached[0], is(true));
+	}
+	
+	/**
+	 * A servlet drops itself from destroy(), which can land while a notification is part way through
+	 * the list. Self-removal is the deterministic stand-in for that race.
+	 */
+	@Test
+	public void willRefreshContext_shouldNotifyEveryListenerWhenOneRemovesItself() {
+		FhirActivator activator = new FhirActivator();
+		boolean[] reached = new boolean[1];
+		
+		ModuleLifecycleListener selfRemoving = new ModuleLifecycleListener() {
+			
+			@Override
+			public void willRefresh() {
+				activator.removeModuleLifecycleLister(this);
+			}
+		};
+		
+		activator.addModuleLifecycleListener(selfRemoving);
+		activator.addModuleLifecycleListener(new ModuleLifecycleListener() {
+			
+			@Override
+			public void willRefresh() {
+				reached[0] = true;
+			}
+		});
+		
+		activator.willRefreshContext();
+		
+		assertThat(reached[0], is(true));
+	}
+	
+	/**
+	 * Each lifecycle method passes its own method reference, so a listener wired to the wrong event
+	 * would leave a servlet holding a stale context with nothing else to catch it.
+	 */
+	@Test
+	public void stopped_shouldNotifyListenersOfStoppedAndNothingElse() {
+		FhirActivator activator = new FhirActivator();
+		List<String> events = new ArrayList<>();
+		
+		activator.addModuleLifecycleListener(new ModuleLifecycleListener() {
+			
+			@Override
+			public void willStop() {
+				events.add("willStop");
+			}
+			
+			@Override
+			public void stopped() {
+				events.add("stopped");
+			}
+		});
+		
+		activator.stopped();
+		
+		assertThat(events, contains("stopped"));
+	}
+	
+	@Test
+	public void willRefreshContext_shouldNotifyEveryListenerWhenOneThrowsAnError() {
+		FhirActivator activator = new FhirActivator();
+		boolean[] reached = new boolean[1];
+		
+		activator.addModuleLifecycleListener(new ModuleLifecycleListener() {
+			
+			@Override
+			public void willRefresh() {
+				// a module classloader swap surfaces as a LinkageError, not an exception
+				throw new NoClassDefFoundError("org/example/AContributedInterceptor");
 			}
 		});
 		activator.addModuleLifecycleListener(new ModuleLifecycleListener() {

--- a/api/src/test/java/org/openmrs/module/fhir2/FhirActivatorTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/FhirActivatorTest.java
@@ -39,8 +39,6 @@ public class FhirActivatorTest {
 		
 		activator.willRefreshContext();
 		
-		// both FHIR servlets register as listeners, so one failing must not leave the other bound to a
-		// context that has been closed
 		assertThat(reached[0], is(true));
 	}
 }

--- a/omod/src/main/java/org/openmrs/module/fhir2/web/authentication/RequireAuthenticationInterceptor.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/web/authentication/RequireAuthenticationInterceptor.java
@@ -18,8 +18,9 @@ import ca.uhn.fhir.interceptor.api.Hook;
 import ca.uhn.fhir.interceptor.api.Interceptor;
 import ca.uhn.fhir.interceptor.api.Pointcut;
 import org.openmrs.api.context.Context;
+import org.openmrs.module.fhir2.FhirConstants;
 
-@Interceptor
+@Interceptor(order = FhirConstants.BUILT_IN_INTERCEPTOR_ORDER)
 public class RequireAuthenticationInterceptor {
 	
 	@Hook(Pointcut.SERVER_INCOMING_REQUEST_PRE_PROCESSED)

--- a/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
@@ -283,8 +283,6 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 		if (started) {
 			final ConfigurableApplicationContext ctx = getModuleApplicationContext();
 			if (ctx != null) {
-				getInterceptorService().unregisterAllInterceptors();
-				
 				unregisterAllProviders();
 				
 				// load the resource providers from the Spring context
@@ -302,10 +300,16 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 				
 				administrationService.addGlobalPropertyListener(fhirRestServletListener);
 				
-				// last, because a contributed bean whose creation was deferred past the context refresh can
-				// throw here, and everything above has to have happened by then or the servlet is left
-				// bound to the context just closed. The provider lookup above runs other modules' code too,
-				// but moving that is FM2-163's business, not this change's.
+				// Unregister and re-register together, and last. Together because the servlet keeps serving
+				// throughout a refresh, and RequireAuthenticationInterceptor is the only thing that rejects
+				// an unauthenticated FHIR request -- AuthenticationFilter deliberately never stops the
+				// chain -- so any work between the two leaves a window where requests are answered with no
+				// authentication at all. Last because this is where another module's code runs: a
+				// contributed bean whose creation was deferred past the context refresh can throw, and
+				// everything above has to have happened by then or the servlet is left bound to the
+				// context just closed. During the provider lookup above, the previous refresh's
+				// interceptors are still in place.
+				getInterceptorService().unregisterAllInterceptors();
 				registerInterceptors();
 			}
 		}

--- a/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
@@ -17,15 +17,20 @@ import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.interceptor.api.Hook;
+import ca.uhn.fhir.interceptor.api.Interceptor;
 import ca.uhn.fhir.rest.api.EncodingEnum;
 import ca.uhn.fhir.rest.server.BasePagingProvider;
 import ca.uhn.fhir.rest.server.FifoMemoryPagingProvider;
@@ -33,8 +38,11 @@ import ca.uhn.fhir.rest.server.IResourceProvider;
 import ca.uhn.fhir.rest.server.IServerAddressStrategy;
 import ca.uhn.fhir.rest.server.RestfulServer;
 import ca.uhn.fhir.rest.server.interceptor.LoggingInterceptor;
+import ca.uhn.fhir.util.ReflectionUtil;
 import lombok.AccessLevel;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.MethodUtils;
 import org.openmrs.GlobalProperty;
 import org.openmrs.api.AdministrationService;
 import org.openmrs.api.GlobalPropertyListener;
@@ -60,6 +68,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.MessageSource;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class FhirRestServlet extends RestfulServer implements ModuleLifecycleListener {
 	
@@ -78,6 +87,13 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 	private LoggingInterceptor loggingInterceptor;
 	
 	private boolean started = false;
+	
+	/**
+	 * What the last {@link #registerInterceptors()} put on the server, so the next one can take it back
+	 * off. Narrower than unregistering everything: an interceptor some other code registered directly
+	 * on this servlet is not ours to drop.
+	 */
+	private final List<Object> registeredInterceptors = new ArrayList<>();
 	
 	@Setter(value = AccessLevel.PUBLIC, onMethod_ = { @Qualifier("messageSourceService"), @Autowired })
 	private MessageSource messageSource;
@@ -168,18 +184,126 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 	}
 	//@formatter:on
 	
-	protected void registerInterceptors() {
-		// keep first: the re-registration in refreshed() serves requests before it finishes
-		registerInterceptor(new RequireAuthenticationInterceptor());
-		registerInterceptor(loggingInterceptor);
-		registerInterceptor(new DisableCacheInterceptor());
-		registerInterceptor(new SummaryInterceptor());
-		registerInterceptor(new SupportMergePatchInterceptor());
+	/**
+	 * Builds the servlet's interceptor set: the module's own interceptors, then any bean another module
+	 * contributes with {@link FhirInterceptor}. Safe to call on a servlet that is already serving,
+	 * which is what {@link #refreshed()} does - the new set is registered before the previous one is
+	 * dropped, so a concurrent request never finds the servlet without
+	 * {@link RequireAuthenticationInterceptor}.
+	 * <p>
+	 * Synchronized because it reads and rewrites {@code registeredInterceptors} around calls that
+	 * mutate HAPI's registry: {@link #initialize()} runs on the container's init thread and
+	 * {@link #refreshed()} on whichever thread drove the context refresh.
+	 */
+	protected synchronized void registerInterceptors() {
+		List<Object> previous = new ArrayList<>(registeredInterceptors);
+		List<Object> current = new ArrayList<>();
 		
-		ConfigurableApplicationContext ctx = getModuleApplicationContext();
-		if (ctx != null) {
-			ctx.getBeansWithAnnotation(FhirInterceptor.class).values().forEach(this::registerInterceptor);
+		try {
+			// these carry FhirConstants.BUILT_IN_INTERCEPTOR_ORDER, so they dispatch ahead of a contributed
+			// bean whatever order the two happen to be registered in - which is only enforced for beans
+			// this method registers, not for interceptors put on the servlet by other means
+			for (Object interceptor : Arrays.asList(new RequireAuthenticationInterceptor(), loggingInterceptor,
+			    new DisableCacheInterceptor(), new SummaryInterceptor(), new SupportMergePatchInterceptor())) {
+				registerInterceptor(interceptor);
+				current.add(interceptor);
+			}
+			
+			// drop the previous set only now that its replacement is in place, and only the entries the new
+			// set did not carry over by identity - unregistering one HAPI has kept would leave a hole
+			Set<Object> retained = Collections.newSetFromMap(new IdentityHashMap<>());
+			retained.addAll(current);
+			previous.stream().filter(interceptor -> !retained.contains(interceptor))
+			        .forEach(getInterceptorService()::unregisterInterceptor);
+			
+			registerContributedInterceptors(current);
 		}
+		finally {
+			// in the finally so that a throw cannot leave the field naming interceptors that are no longer
+			// on the server: the next call would skip unregistering the ones that are, orphaning them
+			registeredInterceptors.clear();
+			registeredInterceptors.addAll(current);
+		}
+	}
+	
+	/**
+	 * Registers each {@link FhirInterceptor} bean, adding the ones HAPI accepts to {@code current}.
+	 * Contributed beans are third-party code, so one that cannot be built or scanned is reported and
+	 * skipped rather than allowed to abandon the rebuild half-done.
+	 */
+	private void registerContributedInterceptors(List<Object> current) {
+		ConfigurableApplicationContext ctx = getModuleApplicationContext();
+		if (ctx == null) {
+			return;
+		}
+		
+		Map<String, Object> contributed;
+		try {
+			contributed = ctx.getBeansWithAnnotation(FhirInterceptor.class);
+		}
+		catch (Exception e) {
+			log.error("Could not read the contributed FHIR interceptors from the Spring context; none of them will run", e);
+			return;
+		}
+		
+		for (Map.Entry<String, Object> entry : contributed.entrySet()) {
+			String beanName = entry.getKey();
+			Object interceptor = entry.getValue();
+			
+			try {
+				String orderViolation = describeOrderViolation(interceptor);
+				
+				if (orderViolation != null) {
+					log.error(
+					    "Not registering contributed FHIR interceptor bean {} ({}): {}, which would run it ahead of this "
+					            + "module's own interceptors, including authentication. Contributed interceptors must "
+					            + "order at or above {}.",
+					    beanName, interceptor.getClass().getName(), orderViolation, Interceptor.DEFAULT_ORDER);
+				} else if (getInterceptorService().registerInterceptor(interceptor)) {
+					current.add(interceptor);
+					log.info("Registered contributed FHIR interceptor bean {} ({})", beanName,
+					    interceptor.getClass().getName());
+				} else {
+					log.error(
+					    "Contributed FHIR interceptor bean {} ({}) declares no @Hook method HAPI can see and will not "
+					            + "run. A bean behind an interface-based Spring proxy hides its hooks; annotate a concrete "
+					            + "class and keep it clear of interface-based AOP.",
+					    beanName, interceptor.getClass().getName());
+				}
+			}
+			catch (Exception e) {
+				log.error("Could not register contributed FHIR interceptor bean {} ({}); it will not run", beanName,
+				    interceptor.getClass().getName(), e);
+			}
+		}
+	}
+	
+	/**
+	 * Where a contributed interceptor declares an order that would sort it ahead of this module's own,
+	 * phrased for a log message, or null if it declares none. HAPI orders the hooks for a pointcut by
+	 * the {@code order} on {@link Interceptor} or {@link Hook}, and this module's interceptors hold
+	 * {@link FhirConstants#BUILT_IN_INTERCEPTOR_ORDER}, so a contributed interceptor only has to stay
+	 * at or above {@link Interceptor#DEFAULT_ORDER} to run after them. Screening the beans this servlet
+	 * registers is all this does; it says nothing about interceptors registered elsewhere.
+	 */
+	private static String describeOrderViolation(Object interceptor) {
+		// mirrors BaseInterceptorService#scanInterceptorForHookMethods, concrete class included, so that
+		// this sees the same orders HAPI will
+		Class<?> type = interceptor.getClass();
+		
+		Interceptor typeAnnotation = type.getAnnotation(Interceptor.class);
+		if (typeAnnotation != null && typeAnnotation.order() < Interceptor.DEFAULT_ORDER) {
+			return "the class declares @Interceptor(order = " + typeAnnotation.order() + ")";
+		}
+		
+		for (Method method : ReflectionUtil.getDeclaredMethods(type, true)) {
+			Hook hook = MethodUtils.getAnnotation(method, Hook.class, true, true);
+			if (hook != null && hook.order() < Interceptor.DEFAULT_ORDER) {
+				return method.getName() + "() declares @Hook(order = " + hook.order() + ")";
+			}
+		}
+		
+		return null;
 	}
 	
 	protected ConfigurableApplicationContext getModuleApplicationContext() {
@@ -278,8 +402,8 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 				
 				administrationService.addGlobalPropertyListener(fhirRestServletListener);
 				
-				// keep adjacent to the re-registration: the gap serves requests unauthenticated
-				getInterceptorService().unregisterAllInterceptors();
+				// last, so that a throw from any of the lookups above leaves the interceptors from the
+				// previous context in place rather than none at all
 				registerInterceptors();
 			}
 		}

--- a/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
@@ -265,7 +265,9 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 				// load the resource providers from the Spring context
 				Set<String> validBeanNames = Arrays.stream(ctx.getBeanNamesForAnnotation(getResourceProviderAnnotation()))
 				        .collect(Collectors.toSet());
-				setResourceProviders(ctx.getBeansOfType(IResourceProvider.class).entrySet().stream()
+				// registerProviders, not setResourceProviders: the setter only repopulates the field, and
+				// unregisterAllProviders has already destroyed the method bindings a read routes on
+				registerProviders(ctx.getBeansOfType(IResourceProvider.class).entrySet().stream()
 				        .filter(entry -> validBeanNames.contains(entry.getKey())).map(Map.Entry::getValue)
 				        .collect(Collectors.toList()));
 				

--- a/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
@@ -175,9 +175,10 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 	 * this way; interceptors were not, and could not be added from outside at all, because
 	 * {@link #refreshed()} unregisters every interceptor and runs whenever any module starts or stops.
 	 * <p>
-	 * A contributed bean that cannot be supplied is left to fail rather than skipped. Skipping would
-	 * leave the FHIR API answering requests with an authorization or audit interceptor quietly missing,
-	 * which is worse than a startup failure naming the bean.
+	 * A contributed bean that cannot be supplied is left to fail rather than skipped: swallowing it
+	 * would leave the FHIR API answering requests with an authorization or audit interceptor quietly
+	 * missing. What OpenMRS then does with the failure differs by path, so this does not promise a
+	 * particular outcome -- on the refresh path the module loader catches it and logs a warning.
 	 */
 	protected void registerInterceptors() {
 		registerInterceptor(loggingInterceptor);

--- a/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
@@ -169,18 +169,14 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 	//@formatter:on
 	
 	/**
-	 * Registers the interceptors this server runs with: the ones this module owns, then any bean in the
-	 * application context annotated {@link FhirInterceptor}, which is how a module other than this one
-	 * contributes a cross-cutting concern.
+	 * Registers this module's own interceptors, then every bean annotated {@link FhirInterceptor} --
+	 * how a module other than this one contributes a cross-cutting concern.
 	 * <p>
-	 * A contributed bean that cannot be supplied is deliberately not caught. Worth knowing before
-	 * relying on that: from {@link #initialize()} at server startup the exception aborts the whole
-	 * OpenMRS boot, not just this module.
+	 * A contributed bean that cannot be supplied is deliberately not caught, and from
+	 * {@link #initialize()} at server startup that aborts the whole OpenMRS boot, not just this module.
 	 */
 	protected void registerInterceptors() {
-		// first, so the window in refreshed() between tearing the registry down and building it back up
-		// is as short as it can be made: everything after this line is registered with authentication
-		// already in place
+		// first, so refreshed() rebuilds the registry with authentication in place before anything else
 		registerInterceptor(new RequireAuthenticationInterceptor());
 		registerInterceptor(loggingInterceptor);
 		registerInterceptor(new DisableCacheInterceptor());
@@ -194,11 +190,9 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 	}
 	
 	/**
-	 * The context {@link #registerInterceptors()} and {@link #refreshed()} read from. Separated so a
-	 * test can supply one without writing the activator's static field, which is shared by every test
-	 * in the module and cannot be put back: {@code FhirActivator.setApplicationContext} assigns only
-	 * when handed a {@link ConfigurableApplicationContext}, so passing null leaves the previous value
-	 * in place.
+	 * The context {@link #registerInterceptors()} and {@link #refreshed()} read from. A test overrides
+	 * this rather than writing {@code FhirActivator}'s static, which it cannot put back afterwards --
+	 * {@code setApplicationContext} assigns only when handed a {@link ConfigurableApplicationContext}.
 	 */
 	protected ConfigurableApplicationContext getModuleApplicationContext() {
 		return FhirActivator.getApplicationContext();
@@ -295,11 +289,9 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 				
 				administrationService.addGlobalPropertyListener(fhirRestServletListener);
 				
-				// Keep these two adjacent: the servlet goes on serving through a refresh, and a request
-				// arriving between them is answered with no interceptors, RequireAuthenticationInterceptor
-				// among them. And keep them last: a contributed bean whose creation was deferred past the
-				// context refresh is constructed here and can throw, so it must not leave the re-wiring
-				// above half done.
+				// Adjacent: a request arriving between them is answered with no interceptors at all,
+				// RequireAuthenticationInterceptor included. Last: a contributed bean deferred past the
+				// context refresh is built here and can throw, which must not pre-empt the re-wiring above.
 				getInterceptorService().unregisterAllInterceptors();
 				registerInterceptors();
 			}

--- a/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
@@ -173,15 +173,22 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 	 * application context annotated {@link FhirInterceptor}, which is how a module other than this one
 	 * contributes a cross-cutting concern.
 	 * <p>
-	 * A contributed bean that cannot be supplied is deliberately not caught, and where that lands
-	 * differs by path: from {@link #initialize()} the servlet is never registered and the FHIR API is
-	 * unavailable until the module is restarted, reported as a module startup error; from
-	 * {@link #refreshed()} OpenMRS logs it at WARN and both servlets keep serving without the
-	 * contributed interceptors, skipping any listener the activator had still to call.
+	 * A contributed bean that cannot be supplied is deliberately not caught, and the blast radius is
+	 * very different on the two paths. From {@link #initialize()} at server startup the
+	 * {@code ModuleException} escapes {@code Listener.performWebStartOfModules}, whose tail loop is
+	 * unguarded, and aborts the whole OpenMRS boot -- not just this module. From {@link #refreshed()}
+	 * OpenMRS logs it at WARN and carries on: the servlet that threw keeps serving with the built-ins
+	 * and no contributed interceptors, while every listener after it is skipped, so the other servlet
+	 * is left un-refreshed and still holding the previous context's providers and interceptors. Only a
+	 * bean whose creation is deferred past the context refresh -- lazy, prototype or scoped -- reaches
+	 * either path; a plain singleton fails the refresh itself, first.
 	 */
 	protected void registerInterceptors() {
-		registerInterceptor(loggingInterceptor);
+		// first, so the window in refreshed() between tearing the registry down and building it back up
+		// is as short as it can be made: everything after this line is registered with authentication
+		// already in place
 		registerInterceptor(new RequireAuthenticationInterceptor());
+		registerInterceptor(loggingInterceptor);
 		registerInterceptor(new DisableCacheInterceptor());
 		registerInterceptor(new SummaryInterceptor());
 		registerInterceptor(new SupportMergePatchInterceptor());
@@ -294,15 +301,18 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 				
 				administrationService.addGlobalPropertyListener(fhirRestServletListener);
 				
-				// Unregister and re-register together, and last. Together because the servlet keeps serving
-				// throughout a refresh, and RequireAuthenticationInterceptor is the only thing that rejects
-				// an unauthenticated FHIR request -- AuthenticationFilter deliberately never stops the
-				// chain -- so any work between the two leaves a window where requests are answered with no
-				// authentication at all. Last because this is where another module's code runs: a
-				// contributed bean whose creation was deferred past the context refresh can throw, and
-				// everything above has to have happened by then or the servlet is left bound to the
-				// context just closed. During the provider lookup above, the previous refresh's
-				// interceptors are still in place.
+				// Unregister and re-register adjacently, and last. Adjacently because the servlet goes on
+				// serving requests throughout a refresh, and a request carrying no credentials at all
+				// passes straight through AuthenticationFilter -- which only rejects one whose Basic
+				// credentials fail -- leaving RequireAuthenticationInterceptor as the thing that rejects
+				// it. Work between the teardown and the rebuild is therefore served with no authentication
+				// at all. Adjacency narrows that window to these two statements rather than closing it;
+				// what it removes is the provider rebuild and two uncached global-property reads. Last
+				// because this is where another module's code runs: a contributed bean whose creation was
+				// deferred past the context refresh can throw, and everything above has to have happened
+				// by then or the servlet is left bound to the context just closed. Through the provider
+				// rebuild above, the interceptors from the previous initialize() or refreshed() are still
+				// in place.
 				getInterceptorService().unregisterAllInterceptors();
 				registerInterceptors();
 			}

--- a/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
@@ -168,12 +168,8 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 	}
 	//@formatter:on
 	
-	/**
-	 * Registers this module's interceptors, then every bean annotated {@link FhirInterceptor}. One that
-	 * cannot be supplied is not caught, and from {@link #initialize()} aborts OpenMRS startup.
-	 */
 	protected void registerInterceptors() {
-		// keep first: the rebuild in refreshed() serves requests before it finishes
+		// keep first: the re-registration in refreshed() serves requests before it finishes
 		registerInterceptor(new RequireAuthenticationInterceptor());
 		registerInterceptor(loggingInterceptor);
 		registerInterceptor(new DisableCacheInterceptor());
@@ -186,10 +182,6 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 		}
 	}
 	
-	/**
-	 * The context {@link #registerInterceptors()} and {@link #refreshed()} read from. Override this in
-	 * a test rather than writing {@code FhirActivator}'s static, which cannot be put back.
-	 */
 	protected ConfigurableApplicationContext getModuleApplicationContext() {
 		return FhirActivator.getApplicationContext();
 	}
@@ -285,9 +277,8 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 				
 				administrationService.addGlobalPropertyListener(fhirRestServletListener);
 				
-				// keep adjacent to the rebuild: the gap serves requests unauthenticated
+				// keep adjacent to the re-registration: the gap serves requests unauthenticated
 				getInterceptorService().unregisterAllInterceptors();
-				// keep last: a contributed bean can throw here
 				registerInterceptors();
 			}
 		}

--- a/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
@@ -172,7 +172,7 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 	 * Registers the interceptors this server runs with: the ones this module owns, then any bean in the
 	 * application context annotated {@link FhirInterceptor}, which is how a module other than this one
 	 * contributes a cross-cutting concern. Resource providers are already collected from the context
-	 * this way; interceptors were not, and could not be added from outside at all, because
+	 * this way; interceptors were not, and one added from outside did not last, because
 	 * {@link #refreshed()} unregisters every interceptor and runs whenever any module starts or stops.
 	 * <p>
 	 * A contributed bean that cannot be supplied is left to fail rather than skipped: swallowing it

--- a/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
@@ -173,15 +173,9 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 	 * application context annotated {@link FhirInterceptor}, which is how a module other than this one
 	 * contributes a cross-cutting concern.
 	 * <p>
-	 * A contributed bean that cannot be supplied is deliberately not caught, and the blast radius is
-	 * very different on the two paths. From {@link #initialize()} at server startup the
-	 * {@code ModuleException} escapes {@code Listener.performWebStartOfModules}, whose tail loop is
-	 * unguarded, and aborts the whole OpenMRS boot -- not just this module. From {@link #refreshed()}
-	 * OpenMRS logs it at WARN and carries on: the servlet that threw keeps serving with the built-ins
-	 * and no contributed interceptors, while every listener after it is skipped, so the other servlet
-	 * is left un-refreshed and still holding the previous context's providers and interceptors. Only a
-	 * bean whose creation is deferred past the context refresh -- lazy, prototype or scoped -- reaches
-	 * either path; a plain singleton fails the refresh itself, first.
+	 * A contributed bean that cannot be supplied is deliberately not caught. Worth knowing before
+	 * relying on that: from {@link #initialize()} at server startup the exception aborts the whole
+	 * OpenMRS boot, not just this module.
 	 */
 	protected void registerInterceptors() {
 		// first, so the window in refreshed() between tearing the registry down and building it back up
@@ -301,18 +295,10 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 				
 				administrationService.addGlobalPropertyListener(fhirRestServletListener);
 				
-				// Unregister and re-register adjacently, and last. Adjacently because the servlet goes on
-				// serving requests throughout a refresh, and a request carrying no credentials at all
-				// passes straight through AuthenticationFilter -- which only rejects one whose Basic
-				// credentials fail -- leaving RequireAuthenticationInterceptor as the thing that rejects
-				// it. Work between the teardown and the rebuild is therefore served with no authentication
-				// at all. Adjacency narrows that window to these two statements rather than closing it;
-				// what it removes is the provider rebuild and two uncached global-property reads. Last
-				// because this is where another module's code runs: a contributed bean whose creation was
-				// deferred past the context refresh can throw, and everything above has to have happened
-				// by then or the servlet is left bound to the context just closed. Through the provider
-				// rebuild above, the interceptors from the previous initialize() or refreshed() are still
-				// in place.
+				// Keep these two adjacent: the servlet goes on serving through a refresh, and a request
+				// arriving between them is answered with no interceptors, RequireAuthenticationInterceptor
+				// among them. And keep them last: this is where another module's code runs, so a throw
+				// here must not leave the re-wiring above half done.
 				getInterceptorService().unregisterAllInterceptors();
 				registerInterceptors();
 			}

--- a/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
@@ -171,19 +171,13 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 	/**
 	 * Registers the interceptors this server runs with: the ones this module owns, then any bean in the
 	 * application context annotated {@link FhirInterceptor}, which is how a module other than this one
-	 * contributes a cross-cutting concern. Resource providers are already collected from the context
-	 * this way; interceptors were not, and one added from outside did not last, because
-	 * {@link #refreshed()} unregisters every interceptor and runs whenever any module starts or stops.
+	 * contributes a cross-cutting concern.
 	 * <p>
-	 * A contributed bean that cannot be supplied is left to fail rather than skipped: swallowing it
-	 * would leave the FHIR API answering requests with an authorization or audit interceptor quietly
-	 * missing. Where that failure lands differs by path, and in opposite directions. From
-	 * {@link #initialize()} the servlet is never registered and the FHIR API is unavailable for the
-	 * life of the JVM, reported as a module startup error. From {@link #refreshed()} OpenMRS logs
-	 * "Unable to invoke method on the module's activator" at WARN and both servlets keep serving --
-	 * without the contributed interceptors, and without any later listener the activator had still to
-	 * call. Either way a bean that is a plain singleton fails the context refresh itself, before this
-	 * runs at all.
+	 * A contributed bean that cannot be supplied is deliberately not caught, and where that lands
+	 * differs by path: from {@link #initialize()} the servlet is never registered and the FHIR API is
+	 * unavailable until the module is restarted, reported as a module startup error; from
+	 * {@link #refreshed()} OpenMRS logs it at WARN and both servlets keep serving without the
+	 * contributed interceptors, skipping any listener the activator had still to call.
 	 */
 	protected void registerInterceptors() {
 		registerInterceptor(loggingInterceptor);

--- a/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
@@ -177,8 +177,13 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 	 * <p>
 	 * A contributed bean that cannot be supplied is left to fail rather than skipped: swallowing it
 	 * would leave the FHIR API answering requests with an authorization or audit interceptor quietly
-	 * missing. What OpenMRS then does with the failure differs by path, so this does not promise a
-	 * particular outcome -- on the refresh path the module loader catches it and logs a warning.
+	 * missing. Where that failure lands differs by path, and in opposite directions. From
+	 * {@link #initialize()} the servlet is never registered and the FHIR API is unavailable for the
+	 * life of the JVM, reported as a module startup error. From {@link #refreshed()} OpenMRS logs
+	 * "Unable to invoke method on the module's activator" at WARN and both servlets keep serving --
+	 * without the contributed interceptors, and without any later listener the activator had still to
+	 * call. Either way a bean that is a plain singleton fails the context refresh itself, before this
+	 * runs at all.
 	 */
 	protected void registerInterceptors() {
 		registerInterceptor(loggingInterceptor);
@@ -199,9 +204,6 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 	 * in the module and cannot be put back: {@code FhirActivator.setApplicationContext} assigns only
 	 * when handed a {@link ConfigurableApplicationContext}, so passing null leaves the previous value
 	 * in place.
-	 * <p>
-	 * {@link #autoInject()} still reads the static directly. It runs before the servlet is started and
-	 * is not on the refresh path, so overriding this does not redirect it.
 	 */
 	protected ConfigurableApplicationContext getModuleApplicationContext() {
 		return FhirActivator.getApplicationContext();
@@ -261,7 +263,7 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 	}
 	
 	protected void autoInject() {
-		final ConfigurableApplicationContext ctx = FhirActivator.getApplicationContext();
+		final ConfigurableApplicationContext ctx = getModuleApplicationContext();
 		if (ctx != null) {
 			AutowiredAnnotationBeanPostProcessor bpp = new AutowiredAnnotationBeanPostProcessor();
 			bpp.setBeanFactory(ctx.getAutowireCapableBeanFactory());
@@ -293,14 +295,18 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 				        .collect(Collectors.toList()));
 				
 				setLoggingInterceptor(ctx.getBean("hapiLoggingInterceptor", LoggingInterceptor.class));
-				registerInterceptors();
-				
 				setAdministrationService(ctx.getBean("adminService", AdministrationService.class));
 				setGlobalPropertyService(ctx.getBean(FhirGlobalPropertyService.class));
 				setServerAddressStrategy(ctx.getBean(IServerAddressStrategy.class));
 				setPagingProvider(createPagingProvider());
 				
 				administrationService.addGlobalPropertyListener(fhirRestServletListener);
+				
+				// last, because a contributed bean whose creation was deferred past the context refresh can
+				// throw here, and everything above has to have happened by then or the servlet is left
+				// bound to the context just closed. The provider lookup above runs other modules' code too,
+				// but moving that is FM2-163's business, not this change's.
+				registerInterceptors();
 			}
 		}
 	}

--- a/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
@@ -193,11 +193,14 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 	}
 	
 	/**
-	 * The application context this servlet reads its collaborators from -- contributed interceptors,
-	 * and everything {@link #refreshed()} re-resolves after the context is rebuilt. Separated so a test
-	 * can supply one without writing to the activator's static field, which is shared by every test in
-	 * the module and cannot be cleared: {@code setApplicationContext} assigns only when handed a
-	 * {@link ConfigurableApplicationContext}, so passing null leaves the previous value in place.
+	 * The context {@link #registerInterceptors()} and {@link #refreshed()} read from. Separated so a
+	 * test can supply one without writing the activator's static field, which is shared by every test
+	 * in the module and cannot be put back: {@code FhirActivator.setApplicationContext} assigns only
+	 * when handed a {@link ConfigurableApplicationContext}, so passing null leaves the previous value
+	 * in place.
+	 * <p>
+	 * {@link #autoInject()} still reads the static directly. It runs before the servlet is started and
+	 * is not on the refresh path, so overriding this does not redirect it.
 	 */
 	protected ConfigurableApplicationContext getModuleApplicationContext() {
 		return FhirActivator.getApplicationContext();

--- a/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
@@ -297,8 +297,9 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 				
 				// Keep these two adjacent: the servlet goes on serving through a refresh, and a request
 				// arriving between them is answered with no interceptors, RequireAuthenticationInterceptor
-				// among them. And keep them last: this is where another module's code runs, so a throw
-				// here must not leave the re-wiring above half done.
+				// among them. And keep them last: a contributed bean whose creation was deferred past the
+				// context refresh is constructed here and can throw, so it must not leave the re-wiring
+				// above half done.
 				getInterceptorService().unregisterAllInterceptors();
 				registerInterceptors();
 			}

--- a/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
@@ -169,14 +169,11 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 	//@formatter:on
 	
 	/**
-	 * Registers this module's own interceptors, then every bean annotated {@link FhirInterceptor} --
-	 * how a module other than this one contributes a cross-cutting concern.
-	 * <p>
-	 * A contributed bean that cannot be supplied is deliberately not caught, and from
-	 * {@link #initialize()} at server startup that aborts the whole OpenMRS boot, not just this module.
+	 * Registers this module's interceptors, then every bean annotated {@link FhirInterceptor}. One that
+	 * cannot be supplied is not caught, and from {@link #initialize()} aborts OpenMRS startup.
 	 */
 	protected void registerInterceptors() {
-		// first, so refreshed() rebuilds the registry with authentication in place before anything else
+		// keep first: the rebuild in refreshed() serves requests before it finishes
 		registerInterceptor(new RequireAuthenticationInterceptor());
 		registerInterceptor(loggingInterceptor);
 		registerInterceptor(new DisableCacheInterceptor());
@@ -190,9 +187,8 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 	}
 	
 	/**
-	 * The context {@link #registerInterceptors()} and {@link #refreshed()} read from. A test overrides
-	 * this rather than writing {@code FhirActivator}'s static, which it cannot put back afterwards --
-	 * {@code setApplicationContext} assigns only when handed a {@link ConfigurableApplicationContext}.
+	 * The context {@link #registerInterceptors()} and {@link #refreshed()} read from. Override this in
+	 * a test rather than writing {@code FhirActivator}'s static, which cannot be put back.
 	 */
 	protected ConfigurableApplicationContext getModuleApplicationContext() {
 		return FhirActivator.getApplicationContext();
@@ -289,10 +285,9 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 				
 				administrationService.addGlobalPropertyListener(fhirRestServletListener);
 				
-				// Adjacent: a request arriving between them is answered with no interceptors at all,
-				// RequireAuthenticationInterceptor included. Last: a contributed bean deferred past the
-				// context refresh is built here and can throw, which must not pre-empt the re-wiring above.
+				// keep adjacent to the rebuild: the gap serves requests unauthenticated
 				getInterceptorService().unregisterAllInterceptors();
+				// keep last: a contributed bean can throw here
 				registerInterceptors();
 			}
 		}

--- a/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
@@ -43,6 +43,7 @@ import org.openmrs.module.ModuleFactory;
 import org.openmrs.module.fhir2.FhirActivator;
 import org.openmrs.module.fhir2.FhirConstants;
 import org.openmrs.module.fhir2.api.FhirGlobalPropertyService;
+import org.openmrs.module.fhir2.api.annotations.FhirInterceptor;
 import org.openmrs.module.fhir2.api.annotations.R4Provider;
 import org.openmrs.module.fhir2.api.spi.ModuleLifecycleListener;
 import org.openmrs.module.fhir2.narrative.OpenmrsThymeleafNarrativeGenerator;
@@ -146,11 +147,7 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 		setPagingProvider(createPagingProvider());
 		setDefaultResponseEncoding(EncodingEnum.JSON);
 
-		registerInterceptor(loggingInterceptor);
-		registerInterceptor(new RequireAuthenticationInterceptor());
-		registerInterceptor(new DisableCacheInterceptor());
-		registerInterceptor(new SummaryInterceptor());
-		registerInterceptor(new SupportMergePatchInterceptor());
+		registerInterceptors();
 
 		String narrativesOverridePropertyFile = NarrativeUtils.getValidatedPropertiesFilePath(
 				globalPropertyService.getGlobalProperty(FhirConstants.NARRATIVES_OVERRIDE_PROPERTY_FILE, null));
@@ -170,6 +167,38 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 		started = true;
 	}
 	//@formatter:on
+	
+	/**
+	 * Registers the interceptors this server runs with: the ones this module owns, then any bean in the
+	 * application context annotated {@link FhirInterceptor}, which is how a module other than this one
+	 * contributes a cross-cutting concern. Resource providers are already collected from the context
+	 * this way; interceptors were not, and could not be added from outside at all, because
+	 * {@link #refreshed()} unregisters every interceptor and runs whenever any module starts or stops.
+	 * <p>
+	 * A contributed bean that cannot be supplied is left to fail rather than skipped. Skipping would
+	 * leave the FHIR API answering requests with an authorization or audit interceptor quietly missing,
+	 * which is worse than a startup failure naming the bean.
+	 */
+	protected void registerInterceptors() {
+		registerInterceptor(loggingInterceptor);
+		registerInterceptor(new RequireAuthenticationInterceptor());
+		registerInterceptor(new DisableCacheInterceptor());
+		registerInterceptor(new SummaryInterceptor());
+		registerInterceptor(new SupportMergePatchInterceptor());
+		
+		ConfigurableApplicationContext ctx = getModuleApplicationContext();
+		if (ctx != null) {
+			ctx.getBeansWithAnnotation(FhirInterceptor.class).values().forEach(this::registerInterceptor);
+		}
+	}
+	
+	/**
+	 * The context contributed interceptors are read from. Separated so a test can supply one without
+	 * writing to the activator's static field, which every other test in the module would then read.
+	 */
+	protected ConfigurableApplicationContext getModuleApplicationContext() {
+		return FhirActivator.getApplicationContext();
+	}
 	
 	protected Class<? extends Annotation> getResourceProviderAnnotation() {
 		return R4Provider.class;
@@ -256,11 +285,8 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 				        .filter(entry -> validBeanNames.contains(entry.getKey())).map(Map.Entry::getValue)
 				        .collect(Collectors.toList()));
 				
-				registerInterceptor(ctx.getBean("hapiLoggingInterceptor", LoggingInterceptor.class));
-				registerInterceptor(new RequireAuthenticationInterceptor());
-				registerInterceptor(new DisableCacheInterceptor());
-				registerInterceptor(new SummaryInterceptor());
-				registerInterceptor(new SupportMergePatchInterceptor());
+				setLoggingInterceptor(ctx.getBean("hapiLoggingInterceptor", LoggingInterceptor.class));
+				registerInterceptors();
 				
 				setAdministrationService(ctx.getBean("adminService", AdministrationService.class));
 				setGlobalPropertyService(ctx.getBean(FhirGlobalPropertyService.class));

--- a/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
@@ -265,8 +265,7 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 				// load the resource providers from the Spring context
 				Set<String> validBeanNames = Arrays.stream(ctx.getBeanNamesForAnnotation(getResourceProviderAnnotation()))
 				        .collect(Collectors.toSet());
-				// registerProviders, not setResourceProviders: the setter only repopulates the field, and
-				// unregisterAllProviders has already destroyed the method bindings a read routes on
+				// registerProviders, not setResourceProviders: the setter leaves no method bindings
 				registerProviders(ctx.getBeansOfType(IResourceProvider.class).entrySet().stream()
 				        .filter(entry -> validBeanNames.contains(entry.getKey())).map(Map.Entry::getValue)
 				        .collect(Collectors.toList()));

--- a/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/web/servlet/FhirRestServlet.java
@@ -193,8 +193,11 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 	}
 	
 	/**
-	 * The context contributed interceptors are read from. Separated so a test can supply one without
-	 * writing to the activator's static field, which every other test in the module would then read.
+	 * The application context this servlet reads its collaborators from -- contributed interceptors,
+	 * and everything {@link #refreshed()} re-resolves after the context is rebuilt. Separated so a test
+	 * can supply one without writing to the activator's static field, which is shared by every test in
+	 * the module and cannot be cleared: {@code setApplicationContext} assigns only when handed a
+	 * {@link ConfigurableApplicationContext}, so passing null leaves the previous value in place.
 	 */
 	protected ConfigurableApplicationContext getModuleApplicationContext() {
 		return FhirActivator.getApplicationContext();
@@ -272,7 +275,7 @@ public class FhirRestServlet extends RestfulServer implements ModuleLifecycleLis
 	@Override
 	public void refreshed() {
 		if (started) {
-			final ConfigurableApplicationContext ctx = FhirActivator.getApplicationContext();
+			final ConfigurableApplicationContext ctx = getModuleApplicationContext();
 			if (ctx != null) {
 				getInterceptorService().unregisterAllInterceptors();
 				

--- a/omod/src/main/java/org/openmrs/module/fhir2/web/util/DisableCacheInterceptor.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/web/util/DisableCacheInterceptor.java
@@ -15,8 +15,9 @@ import ca.uhn.fhir.interceptor.api.Pointcut;
 import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.RestOperationTypeEnum;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
+import org.openmrs.module.fhir2.FhirConstants;
 
-@Interceptor
+@Interceptor(order = FhirConstants.BUILT_IN_INTERCEPTOR_ORDER)
 public class DisableCacheInterceptor {
 	
 	@Hook(Pointcut.SERVER_OUTGOING_RESPONSE)

--- a/omod/src/main/java/org/openmrs/module/fhir2/web/util/SummaryInterceptor.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/web/util/SummaryInterceptor.java
@@ -13,8 +13,9 @@ import ca.uhn.fhir.interceptor.api.Hook;
 import ca.uhn.fhir.interceptor.api.Interceptor;
 import ca.uhn.fhir.interceptor.api.Pointcut;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
+import org.openmrs.module.fhir2.FhirConstants;
 
-@Interceptor
+@Interceptor(order = FhirConstants.BUILT_IN_INTERCEPTOR_ORDER)
 public class SummaryInterceptor {
 	
 	@Hook(Pointcut.SERVER_INCOMING_REQUEST_POST_PROCESSED)

--- a/omod/src/main/java/org/openmrs/module/fhir2/web/util/SupportMergePatchInterceptor.java
+++ b/omod/src/main/java/org/openmrs/module/fhir2/web/util/SupportMergePatchInterceptor.java
@@ -21,8 +21,9 @@ import ca.uhn.fhir.rest.api.RequestTypeEnum;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
 import org.apache.commons.lang.StringUtils;
+import org.openmrs.module.fhir2.FhirConstants;
 
-@Interceptor
+@Interceptor(order = FhirConstants.BUILT_IN_INTERCEPTOR_ORDER)
 public class SupportMergePatchInterceptor {
 	
 	private static final String JSON_MERGE_PATCH_CONTENT_TYPE = "application/merge-patch+json";

--- a/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
@@ -11,6 +11,7 @@ package org.openmrs.module.fhir2.web.servlet;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -27,15 +28,22 @@ import java.io.PrintWriter;
 
 import ca.uhn.fhir.interceptor.api.Hook;
 import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.rest.server.IServerAddressStrategy;
 import ca.uhn.fhir.rest.server.interceptor.LoggingInterceptor;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.openmrs.api.AdministrationService;
+import org.openmrs.module.fhir2.FhirConstants;
+import org.openmrs.module.fhir2.api.FhirGlobalPropertyService;
 import org.openmrs.module.fhir2.api.annotations.FhirInterceptor;
+import org.openmrs.module.fhir2.web.authentication.RequireAuthenticationInterceptor;
 import org.openmrs.util.OpenmrsClassLoader;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.context.support.StaticMessageSource;
 
 public class FhirRestServletTest {
 	
@@ -51,6 +59,9 @@ public class FhirRestServletTest {
 	@Mock
 	private PrintWriter mockWriter;
 	
+	@Mock
+	private FhirGlobalPropertyService globalPropertyService;
+	
 	private TestableFhirRestServlet servlet;
 	
 	private GenericApplicationContext context;
@@ -63,6 +74,13 @@ public class FhirRestServletTest {
 		
 		when(mockServletConfig.getServletContext()).thenReturn(mock(javax.servlet.ServletContext.class));
 		when(mockResponse.getWriter()).thenReturn(mockWriter);
+		
+		// the page sizes the module ships with; the paging provider rejects a size of zero, which is what
+		// an unstubbed mock would hand it
+		when(globalPropertyService.getGlobalPropertyAsInteger(FhirConstants.OPENMRS_FHIR_DEFAULT_PAGE_SIZE, 10))
+		        .thenReturn(10);
+		when(globalPropertyService.getGlobalPropertyAsInteger(FhirConstants.OPENMRS_FHIR_MAXIMUM_PAGE_SIZE, 100))
+		        .thenReturn(100);
 		
 		servlet.init(mockServletConfig);
 	}
@@ -117,6 +135,51 @@ public class FhirRestServletTest {
 		assertThat(servlet.getInterceptorService().getAllRegisteredInterceptors(), not(hasItem(ignored)));
 	}
 	
+	/**
+	 * The acceptance criterion this ticket turns on. The two tests above call registerInterceptors()
+	 * directly, so they never run unregisterAllInterceptors() and cannot tell "registered" apart from
+	 * "survives being unregistered and registered again" -- which is the whole defect. This one drives
+	 * the real initialize() and then the real refreshed(), the path a module start or stop actually
+	 * takes.
+	 */
+	@Test
+	public void refreshed_shouldStillHaveTheContributedInterceptorAfterAContextRefresh() throws ServletException {
+		ContributedInterceptor contributed = withRefreshableContext();
+		
+		RefreshableFhirRestServlet refreshable = new RefreshableFhirRestServlet();
+		refreshable.setGlobalPropertyService(globalPropertyService);
+		refreshable.setLoggingInterceptor(new LoggingInterceptor());
+		refreshable.setMessageSource(new StaticMessageSource());
+		refreshable.init(mockServletConfig);
+		
+		assertThat(refreshable.getInterceptorService().getAllRegisteredInterceptors(), hasItem(contributed));
+		
+		refreshable.refreshed();
+		
+		assertThat(refreshable.getInterceptorService().getAllRegisteredInterceptors(), hasItem(contributed));
+		// the built-ins coming back is what shows the unregister-and-re-register cycle really ran, rather
+		// than the contributed one having simply never been removed
+		assertThat(refreshable.getInterceptorService().getAllRegisteredInterceptors(),
+		    hasItem(instanceOf(RequireAuthenticationInterceptor.class)));
+	}
+	
+	/**
+	 * A context carrying the contributed interceptor plus every bean refreshed() resolves by name or by
+	 * type. The names are the ones the servlet asks for; a rename here reads as the interceptor being
+	 * lost rather than as the bean being missing.
+	 */
+	private ContributedInterceptor withRefreshableContext() {
+		context = new GenericApplicationContext();
+		context.registerBeanDefinition("contributed",
+		    BeanDefinitionBuilder.genericBeanDefinition(ContributedInterceptor.class).getBeanDefinition());
+		context.getBeanFactory().registerSingleton("hapiLoggingInterceptor", new LoggingInterceptor());
+		context.getBeanFactory().registerSingleton("adminService", mock(AdministrationService.class));
+		context.getBeanFactory().registerSingleton("fhirGlobalPropertyService", globalPropertyService);
+		context.getBeanFactory().registerSingleton("serverAddressStrategy", mock(IServerAddressStrategy.class));
+		context.refresh();
+		return context.getBean("contributed", ContributedInterceptor.class);
+	}
+	
 	private <T> T withContextContaining(String beanName, Class<T> beanClass) {
 		context = new GenericApplicationContext();
 		context.registerBeanDefinition(beanName, org.springframework.beans.factory.support.BeanDefinitionBuilder
@@ -144,6 +207,18 @@ public class FhirRestServletTest {
 		@Hook(Pointcut.SERVER_INCOMING_REQUEST_PRE_PROCESSED)
 		public boolean incomingRequest(HttpServletRequest request, HttpServletResponse response) {
 			return true;
+		}
+	}
+	
+	/**
+	 * Unlike {@link TestableFhirRestServlet} this leaves initialize() alone, because refreshed() does
+	 * nothing until initialize() has set the servlet started.
+	 */
+	class RefreshableFhirRestServlet extends FhirRestServlet {
+		
+		@Override
+		protected GenericApplicationContext getModuleApplicationContext() {
+			return context;
 		}
 	}
 	

--- a/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
@@ -28,12 +28,16 @@ import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.ArrayList;
 import java.util.List;
 
 import ca.uhn.fhir.interceptor.api.Hook;
 import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.rest.server.IResourceProvider;
 import ca.uhn.fhir.rest.server.IServerAddressStrategy;
 import ca.uhn.fhir.rest.server.interceptor.LoggingInterceptor;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Patient;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -206,6 +210,32 @@ public class FhirRestServletTest {
 	}
 	
 	/**
+	 * The servlet keeps answering requests all through a refresh, and RequireAuthenticationInterceptor
+	 * is the only thing that rejects an unauthenticated FHIR request -- AuthenticationFilter never
+	 * stops the chain itself. So the registry must not be left empty while refreshed() rebuilds the
+	 * providers, which runs every other module's provider constructors and reads two global properties
+	 * from the database. This provider reports what was registered at the moment it was built.
+	 */
+	@Test
+	public void refreshed_shouldKeepInterceptorsRegisteredWhileTheProvidersAreRebuilt() throws ServletException {
+		withRefreshableContext();
+		context.registerBeanDefinition("interceptorWatchingProvider",
+		    BeanDefinitionBuilder.genericBeanDefinition(InterceptorWatchingProvider.class).getBeanDefinition());
+		
+		R4ServletWithTestContext refreshable = new R4ServletWithTestContext();
+		refreshable.setGlobalPropertyService(globalPropertyService);
+		refreshable.setLoggingInterceptor(new LoggingInterceptor());
+		refreshable.setMessageSource(new StaticMessageSource());
+		refreshable.init(mockServletConfig);
+		
+		InterceptorWatchingProvider.watch(refreshable);
+		refreshable.refreshed();
+		
+		assertThat(InterceptorWatchingProvider.seenWhileBeingBuilt,
+		    hasItem(instanceOf(RequireAuthenticationInterceptor.class)));
+	}
+	
+	/**
 	 * A context carrying the contributed interceptor plus the four beans refreshed() throws without.
 	 * The contributed one is found by its annotation, so its bean name is arbitrary; the other four are
 	 * the names and types refreshed() asks for by hand. Resource providers it resolves by type, and
@@ -225,6 +255,33 @@ public class FhirRestServletTest {
 		context.registerBeanDefinition(beanName, BeanDefinitionBuilder.genericBeanDefinition(beanClass).getBeanDefinition());
 		context.refresh();
 		return context.getBean(beanName, beanClass);
+	}
+	
+	/**
+	 * Records the servlet's interceptor registry from its own constructor, which refreshed() runs while
+	 * it is rebuilding the resource providers. Static because Spring, not the test, constructs it.
+	 */
+	public static class InterceptorWatchingProvider implements IResourceProvider {
+		
+		private static FhirRestServlet watched;
+		
+		static List<Object> seenWhileBeingBuilt;
+		
+		static void watch(FhirRestServlet servlet) {
+			watched = servlet;
+			seenWhileBeingBuilt = null;
+		}
+		
+		public InterceptorWatchingProvider() {
+			if (watched != null) {
+				seenWhileBeingBuilt = new ArrayList<>(watched.getInterceptorService().getAllRegisteredInterceptors());
+			}
+		}
+		
+		@Override
+		public Class<? extends IBaseResource> getResourceType() {
+			return Patient.class;
+		}
 	}
 	
 	/**

--- a/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
@@ -132,9 +132,8 @@ public class FhirRestServletTest {
 	}
 	
 	/**
-	 * Picking up an unannotated bean would put every hook-bearing bean in every module into the FHIR
-	 * request path uninvited. The fixture carries real hooks because HAPI drops a hookless interceptor
-	 * anyway, so a hookless one would pass this whether the annotation were honoured or not.
+	 * Fails if the scan matches hook-bearing beans instead of the annotation. The fixture carries real
+	 * hooks because HAPI drops a hookless one regardless, which would pass either way.
 	 */
 	@Test
 	public void registerInterceptors_shouldIgnoreAHookBearingBeanThatIsNotAnnotated() {
@@ -147,10 +146,8 @@ public class FhirRestServletTest {
 	}
 	
 	/**
-	 * The {@code registerInterceptors_should...} tests call that method directly, so they never reach
-	 * unregisterAllInterceptors() and cannot tell "registered" from "survives being unregistered and
-	 * registered again" -- the whole defect. This drives the real initialize() then the real
-	 * refreshed().
+	 * Not redundant with the tests that call registerInterceptors() directly: those never reach
+	 * unregisterAllInterceptors(), which is the defect. This drives initialize() then refreshed().
 	 */
 	@Test
 	public void refreshed_shouldStillHaveTheContributedInterceptorAfterAContextRefresh() throws ServletException {
@@ -176,17 +173,15 @@ public class FhirRestServletTest {
 		        instanceOf(SummaryInterceptor.class), instanceOf(SupportMergePatchInterceptor.class)));
 		assertThat(afterRefresh, hasItem(contributed));
 		assertThat(afterRefresh, hasItem(sameInstance(context.getBean("hapiLoggingInterceptor", LoggingInterceptor.class))));
-		// the assertion that shows the registry was torn down -- the rebuilt one's presence above passes
-		// either way
+		// this is what shows the teardown ran; asserting the rebuilt interceptor present does not
 		assertThat(afterRefresh, not(hasItem(sameInstance(loggingInterceptorBeforeInit))));
 		// and nothing else, so a duplicate or a stray registration is caught rather than ignored
 		assertThat(afterRefresh, hasSize(6));
 	}
 	
 	/**
-	 * The case FM2-698 describes: the contributing module starts after this one, so its bean reaches
-	 * the context only at the refresh. registerInterceptors() reads the context each time it runs,
-	 * rather than replaying what initialize() found, and that is what picks this bean up.
+	 * Fails if registerInterceptors() caches the contributed beans at initialize() rather than reading
+	 * the context each time, which drops a module that starts after this one.
 	 */
 	@Test
 	public void refreshed_shouldRegisterAContributedInterceptorThatReachedTheContextAfterInitialize()
@@ -211,9 +206,8 @@ public class FhirRestServletTest {
 	}
 	
 	/**
-	 * {@link FhirInterceptor} promises a module author every version-specific servlet. R3 keeps that by
-	 * inheriting initialize(), so an override added there later would drop contributed interceptors
-	 * from the R3 API.
+	 * Fails if FhirR3RestServlet overrides initialize(), which would drop contributed interceptors from
+	 * the R3 API.
 	 */
 	@Test
 	public void initialize_shouldRegisterTheContributedInterceptorOnTheR3ServletToo() throws ServletException {
@@ -229,10 +223,8 @@ public class FhirRestServletTest {
 	}
 	
 	/**
-	 * The servlet keeps answering through a refresh, and a request carrying no credentials passes
-	 * straight through AuthenticationFilter -- which rejects only a failed Basic one -- so
-	 * RequireAuthenticationInterceptor is what stops it. This provider reports the registry as it was
-	 * when refreshed() built it, in the middle of rebuilding the providers.
+	 * Fails if unregisterAllInterceptors() moves back before the provider rebuild, which would answer
+	 * requests unauthenticated while other modules' provider constructors run.
 	 */
 	@Test
 	public void refreshed_shouldKeepInterceptorsRegisteredWhileTheProvidersAreRebuilt() throws ServletException {
@@ -254,9 +246,8 @@ public class FhirRestServletTest {
 	}
 	
 	/**
-	 * The contributed interceptor plus the four beans refreshed() throws without. It finds the
-	 * contributed one by annotation, so that bean name is arbitrary; of the rest it asks for
-	 * hapiLoggingInterceptor and adminService by name, the other two by type.
+	 * The beans refreshed() throws without. It asks for hapiLoggingInterceptor and adminService by
+	 * name, so those two cannot be renamed here.
 	 */
 	private ContributedInterceptor withRefreshableContext() {
 		ContributedInterceptor contributed = withContextContaining("contributed", ContributedInterceptor.class);

--- a/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
@@ -86,7 +86,7 @@ public class FhirRestServletTest {
 		when(mockServletConfig.getServletContext()).thenReturn(mock(javax.servlet.ServletContext.class));
 		when(mockResponse.getWriter()).thenReturn(mockWriter);
 		
-		// the shipped defaults; the paging provider rejects the zero an unstubbed mock would hand it
+		// an unstubbed mock returns 0, which BasePagingProvider rejects
 		when(globalPropertyService.getGlobalPropertyAsInteger(FhirConstants.OPENMRS_FHIR_DEFAULT_PAGE_SIZE, 10))
 		        .thenReturn(10);
 		when(globalPropertyService.getGlobalPropertyAsInteger(FhirConstants.OPENMRS_FHIR_MAXIMUM_PAGE_SIZE, 100))
@@ -101,7 +101,6 @@ public class FhirRestServletTest {
 			context.close();
 			context = null;
 		}
-		// static, and every test in this module shares one JVM
 		InterceptorWatchingProvider.watch(null);
 	}
 	
@@ -132,8 +131,8 @@ public class FhirRestServletTest {
 	}
 	
 	/**
-	 * Fails if the scan matches hook-bearing beans instead of the annotation. The fixture carries real
-	 * hooks because HAPI drops a hookless one regardless, which would pass either way.
+	 * The fixture declares a real hook: HAPI refuses a hookless interceptor anyway, so without one the
+	 * test would pass either way.
 	 */
 	@Test
 	public void registerInterceptors_shouldIgnoreAHookBearingBeanThatIsNotAnnotated() {
@@ -145,10 +144,6 @@ public class FhirRestServletTest {
 		assertThat(servlet.getInterceptorService().getAllRegisteredInterceptors(), not(hasItem(ignored)));
 	}
 	
-	/**
-	 * Not redundant with the tests that call registerInterceptors() directly: those never reach
-	 * unregisterAllInterceptors(), which is the defect. This drives initialize() then refreshed().
-	 */
 	@Test
 	public void refreshed_shouldStillHaveTheContributedInterceptorAfterAContextRefresh() throws ServletException {
 		ContributedInterceptor contributed = withRefreshableContext();
@@ -167,7 +162,6 @@ public class FhirRestServletTest {
 		
 		List<Object> afterRefresh = refreshable.getInterceptorService().getAllRegisteredInterceptors();
 		
-		// the built-ins have to come back too, and nothing else here would notice if one stopped
 		assertThat(afterRefresh,
 		    hasItems(instanceOf(RequireAuthenticationInterceptor.class), instanceOf(DisableCacheInterceptor.class),
 		        instanceOf(SummaryInterceptor.class), instanceOf(SupportMergePatchInterceptor.class)));
@@ -175,14 +169,9 @@ public class FhirRestServletTest {
 		assertThat(afterRefresh, hasItem(sameInstance(context.getBean("hapiLoggingInterceptor", LoggingInterceptor.class))));
 		// this is what shows the teardown ran; asserting the rebuilt interceptor present does not
 		assertThat(afterRefresh, not(hasItem(sameInstance(loggingInterceptorBeforeInit))));
-		// and nothing else, so a duplicate or a stray registration is caught rather than ignored
 		assertThat(afterRefresh, hasSize(6));
 	}
 	
-	/**
-	 * Fails if registerInterceptors() caches the contributed beans at initialize() rather than reading
-	 * the context each time, which drops a module that starts after this one.
-	 */
 	@Test
 	public void refreshed_shouldRegisterAContributedInterceptorThatReachedTheContextAfterInitialize()
 	        throws ServletException {
@@ -205,10 +194,6 @@ public class FhirRestServletTest {
 		assertThat(refreshable.getInterceptorService().getAllRegisteredInterceptors(), hasItem(lateComer));
 	}
 	
-	/**
-	 * Fails if FhirR3RestServlet overrides initialize(), which would drop contributed interceptors from
-	 * the R3 API.
-	 */
 	@Test
 	public void initialize_shouldRegisterTheContributedInterceptorOnTheR3ServletToo() throws ServletException {
 		ContributedInterceptor contributed = withContextContaining("contributed", ContributedInterceptor.class);
@@ -222,10 +207,6 @@ public class FhirRestServletTest {
 		assertThat(r3.getInterceptorService().getAllRegisteredInterceptors(), hasItem(contributed));
 	}
 	
-	/**
-	 * Fails if unregisterAllInterceptors() moves back before the provider rebuild, which would answer
-	 * requests unauthenticated while other modules' provider constructors run.
-	 */
 	@Test
 	public void refreshed_shouldKeepInterceptorsRegisteredWhileTheProvidersAreRebuilt() throws ServletException {
 		withRefreshableContext();
@@ -246,8 +227,8 @@ public class FhirRestServletTest {
 	}
 	
 	/**
-	 * The beans refreshed() throws without. It asks for hapiLoggingInterceptor and adminService by
-	 * name, so those two cannot be renamed here.
+	 * refreshed() looks two of these up by name, so hapiLoggingInterceptor and adminService cannot be
+	 * renamed.
 	 */
 	private ContributedInterceptor withRefreshableContext() {
 		ContributedInterceptor contributed = withContextContaining("contributed", ContributedInterceptor.class);
@@ -266,8 +247,8 @@ public class FhirRestServletTest {
 	}
 	
 	/**
-	 * Records the servlet's interceptor registry from its own constructor, which refreshed() runs while
-	 * it is rebuilding the resource providers. Static because Spring, not the test, constructs it.
+	 * Captures the interceptor registry from its constructor, which Spring runs during the provider
+	 * rebuild. Static because Spring, not the test, constructs it.
 	 */
 	public static class InterceptorWatchingProvider implements IResourceProvider {
 		

--- a/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
@@ -9,11 +9,14 @@
  */
 package org.openmrs.module.fhir2.web.servlet;
 
+import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertEquals;
@@ -31,12 +34,16 @@ import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
 
+import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.interceptor.api.Hook;
 import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.rest.annotation.IdParam;
+import ca.uhn.fhir.rest.annotation.Read;
 import ca.uhn.fhir.rest.server.IResourceProvider;
 import ca.uhn.fhir.rest.server.IServerAddressStrategy;
 import ca.uhn.fhir.rest.server.interceptor.LoggingInterceptor;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Patient;
 import org.junit.After;
 import org.junit.Before;
@@ -47,6 +54,7 @@ import org.openmrs.api.AdministrationService;
 import org.openmrs.module.fhir2.FhirConstants;
 import org.openmrs.module.fhir2.api.FhirGlobalPropertyService;
 import org.openmrs.module.fhir2.api.annotations.FhirInterceptor;
+import org.openmrs.module.fhir2.api.annotations.R4Provider;
 import org.openmrs.module.fhir2.web.authentication.RequireAuthenticationInterceptor;
 import org.openmrs.module.fhir2.web.util.DisableCacheInterceptor;
 import org.openmrs.module.fhir2.web.util.SummaryInterceptor;
@@ -226,6 +234,37 @@ public class FhirRestServletTest {
 		    hasItem(instanceOf(RequireAuthenticationInterceptor.class)));
 	}
 	
+	@Test
+	public void refreshed_shouldStillRouteAResourceReadAfterARefresh() throws ServletException {
+		withRefreshableContext();
+		context.registerBeanDefinition("patientProvider",
+		    BeanDefinitionBuilder.genericBeanDefinition(ReadablePatientProvider.class).getBeanDefinition());
+		
+		R4ServletWithTestContext refreshable = new R4ServletWithTestContext();
+		refreshable.setFhirContext(FhirContext.forR4());
+		refreshable.setGlobalPropertyService(globalPropertyService);
+		refreshable.setLoggingInterceptor(new LoggingInterceptor());
+		refreshable.setMessageSource(new StaticMessageSource());
+		refreshable.setResourceProviders(singletonList(context.getBean("patientProvider", ReadablePatientProvider.class)));
+		refreshable.init(mockServletConfig);
+		
+		int boundAtInit = bindingCountFor(refreshable, "Patient");
+		assertThat(boundAtInit, greaterThan(0));
+		
+		refreshable.refreshed();
+		
+		// the provider list is repopulated either way; the bindings are what a read routes on. Equality
+		// rather than greaterThan, because registerProviders appends and only unregisterAllProviders
+		// running first keeps that from doubling them
+		assertThat(bindingCountFor(refreshable, "Patient"), is(boundAtInit));
+		assertThat(refreshable.getResourceProviders(), hasSize(1));
+	}
+	
+	private int bindingCountFor(FhirRestServlet servlet, String resourceName) {
+		return servlet.getResourceBindings().stream().filter(b -> resourceName.equals(b.getResourceName()))
+		        .mapToInt(b -> b.getMethodBindings().size()).sum();
+	}
+	
 	/**
 	 * refreshed() looks two of these up by name, so hapiLoggingInterceptor and adminService cannot be
 	 * renamed.
@@ -265,6 +304,20 @@ public class FhirRestServletTest {
 			if (watched != null) {
 				seenWhileBeingBuilt = new ArrayList<>(watched.getInterceptorService().getAllRegisteredInterceptors());
 			}
+		}
+		
+		@Override
+		public Class<? extends IBaseResource> getResourceType() {
+			return Patient.class;
+		}
+	}
+	
+	@R4Provider
+	public static class ReadablePatientProvider implements IResourceProvider {
+		
+		@Read
+		public Patient read(@IdParam IdType id) {
+			return new Patient();
 		}
 		
 		@Override

--- a/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
@@ -11,7 +11,6 @@ package org.openmrs.module.fhir2.web.servlet;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -39,7 +38,6 @@ import org.openmrs.api.AdministrationService;
 import org.openmrs.module.fhir2.FhirConstants;
 import org.openmrs.module.fhir2.api.FhirGlobalPropertyService;
 import org.openmrs.module.fhir2.api.annotations.FhirInterceptor;
-import org.openmrs.module.fhir2.web.authentication.RequireAuthenticationInterceptor;
 import org.openmrs.util.OpenmrsClassLoader;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.context.support.GenericApplicationContext;
@@ -146,9 +144,11 @@ public class FhirRestServletTest {
 	public void refreshed_shouldStillHaveTheContributedInterceptorAfterAContextRefresh() throws ServletException {
 		ContributedInterceptor contributed = withRefreshableContext();
 		
+		LoggingInterceptor loggingInterceptorBeforeInit = new LoggingInterceptor();
+		
 		RefreshableFhirRestServlet refreshable = new RefreshableFhirRestServlet();
 		refreshable.setGlobalPropertyService(globalPropertyService);
-		refreshable.setLoggingInterceptor(new LoggingInterceptor());
+		refreshable.setLoggingInterceptor(loggingInterceptorBeforeInit);
 		refreshable.setMessageSource(new StaticMessageSource());
 		refreshable.init(mockServletConfig);
 		
@@ -157,10 +157,13 @@ public class FhirRestServletTest {
 		refreshable.refreshed();
 		
 		assertThat(refreshable.getInterceptorService().getAllRegisteredInterceptors(), hasItem(contributed));
-		// the built-ins coming back is what shows the unregister-and-re-register cycle really ran, rather
-		// than the contributed one having simply never been removed
+		// the rebuilt context's logging interceptor is what shows the registry was actually torn down and
+		// rebuilt. The built-ins alone would not: had unregisterAllInterceptors() never run they would
+		// still be there from initialize(), so their presence tells the two cases apart not at all.
 		assertThat(refreshable.getInterceptorService().getAllRegisteredInterceptors(),
-		    hasItem(instanceOf(RequireAuthenticationInterceptor.class)));
+		    hasItem(context.getBean("hapiLoggingInterceptor", LoggingInterceptor.class)));
+		assertThat(refreshable.getInterceptorService().getAllRegisteredInterceptors(),
+		    not(hasItem(loggingInterceptorBeforeInit)));
 	}
 	
 	/**
@@ -182,8 +185,7 @@ public class FhirRestServletTest {
 	
 	private <T> T withContextContaining(String beanName, Class<T> beanClass) {
 		context = new GenericApplicationContext();
-		context.registerBeanDefinition(beanName, org.springframework.beans.factory.support.BeanDefinitionBuilder
-		        .genericBeanDefinition(beanClass).getBeanDefinition());
+		context.registerBeanDefinition(beanName, BeanDefinitionBuilder.genericBeanDefinition(beanClass).getBeanDefinition());
 		context.refresh();
 		return context.getBean(beanName, beanClass);
 	}

--- a/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
@@ -102,6 +102,8 @@ public class FhirRestServletTest {
 			context.close();
 			context = null;
 		}
+		// static, and every test in this module shares one JVM
+		InterceptorWatchingProvider.watch(null);
 	}
 	
 	@Test
@@ -205,11 +207,12 @@ public class FhirRestServletTest {
 	}
 	
 	/**
-	 * The servlet keeps answering requests all through a refresh, and RequireAuthenticationInterceptor
-	 * is the only thing that rejects an unauthenticated FHIR request -- AuthenticationFilter never
-	 * stops the chain itself. So the registry must not be left empty while refreshed() rebuilds the
-	 * providers, which runs every other module's provider constructors and reads two global properties
-	 * from the database. This provider reports what was registered at the moment it was built.
+	 * The servlet keeps answering requests all through a refresh, and a request carrying no credentials
+	 * passes straight through AuthenticationFilter -- which only rejects one whose Basic credentials
+	 * fail -- so RequireAuthenticationInterceptor is what rejects it. The registry must not be left
+	 * empty while refreshed() rebuilds the providers, which runs every other module's provider
+	 * constructors and reads two global properties from the database. This provider reports what was
+	 * registered when it was built.
 	 */
 	@Test
 	public void refreshed_shouldKeepInterceptorsRegisteredWhileTheProvidersAreRebuilt() throws ServletException {

--- a/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertEquals;
@@ -178,6 +179,11 @@ public class FhirRestServletTest {
 		// this is what shows the teardown ran; asserting the rebuilt interceptor present does not
 		assertThat(afterRefresh, not(hasItem(sameInstance(loggingInterceptorBeforeInit))));
 		assertThat(afterRefresh, hasSize(6));
+		// a contributed hook that leaves @Interceptor(order) at its default runs after authentication
+		// only because it is registered after it: HAPI sorts by order and leaves registration as the
+		// tie-break
+		assertThat(indexOfType(afterRefresh, RequireAuthenticationInterceptor.class),
+		    lessThan(afterRefresh.indexOf(contributed)));
 	}
 	
 	@Test
@@ -258,6 +264,15 @@ public class FhirRestServletTest {
 		// running first keeps that from doubling them
 		assertThat(bindingCountFor(refreshable, "Patient"), is(boundAtInit));
 		assertThat(refreshable.getResourceProviders(), hasSize(1));
+	}
+	
+	private int indexOfType(List<Object> interceptors, Class<?> type) {
+		for (int i = 0; i < interceptors.size(); i++) {
+			if (type.isInstance(interceptors.get(i))) {
+				return i;
+			}
+		}
+		return -1;
 	}
 	
 	private int bindingCountFor(FhirRestServlet servlet, String resourceName) {

--- a/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
@@ -167,6 +167,24 @@ public class FhirRestServletTest {
 	}
 	
 	/**
+	 * {@link FhirInterceptor} tells a module author its bean is picked up by every version-specific
+	 * servlet, and nothing else checks that promise -- the R3 servlet keeps it only by not overriding
+	 * initialize(), which a later change could do without noticing what it costs.
+	 */
+	@Test
+	public void initialize_shouldRegisterTheContributedInterceptorOnTheR3ServletToo() throws ServletException {
+		ContributedInterceptor contributed = withContextContaining("contributed", ContributedInterceptor.class);
+		
+		R3ServletReadingTheTestContext r3 = new R3ServletReadingTheTestContext();
+		r3.setGlobalPropertyService(globalPropertyService);
+		r3.setLoggingInterceptor(new LoggingInterceptor());
+		r3.setMessageSource(new StaticMessageSource());
+		r3.init(mockServletConfig);
+		
+		assertThat(r3.getInterceptorService().getAllRegisteredInterceptors(), hasItem(contributed));
+	}
+	
+	/**
 	 * A context carrying the contributed interceptor plus every bean refreshed() resolves by name or by
 	 * type. The names are the ones the servlet asks for; a rename here reads as the interceptor being
 	 * lost rather than as the bean being missing.
@@ -209,6 +227,14 @@ public class FhirRestServletTest {
 		@Hook(Pointcut.SERVER_INCOMING_REQUEST_PRE_PROCESSED)
 		public boolean incomingRequest(HttpServletRequest request, HttpServletResponse response) {
 			return true;
+		}
+	}
+	
+	class R3ServletReadingTheTestContext extends FhirR3RestServlet {
+		
+		@Override
+		protected GenericApplicationContext getModuleApplicationContext() {
+			return context;
 		}
 	}
 	

--- a/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
@@ -184,6 +184,33 @@ public class FhirRestServletTest {
 	}
 	
 	/**
+	 * The case FM2-698 describes: the contributing module starts after this one, so its bean reaches
+	 * the context only at the refresh. registerInterceptors() reads the context each time it runs,
+	 * rather than replaying what initialize() found, and that is what picks this bean up.
+	 */
+	@Test
+	public void refreshed_shouldRegisterAContributedInterceptorThatReachedTheContextAfterInitialize()
+	        throws ServletException {
+		withRefreshableContext();
+		
+		R4ServletWithTestContext refreshable = new R4ServletWithTestContext();
+		refreshable.setGlobalPropertyService(globalPropertyService);
+		refreshable.setLoggingInterceptor(new LoggingInterceptor());
+		refreshable.setMessageSource(new StaticMessageSource());
+		refreshable.init(mockServletConfig);
+		
+		context.registerBeanDefinition("lateComer",
+		    BeanDefinitionBuilder.genericBeanDefinition(ContributedInterceptor.class).getBeanDefinition());
+		ContributedInterceptor lateComer = context.getBean("lateComer", ContributedInterceptor.class);
+		
+		assertThat(refreshable.getInterceptorService().getAllRegisteredInterceptors(), not(hasItem(lateComer)));
+		
+		refreshable.refreshed();
+		
+		assertThat(refreshable.getInterceptorService().getAllRegisteredInterceptors(), hasItem(lateComer));
+	}
+	
+	/**
 	 * {@link FhirInterceptor} promises a module author every version-specific servlet. R3 keeps that by
 	 * inheriting initialize(), so an override added there later would drop contributed interceptors
 	 * from the R3 API.

--- a/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
@@ -17,12 +17,12 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import javax.servlet.ServletConfig;
@@ -179,11 +179,32 @@ public class FhirRestServletTest {
 		// this is what shows the teardown ran; asserting the rebuilt interceptor present does not
 		assertThat(afterRefresh, not(hasItem(sameInstance(loggingInterceptorBeforeInit))));
 		assertThat(afterRefresh, hasSize(6));
-		// a contributed hook that leaves @Interceptor(order) at its default runs after authentication
-		// only because it is registered after it: HAPI sorts by order and leaves registration as the
-		// tie-break
-		assertThat(indexOfType(afterRefresh, RequireAuthenticationInterceptor.class),
-		    lessThan(afterRefresh.indexOf(contributed)));
+	}
+	
+	@Test
+	public void refreshed_shouldRejectAnUnauthenticatedRequestBeforeAContributedInterceptorSeesIt()
+	        throws ServletException, IOException {
+		ContributedInterceptor contributed = withRefreshableContext();
+		
+		R4ServletWithTestContext refreshable = new R4ServletWithTestContext();
+		refreshable.setGlobalPropertyService(globalPropertyService);
+		refreshable.setLoggingInterceptor(new LoggingInterceptor());
+		refreshable.setMessageSource(new StaticMessageSource());
+		refreshable.init(mockServletConfig);
+		refreshable.refreshed();
+		
+		when(mockRequest.getMethod()).thenReturn("GET");
+		when(mockRequest.getRequestURI()).thenReturn("/fhir2Servlet/Patient/1");
+		when(mockRequest.getRequestURL()).thenReturn(new StringBuffer("http://localhost/fhir2Servlet/Patient/1"));
+		when(mockRequest.getServletPath()).thenReturn("");
+		when(mockRequest.getContextPath()).thenReturn("");
+		when(mockRequest.getQueryString()).thenReturn("");
+		
+		refreshable.service(mockRequest, mockResponse);
+		
+		// dispatch order, not registry order: the registry sorts on class-level order alone
+		verify(mockResponse).sendError(HttpServletResponse.SC_UNAUTHORIZED, "Not authenticated");
+		assertThat(contributed.sawRequest, is(false));
 	}
 	
 	@Test
@@ -259,20 +280,9 @@ public class FhirRestServletTest {
 		
 		refreshable.refreshed();
 		
-		// the provider list is repopulated either way; the bindings are what a read routes on. Equality
-		// rather than greaterThan, because registerProviders appends and only unregisterAllProviders
-		// running first keeps that from doubling them
+		// equality, not greaterThan: registerProviders appends, so a skipped unregister doubles it
 		assertThat(bindingCountFor(refreshable, "Patient"), is(boundAtInit));
 		assertThat(refreshable.getResourceProviders(), hasSize(1));
-	}
-	
-	private int indexOfType(List<Object> interceptors, Class<?> type) {
-		for (int i = 0; i < interceptors.size(); i++) {
-			if (type.isInstance(interceptors.get(i))) {
-				return i;
-			}
-		}
-		return -1;
 	}
 	
 	private int bindingCountFor(FhirRestServlet servlet, String resourceName) {
@@ -344,8 +354,11 @@ public class FhirRestServletTest {
 	@FhirInterceptor
 	public static class ContributedInterceptor {
 		
+		boolean sawRequest;
+		
 		@Hook(Pointcut.SERVER_INCOMING_REQUEST_PRE_PROCESSED)
 		public boolean incomingRequest(HttpServletRequest request, HttpServletResponse response) {
+			sawRequest = true;
 			return true;
 		}
 	}

--- a/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
@@ -9,6 +9,9 @@
  */
 package org.openmrs.module.fhir2.web.servlet;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
@@ -22,11 +25,17 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 
+import ca.uhn.fhir.interceptor.api.Hook;
+import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.rest.server.interceptor.LoggingInterceptor;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.openmrs.module.fhir2.api.annotations.FhirInterceptor;
 import org.openmrs.util.OpenmrsClassLoader;
+import org.springframework.context.support.GenericApplicationContext;
 
 public class FhirRestServletTest {
 	
@@ -44,6 +53,8 @@ public class FhirRestServletTest {
 	
 	private TestableFhirRestServlet servlet;
 	
+	private GenericApplicationContext context;
+	
 	@Before
 	public void setUp() throws ServletException, IOException {
 		MockitoAnnotations.initMocks(this);
@@ -54,6 +65,14 @@ public class FhirRestServletTest {
 		when(mockResponse.getWriter()).thenReturn(mockWriter);
 		
 		servlet.init(mockServletConfig);
+	}
+	
+	@After
+	public void closeContext() {
+		if (context != null) {
+			context.close();
+			context = null;
+		}
 	}
 	
 	@Test
@@ -72,10 +91,71 @@ public class FhirRestServletTest {
 		assertEquals(OpenmrsClassLoader.getInstance(), Thread.currentThread().getContextClassLoader());
 	}
 	
+	@Test
+	public void registerInterceptors_shouldRegisterAnAnnotatedInterceptorBeanFromTheContext() {
+		ContributedInterceptor contributed = withContextContaining("contributed", ContributedInterceptor.class);
+		
+		servlet.setLoggingInterceptor(new LoggingInterceptor());
+		servlet.registerInterceptors();
+		
+		assertThat(servlet.getInterceptorService().getAllRegisteredInterceptors(), hasItem(contributed));
+	}
+	
+	/**
+	 * A bean carrying hook methods but not the annotation is an ordinary bean, and picking it up would
+	 * put every hook-bearing bean in every module into the FHIR request path without its author saying
+	 * so. It carries real hooks deliberately: HAPI refuses an interceptor with none, so a hookless bean
+	 * would pass this whether the annotation were honoured or not.
+	 */
+	@Test
+	public void registerInterceptors_shouldIgnoreAHookBearingBeanThatIsNotAnnotated() {
+		HookedButNotAnnotated ignored = withContextContaining("ignored", HookedButNotAnnotated.class);
+		
+		servlet.setLoggingInterceptor(new LoggingInterceptor());
+		servlet.registerInterceptors();
+		
+		assertThat(servlet.getInterceptorService().getAllRegisteredInterceptors(), not(hasItem(ignored)));
+	}
+	
+	private <T> T withContextContaining(String beanName, Class<T> beanClass) {
+		context = new GenericApplicationContext();
+		context.registerBeanDefinition(beanName, org.springframework.beans.factory.support.BeanDefinitionBuilder
+		        .genericBeanDefinition(beanClass).getBeanDefinition());
+		context.refresh();
+		return context.getBean(beanName, beanClass);
+	}
+	
+	/**
+	 * Carries a real hook because HAPI refuses an interceptor that has none: it logs "Interceptor
+	 * registered with no valid hooks" and moves on, so a bean annotated but hookless is silently absent
+	 * from the request path.
+	 */
+	@FhirInterceptor
+	public static class ContributedInterceptor {
+		
+		@Hook(Pointcut.SERVER_INCOMING_REQUEST_PRE_PROCESSED)
+		public boolean incomingRequest(HttpServletRequest request, HttpServletResponse response) {
+			return true;
+		}
+	}
+	
+	public static class HookedButNotAnnotated {
+		
+		@Hook(Pointcut.SERVER_INCOMING_REQUEST_PRE_PROCESSED)
+		public boolean incomingRequest(HttpServletRequest request, HttpServletResponse response) {
+			return true;
+		}
+	}
+	
 	class TestableFhirRestServlet extends FhirRestServlet {
 		
 		@Override
 		public void initialize() {
+		}
+		
+		@Override
+		protected GenericApplicationContext getModuleApplicationContext() {
+			return context;
 		}
 	}
 }

--- a/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
@@ -134,11 +134,11 @@ public class FhirRestServletTest {
 	}
 	
 	/**
-	 * The acceptance criterion this ticket turns on. The two tests above call registerInterceptors()
-	 * directly, so they never run unregisterAllInterceptors() and cannot tell "registered" apart from
-	 * "survives being unregistered and registered again" -- which is the whole defect. This one drives
-	 * the real initialize() and then the real refreshed(), the path a module start or stop actually
-	 * takes.
+	 * The acceptance criterion this ticket turns on. The two {@code registerInterceptors_should...}
+	 * tests call that method directly, so they never run unregisterAllInterceptors() and cannot tell
+	 * "registered" apart from "survives being unregistered and registered again" -- which is the whole
+	 * defect. This one drives the real initialize() and then the real refreshed(), the path a module
+	 * start or stop actually takes.
 	 */
 	@Test
 	public void refreshed_shouldStillHaveTheContributedInterceptorAfterAContextRefresh() throws ServletException {
@@ -168,8 +168,8 @@ public class FhirRestServletTest {
 	
 	/**
 	 * {@link FhirInterceptor} tells a module author its bean is picked up by every version-specific
-	 * servlet, and nothing else checks that promise -- the R3 servlet keeps it only by not overriding
-	 * initialize(), which a later change could do without noticing what it costs.
+	 * servlet. FhirR3RestServlet keeps that by inheriting initialize(), so an override added there
+	 * later would drop contributed interceptors from the R3 API; this fails if one does.
 	 */
 	@Test
 	public void initialize_shouldRegisterTheContributedInterceptorOnTheR3ServletToo() throws ServletException {

--- a/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
@@ -186,8 +186,8 @@ public class FhirRestServletTest {
 	
 	/**
 	 * A context carrying the contributed interceptor plus every bean refreshed() resolves by name or by
-	 * type. The names are the ones the servlet asks for; a rename here reads as the interceptor being
-	 * lost rather than as the bean being missing.
+	 * type. The contributed one is found by its annotation, so its bean name is arbitrary; the other
+	 * four are the names and types refreshed() asks for by hand.
 	 */
 	private ContributedInterceptor withRefreshableContext() {
 		context = new GenericApplicationContext();

--- a/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
@@ -147,11 +147,10 @@ public class FhirRestServletTest {
 	}
 	
 	/**
-	 * The acceptance criterion this ticket turns on. The two {@code registerInterceptors_should...}
-	 * tests call that method directly, so they never run unregisterAllInterceptors() and cannot tell
-	 * "registered" apart from "survives being unregistered and registered again" -- which is the whole
-	 * defect. This one drives the real initialize() and then the real refreshed(), the path a module
-	 * start or stop actually takes.
+	 * The two {@code registerInterceptors_should...} tests call that method directly, so they never run
+	 * unregisterAllInterceptors() and cannot tell "registered" apart from "survives being unregistered
+	 * and registered again" -- which is the whole defect. This one drives the real initialize() and
+	 * then the real refreshed(), the path a module start or stop actually takes.
 	 */
 	@Test
 	public void refreshed_shouldStillHaveTheContributedInterceptorAfterAContextRefresh() throws ServletException {
@@ -169,10 +168,6 @@ public class FhirRestServletTest {
 		
 		refreshable.refreshed();
 		
-		// the whole registry, not just the contributed one: the built-ins have to come back too, and
-		// nothing else here would notice if one stopped being registered. The absent pre-init logging
-		// interceptor is the assertion that shows the registry was torn down -- the rebuilt one's
-		// presence passes whether unregisterAllInterceptors() ran or not.
 		List<Object> afterRefresh = refreshable.getInterceptorService().getAllRegisteredInterceptors();
 		
 		// the built-ins have to come back too, and nothing else here would notice if one stopped being
@@ -181,7 +176,7 @@ public class FhirRestServletTest {
 		assertThat(afterRefresh,
 		    hasItems(instanceOf(RequireAuthenticationInterceptor.class), instanceOf(DisableCacheInterceptor.class),
 		        instanceOf(SummaryInterceptor.class), instanceOf(SupportMergePatchInterceptor.class)));
-		assertThat(afterRefresh, hasItem(sameInstance(contributed)));
+		assertThat(afterRefresh, hasItem(contributed));
 		assertThat(afterRefresh, hasItem(sameInstance(context.getBean("hapiLoggingInterceptor", LoggingInterceptor.class))));
 		// this is the assertion that shows the registry was torn down: the rebuilt logging interceptor's
 		// presence passes whether unregisterAllInterceptors() ran or not, the pre-init one's absence does
@@ -237,9 +232,10 @@ public class FhirRestServletTest {
 	
 	/**
 	 * A context carrying the contributed interceptor plus the four beans refreshed() throws without.
-	 * The contributed one is found by its annotation, so its bean name is arbitrary; the other four are
-	 * the names and types refreshed() asks for by hand. Resource providers it resolves by type, and
-	 * none here, which is a bundle with no providers rather than a failure.
+	 * The contributed one is found by its annotation, so its bean name is arbitrary; of the other four,
+	 * refreshed() asks for hapiLoggingInterceptor and adminService by name and the remaining two by
+	 * type. Resource providers it resolves by type, and none here, which is a bundle with no providers
+	 * rather than a failure.
 	 */
 	private ContributedInterceptor withRefreshableContext() {
 		ContributedInterceptor contributed = withContextContaining("contributed", ContributedInterceptor.class);
@@ -284,11 +280,6 @@ public class FhirRestServletTest {
 		}
 	}
 	
-	/**
-	 * Carries a real hook because HAPI refuses an interceptor that has none: it logs "Interceptor
-	 * registered with no valid hooks" and moves on, so a bean annotated but hookless is silently absent
-	 * from the request path.
-	 */
 	@FhirInterceptor
 	public static class ContributedInterceptor {
 		

--- a/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
@@ -11,7 +11,11 @@ package org.openmrs.module.fhir2.web.servlet;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
@@ -24,6 +28,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.List;
 
 import ca.uhn.fhir.interceptor.api.Hook;
 import ca.uhn.fhir.interceptor.api.Pointcut;
@@ -38,6 +43,10 @@ import org.openmrs.api.AdministrationService;
 import org.openmrs.module.fhir2.FhirConstants;
 import org.openmrs.module.fhir2.api.FhirGlobalPropertyService;
 import org.openmrs.module.fhir2.api.annotations.FhirInterceptor;
+import org.openmrs.module.fhir2.web.authentication.RequireAuthenticationInterceptor;
+import org.openmrs.module.fhir2.web.util.DisableCacheInterceptor;
+import org.openmrs.module.fhir2.web.util.SummaryInterceptor;
+import org.openmrs.module.fhir2.web.util.SupportMergePatchInterceptor;
 import org.openmrs.util.OpenmrsClassLoader;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.context.support.GenericApplicationContext;
@@ -146,7 +155,7 @@ public class FhirRestServletTest {
 		
 		LoggingInterceptor loggingInterceptorBeforeInit = new LoggingInterceptor();
 		
-		RefreshableFhirRestServlet refreshable = new RefreshableFhirRestServlet();
+		R4ServletWithTestContext refreshable = new R4ServletWithTestContext();
 		refreshable.setGlobalPropertyService(globalPropertyService);
 		refreshable.setLoggingInterceptor(loggingInterceptorBeforeInit);
 		refreshable.setMessageSource(new StaticMessageSource());
@@ -156,14 +165,26 @@ public class FhirRestServletTest {
 		
 		refreshable.refreshed();
 		
-		assertThat(refreshable.getInterceptorService().getAllRegisteredInterceptors(), hasItem(contributed));
-		// the rebuilt context's logging interceptor is what shows the registry was actually torn down and
-		// rebuilt. The built-ins alone would not: had unregisterAllInterceptors() never run they would
-		// still be there from initialize(), so their presence tells the two cases apart not at all.
-		assertThat(refreshable.getInterceptorService().getAllRegisteredInterceptors(),
-		    hasItem(context.getBean("hapiLoggingInterceptor", LoggingInterceptor.class)));
-		assertThat(refreshable.getInterceptorService().getAllRegisteredInterceptors(),
-		    not(hasItem(loggingInterceptorBeforeInit)));
+		// the whole registry, not just the contributed one: the built-ins have to come back too, and
+		// nothing else here would notice if one stopped being registered. The absent pre-init logging
+		// interceptor is the assertion that shows the registry was torn down -- the rebuilt one's
+		// presence passes whether unregisterAllInterceptors() ran or not.
+		List<Object> afterRefresh = refreshable.getInterceptorService().getAllRegisteredInterceptors();
+		
+		// the built-ins have to come back too, and nothing else here would notice if one stopped being
+		// registered -- deleting RequireAuthenticationInterceptor from registerInterceptors() left this
+		// file green when the only assertion was about the contributed one
+		assertThat(afterRefresh,
+		    hasItems(instanceOf(RequireAuthenticationInterceptor.class), instanceOf(DisableCacheInterceptor.class),
+		        instanceOf(SummaryInterceptor.class), instanceOf(SupportMergePatchInterceptor.class)));
+		assertThat(afterRefresh, hasItem(sameInstance(contributed)));
+		assertThat(afterRefresh, hasItem(sameInstance(context.getBean("hapiLoggingInterceptor", LoggingInterceptor.class))));
+		// this is the assertion that shows the registry was torn down: the rebuilt logging interceptor's
+		// presence passes whether unregisterAllInterceptors() ran or not, the pre-init one's absence does
+		// not
+		assertThat(afterRefresh, not(hasItem(sameInstance(loggingInterceptorBeforeInit))));
+		// and nothing else, so a duplicate or a stray registration is caught rather than ignored
+		assertThat(afterRefresh, hasSize(6));
 	}
 	
 	/**
@@ -175,7 +196,7 @@ public class FhirRestServletTest {
 	public void initialize_shouldRegisterTheContributedInterceptorOnTheR3ServletToo() throws ServletException {
 		ContributedInterceptor contributed = withContextContaining("contributed", ContributedInterceptor.class);
 		
-		R3ServletReadingTheTestContext r3 = new R3ServletReadingTheTestContext();
+		R3ServletWithTestContext r3 = new R3ServletWithTestContext();
 		r3.setGlobalPropertyService(globalPropertyService);
 		r3.setLoggingInterceptor(new LoggingInterceptor());
 		r3.setMessageSource(new StaticMessageSource());
@@ -191,15 +212,12 @@ public class FhirRestServletTest {
 	 * none here, which is a bundle with no providers rather than a failure.
 	 */
 	private ContributedInterceptor withRefreshableContext() {
-		context = new GenericApplicationContext();
-		context.registerBeanDefinition("contributed",
-		    BeanDefinitionBuilder.genericBeanDefinition(ContributedInterceptor.class).getBeanDefinition());
+		ContributedInterceptor contributed = withContextContaining("contributed", ContributedInterceptor.class);
 		context.getBeanFactory().registerSingleton("hapiLoggingInterceptor", new LoggingInterceptor());
 		context.getBeanFactory().registerSingleton("adminService", mock(AdministrationService.class));
 		context.getBeanFactory().registerSingleton("fhirGlobalPropertyService", globalPropertyService);
 		context.getBeanFactory().registerSingleton("serverAddressStrategy", mock(IServerAddressStrategy.class));
-		context.refresh();
-		return context.getBean("contributed", ContributedInterceptor.class);
+		return contributed;
 	}
 	
 	private <T> T withContextContaining(String beanName, Class<T> beanClass) {
@@ -231,7 +249,7 @@ public class FhirRestServletTest {
 		}
 	}
 	
-	class R3ServletReadingTheTestContext extends FhirR3RestServlet {
+	class R3ServletWithTestContext extends FhirR3RestServlet {
 		
 		@Override
 		protected GenericApplicationContext getModuleApplicationContext() {
@@ -243,7 +261,7 @@ public class FhirRestServletTest {
 	 * Unlike {@link TestableFhirRestServlet} this leaves initialize() alone, because refreshed() does
 	 * nothing until initialize() has set the servlet started.
 	 */
-	class RefreshableFhirRestServlet extends FhirRestServlet {
+	class R4ServletWithTestContext extends FhirRestServlet {
 		
 		@Override
 		protected GenericApplicationContext getModuleApplicationContext() {

--- a/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
@@ -185,9 +185,10 @@ public class FhirRestServletTest {
 	}
 	
 	/**
-	 * A context carrying the contributed interceptor plus every bean refreshed() resolves by name or by
-	 * type. The contributed one is found by its annotation, so its bean name is arbitrary; the other
-	 * four are the names and types refreshed() asks for by hand.
+	 * A context carrying the contributed interceptor plus the four beans refreshed() throws without.
+	 * The contributed one is found by its annotation, so its bean name is arbitrary; the other four are
+	 * the names and types refreshed() asks for by hand. Resource providers it resolves by type, and
+	 * none here, which is a bundle with no providers rather than a failure.
 	 */
 	private ContributedInterceptor withRefreshableContext() {
 		context = new GenericApplicationContext();

--- a/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
@@ -86,8 +86,7 @@ public class FhirRestServletTest {
 		when(mockServletConfig.getServletContext()).thenReturn(mock(javax.servlet.ServletContext.class));
 		when(mockResponse.getWriter()).thenReturn(mockWriter);
 		
-		// the page sizes the module ships with; the paging provider rejects a size of zero, which is what
-		// an unstubbed mock would hand it
+		// the shipped defaults; the paging provider rejects the zero an unstubbed mock would hand it
 		when(globalPropertyService.getGlobalPropertyAsInteger(FhirConstants.OPENMRS_FHIR_DEFAULT_PAGE_SIZE, 10))
 		        .thenReturn(10);
 		when(globalPropertyService.getGlobalPropertyAsInteger(FhirConstants.OPENMRS_FHIR_MAXIMUM_PAGE_SIZE, 100))
@@ -133,10 +132,9 @@ public class FhirRestServletTest {
 	}
 	
 	/**
-	 * A bean carrying hook methods but not the annotation is an ordinary bean, and picking it up would
-	 * put every hook-bearing bean in every module into the FHIR request path without its author saying
-	 * so. It carries real hooks deliberately: HAPI refuses an interceptor with none, so a hookless bean
-	 * would pass this whether the annotation were honoured or not.
+	 * Picking up an unannotated bean would put every hook-bearing bean in every module into the FHIR
+	 * request path uninvited. The fixture carries real hooks because HAPI drops a hookless interceptor
+	 * anyway, so a hookless one would pass this whether the annotation were honoured or not.
 	 */
 	@Test
 	public void registerInterceptors_shouldIgnoreAHookBearingBeanThatIsNotAnnotated() {
@@ -149,10 +147,10 @@ public class FhirRestServletTest {
 	}
 	
 	/**
-	 * The two {@code registerInterceptors_should...} tests call that method directly, so they never run
-	 * unregisterAllInterceptors() and cannot tell "registered" apart from "survives being unregistered
-	 * and registered again" -- which is the whole defect. This one drives the real initialize() and
-	 * then the real refreshed(), the path a module start or stop actually takes.
+	 * The {@code registerInterceptors_should...} tests call that method directly, so they never reach
+	 * unregisterAllInterceptors() and cannot tell "registered" from "survives being unregistered and
+	 * registered again" -- the whole defect. This drives the real initialize() then the real
+	 * refreshed().
 	 */
 	@Test
 	public void refreshed_shouldStillHaveTheContributedInterceptorAfterAContextRefresh() throws ServletException {
@@ -172,26 +170,23 @@ public class FhirRestServletTest {
 		
 		List<Object> afterRefresh = refreshable.getInterceptorService().getAllRegisteredInterceptors();
 		
-		// the built-ins have to come back too, and nothing else here would notice if one stopped being
-		// registered -- deleting RequireAuthenticationInterceptor from registerInterceptors() left this
-		// file green when the only assertion was about the contributed one
+		// the built-ins have to come back too, and nothing else here would notice if one stopped
 		assertThat(afterRefresh,
 		    hasItems(instanceOf(RequireAuthenticationInterceptor.class), instanceOf(DisableCacheInterceptor.class),
 		        instanceOf(SummaryInterceptor.class), instanceOf(SupportMergePatchInterceptor.class)));
 		assertThat(afterRefresh, hasItem(contributed));
 		assertThat(afterRefresh, hasItem(sameInstance(context.getBean("hapiLoggingInterceptor", LoggingInterceptor.class))));
-		// this is the assertion that shows the registry was torn down: the rebuilt logging interceptor's
-		// presence passes whether unregisterAllInterceptors() ran or not, the pre-init one's absence does
-		// not
+		// the assertion that shows the registry was torn down -- the rebuilt one's presence above passes
+		// either way
 		assertThat(afterRefresh, not(hasItem(sameInstance(loggingInterceptorBeforeInit))));
 		// and nothing else, so a duplicate or a stray registration is caught rather than ignored
 		assertThat(afterRefresh, hasSize(6));
 	}
 	
 	/**
-	 * {@link FhirInterceptor} tells a module author its bean is picked up by every version-specific
-	 * servlet. FhirR3RestServlet keeps that by inheriting initialize(), so an override added there
-	 * later would drop contributed interceptors from the R3 API; this fails if one does.
+	 * {@link FhirInterceptor} promises a module author every version-specific servlet. R3 keeps that by
+	 * inheriting initialize(), so an override added there later would drop contributed interceptors
+	 * from the R3 API.
 	 */
 	@Test
 	public void initialize_shouldRegisterTheContributedInterceptorOnTheR3ServletToo() throws ServletException {
@@ -207,12 +202,10 @@ public class FhirRestServletTest {
 	}
 	
 	/**
-	 * The servlet keeps answering requests all through a refresh, and a request carrying no credentials
-	 * passes straight through AuthenticationFilter -- which only rejects one whose Basic credentials
-	 * fail -- so RequireAuthenticationInterceptor is what rejects it. The registry must not be left
-	 * empty while refreshed() rebuilds the providers, which runs every other module's provider
-	 * constructors and reads two global properties from the database. This provider reports what was
-	 * registered when it was built.
+	 * The servlet keeps answering through a refresh, and a request carrying no credentials passes
+	 * straight through AuthenticationFilter -- which rejects only a failed Basic one -- so
+	 * RequireAuthenticationInterceptor is what stops it. This provider reports the registry as it was
+	 * when refreshed() built it, in the middle of rebuilding the providers.
 	 */
 	@Test
 	public void refreshed_shouldKeepInterceptorsRegisteredWhileTheProvidersAreRebuilt() throws ServletException {
@@ -234,11 +227,9 @@ public class FhirRestServletTest {
 	}
 	
 	/**
-	 * A context carrying the contributed interceptor plus the four beans refreshed() throws without.
-	 * The contributed one is found by its annotation, so its bean name is arbitrary; of the other four,
-	 * refreshed() asks for hapiLoggingInterceptor and adminService by name and the remaining two by
-	 * type. Resource providers it resolves by type, and none here, which is a bundle with no providers
-	 * rather than a failure.
+	 * The contributed interceptor plus the four beans refreshed() throws without. It finds the
+	 * contributed one by annotation, so that bean name is arbitrary; of the rest it asks for
+	 * hapiLoggingInterceptor and adminService by name, the other two by type.
 	 */
 	private ContributedInterceptor withRefreshableContext() {
 		ContributedInterceptor contributed = withContextContaining("contributed", ContributedInterceptor.class);

--- a/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
+++ b/omod/src/test/java/org/openmrs/module/fhir2/web/servlet/FhirRestServletTest.java
@@ -11,6 +11,10 @@ package org.openmrs.module.fhir2.web.servlet;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
@@ -37,12 +41,22 @@ import java.util.List;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.interceptor.api.Hook;
+import ca.uhn.fhir.interceptor.api.Interceptor;
 import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.interceptor.executor.InterceptorService;
 import ca.uhn.fhir.rest.annotation.IdParam;
 import ca.uhn.fhir.rest.annotation.Read;
 import ca.uhn.fhir.rest.server.IResourceProvider;
 import ca.uhn.fhir.rest.server.IServerAddressStrategy;
 import ca.uhn.fhir.rest.server.interceptor.LoggingInterceptor;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.Property;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Patient;
@@ -55,6 +69,7 @@ import org.openmrs.api.AdministrationService;
 import org.openmrs.module.fhir2.FhirConstants;
 import org.openmrs.module.fhir2.api.FhirGlobalPropertyService;
 import org.openmrs.module.fhir2.api.annotations.FhirInterceptor;
+import org.openmrs.module.fhir2.api.annotations.R3Provider;
 import org.openmrs.module.fhir2.api.annotations.R4Provider;
 import org.openmrs.module.fhir2.web.authentication.RequireAuthenticationInterceptor;
 import org.openmrs.module.fhir2.web.util.DisableCacheInterceptor;
@@ -285,6 +300,279 @@ public class FhirRestServletTest {
 		assertThat(refreshable.getResourceProviders(), hasSize(1));
 	}
 	
+	@Test
+	public void registerInterceptors_shouldNotRegisterAnInterceptorThatWouldSortAheadOfTheBuiltIns() {
+		JumpsTheQueueInterceptor byType = withContextContaining("byType", JumpsTheQueueInterceptor.class);
+		context.registerBeanDefinition("byHook",
+		    BeanDefinitionBuilder.genericBeanDefinition(HookJumpsTheQueueInterceptor.class).getBeanDefinition());
+		HookJumpsTheQueueInterceptor byHook = context.getBean("byHook", HookJumpsTheQueueInterceptor.class);
+		// a well-ordered bean alongside them: rejecting one must not suppress the rest
+		context.registerBeanDefinition("contributed",
+		    BeanDefinitionBuilder.genericBeanDefinition(ContributedInterceptor.class).getBeanDefinition());
+		ContributedInterceptor accepted = context.getBean("contributed", ContributedInterceptor.class);
+		
+		servlet.setLoggingInterceptor(new LoggingInterceptor());
+		servlet.registerInterceptors();
+		
+		List<Object> registered = servlet.getInterceptorService().getAllRegisteredInterceptors();
+		assertThat(registered, not(hasItem(byType)));
+		assertThat(registered, not(hasItem(byHook)));
+		assertThat(registered, hasItem(accepted));
+		assertThat(registered, hasItem(instanceOf(RequireAuthenticationInterceptor.class)));
+	}
+	
+	/**
+	 * The invariant is about the moment an interceptor comes off, not the state either side of the
+	 * refresh, so this watches every unregistration rather than comparing before and after.
+	 */
+	@Test
+	public void refreshed_shouldNeverLeaveTheServletWithoutAnAuthenticationInterceptor() throws ServletException {
+		withRefreshableContext();
+		
+		AuthenticationWatchingInterceptorService interceptorService = new AuthenticationWatchingInterceptorService();
+		
+		R4ServletWithTestContext refreshable = new R4ServletWithTestContext();
+		refreshable.setInterceptorService(interceptorService);
+		refreshable.setGlobalPropertyService(globalPropertyService);
+		refreshable.setLoggingInterceptor(new LoggingInterceptor());
+		refreshable.setMessageSource(new StaticMessageSource());
+		refreshable.init(mockServletConfig);
+		
+		refreshable.refreshed();
+		
+		assertThat(interceptorService.authenticatedAtEachUnregister, not(empty()));
+		assertThat(interceptorService.authenticatedAtEachUnregister, everyItem(is(true)));
+		assertThat(refreshable.getInterceptorService().getAllRegisteredInterceptors(),
+		    hasItem(instanceOf(RequireAuthenticationInterceptor.class)));
+	}
+	
+	/**
+	 * A refresh that does not rebuild the Spring context hands back the same hapiLoggingInterceptor
+	 * singleton, which the previous set also holds.
+	 */
+	@Test
+	public void refreshed_shouldKeepALoggingInterceptorTheContextHandsBackUnchanged() throws ServletException {
+		withRefreshableContext();
+		LoggingInterceptor fromContext = context.getBean("hapiLoggingInterceptor", LoggingInterceptor.class);
+		
+		R4ServletWithTestContext refreshable = new R4ServletWithTestContext();
+		refreshable.setGlobalPropertyService(globalPropertyService);
+		refreshable.setLoggingInterceptor(fromContext);
+		refreshable.setMessageSource(new StaticMessageSource());
+		refreshable.init(mockServletConfig);
+		
+		refreshable.refreshed();
+		
+		assertThat(refreshable.getInterceptorService().getAllRegisteredInterceptors(), hasItem(sameInstance(fromContext)));
+	}
+	
+	/**
+	 * The servlet unregisters only what it registered, so an interceptor another module put on the
+	 * servlet directly outlives a refresh.
+	 */
+	@Test
+	public void refreshed_shouldLeaveAnInterceptorRegisteredOutsideTheServletAlone() throws ServletException {
+		withRefreshableContext();
+		
+		R4ServletWithTestContext refreshable = new R4ServletWithTestContext();
+		refreshable.setGlobalPropertyService(globalPropertyService);
+		refreshable.setLoggingInterceptor(new LoggingInterceptor());
+		refreshable.setMessageSource(new StaticMessageSource());
+		refreshable.init(mockServletConfig);
+		
+		ContributedInterceptor outsider = new ContributedInterceptor();
+		refreshable.registerInterceptor(outsider);
+		
+		refreshable.refreshed();
+		
+		assertThat(refreshable.getInterceptorService().getAllRegisteredInterceptors(), hasItem(sameInstance(outsider)));
+	}
+	
+	/**
+	 * Surviving a refresh must not also mean overtaking authentication. The rebuilt interceptors are
+	 * appended, so an outsider registered at the default order keeps an earlier slot in HAPI's list and
+	 * only the reserved order on RequireAuthenticationInterceptor holds it back. An outsider that
+	 * declares a lower order still wins; nothing here screens what it did not register.
+	 */
+	@Test
+	public void refreshed_shouldRejectAnUnauthenticatedRequestBeforeAnOutsideInterceptorSeesIt()
+	        throws ServletException, IOException {
+		withRefreshableContext();
+		
+		R4ServletWithTestContext refreshable = new R4ServletWithTestContext();
+		refreshable.setGlobalPropertyService(globalPropertyService);
+		refreshable.setLoggingInterceptor(new LoggingInterceptor());
+		refreshable.setMessageSource(new StaticMessageSource());
+		refreshable.init(mockServletConfig);
+		
+		ContributedInterceptor outsider = new ContributedInterceptor();
+		refreshable.registerInterceptor(outsider);
+		
+		refreshable.refreshed();
+		
+		givenARequestFor("/fhir2Servlet/Patient/1");
+		refreshable.service(mockRequest, mockResponse);
+		
+		verify(mockResponse).sendError(HttpServletResponse.SC_UNAUTHORIZED, "Not authenticated");
+		assertThat(outsider.sawRequest, is(false));
+	}
+	
+	/**
+	 * The sibling test asserting a contributed interceptor does not see an unauthenticated request
+	 * would pass just as well if contributed hooks never dispatched at all; /metadata is the path
+	 * RequireAuthenticationInterceptor lets through.
+	 */
+	@Test
+	public void refreshed_shouldDispatchToAContributedInterceptorOnAnExemptRequest() throws ServletException, IOException {
+		ContributedInterceptor contributed = withRefreshableContext();
+		
+		R4ServletWithTestContext refreshable = new R4ServletWithTestContext();
+		refreshable.setFhirContext(FhirContext.forR4());
+		refreshable.setGlobalPropertyService(globalPropertyService);
+		refreshable.setLoggingInterceptor(new LoggingInterceptor());
+		refreshable.setMessageSource(new StaticMessageSource());
+		refreshable.init(mockServletConfig);
+		refreshable.refreshed();
+		
+		givenARequestFor("/fhir2Servlet/metadata");
+		refreshable.service(mockRequest, mockResponse);
+		
+		assertThat(contributed.sawRequest, is(true));
+	}
+	
+	/**
+	 * A contributed bean HAPI cannot scan is third-party code failing, not a reason to abandon the
+	 * rebuild: the beans after it still register and the built-ins are not left doubled up.
+	 */
+	@Test
+	public void refreshed_shouldNotDuplicateTheBuiltInsWhenAContributedInterceptorCannotBeRegistered()
+	        throws ServletException {
+		context = new GenericApplicationContext();
+		// declared first, so a rebuild that gave up on the first failure would drop "contributed"
+		context.registerBeanDefinition("badHook",
+		    BeanDefinitionBuilder.genericBeanDefinition(BadHookSignatureInterceptor.class).getBeanDefinition());
+		context.registerBeanDefinition("contributed",
+		    BeanDefinitionBuilder.genericBeanDefinition(ContributedInterceptor.class).getBeanDefinition());
+		context.refresh();
+		withRefreshableSingletons();
+		ContributedInterceptor contributed = context.getBean("contributed", ContributedInterceptor.class);
+		
+		R4ServletWithTestContext refreshable = new R4ServletWithTestContext();
+		refreshable.setGlobalPropertyService(globalPropertyService);
+		refreshable.setLoggingInterceptor(new LoggingInterceptor());
+		refreshable.setMessageSource(new StaticMessageSource());
+		refreshable.init(mockServletConfig);
+		
+		// twice, because a set orphaned by a throw only becomes visible on the refresh after it
+		refreshable.refreshed();
+		refreshable.refreshed();
+		
+		assertThat(countRegistered(refreshable, RequireAuthenticationInterceptor.class), is(1L));
+		assertThat(countRegistered(refreshable, DisableCacheInterceptor.class), is(1L));
+		assertThat(countRegistered(refreshable, SummaryInterceptor.class), is(1L));
+		assertThat(countRegistered(refreshable, SupportMergePatchInterceptor.class), is(1L));
+		assertThat(refreshable.getInterceptorService().getAllRegisteredInterceptors(), hasItem(contributed));
+	}
+	
+	/**
+	 * getResourceProviderAnnotation() is overridden on the R3 servlet but read only from refreshed(),
+	 * so no other test in this class reaches the override.
+	 */
+	@Test
+	public void refreshed_shouldRegisterOnlyR3ProvidersOnTheR3Servlet() throws ServletException {
+		withRefreshableContext();
+		context.registerBeanDefinition("r3PatientProvider",
+		    BeanDefinitionBuilder.genericBeanDefinition(R3PatientProvider.class).getBeanDefinition());
+		context.registerBeanDefinition("r4PatientProvider",
+		    BeanDefinitionBuilder.genericBeanDefinition(ReadablePatientProvider.class).getBeanDefinition());
+		
+		R3ServletWithTestContext r3 = new R3ServletWithTestContext();
+		r3.setFhirContext(FhirContext.forDstu3());
+		r3.setGlobalPropertyService(globalPropertyService);
+		r3.setLoggingInterceptor(new LoggingInterceptor());
+		r3.setMessageSource(new StaticMessageSource());
+		r3.init(mockServletConfig);
+		
+		r3.refreshed();
+		
+		assertThat(r3.getResourceProviders(), hasSize(1));
+		assertThat(r3.getResourceProviders(), hasItem(instanceOf(R3PatientProvider.class)));
+	}
+	
+	/** refreshed() reaches a servlet the container has not initialized yet, and must no-op. */
+	@Test
+	public void refreshed_shouldDoNothingBeforeTheServletIsInitialized() {
+		withRefreshableContext();
+		
+		R4ServletWithTestContext neverInitialized = new R4ServletWithTestContext();
+		neverInitialized.setGlobalPropertyService(globalPropertyService);
+		
+		neverInitialized.refreshed();
+		
+		assertThat(neverInitialized.getInterceptorService().getAllRegisteredInterceptors(), is(empty()));
+	}
+	
+	/**
+	 * HAPI drops a hookless interceptor with only a WARN naming the runtime class, which for a proxied
+	 * bean is a synthetic name that says nothing about FHIR2. The module's own error is the only thing
+	 * that ties the drop back to a bean an author can go and fix, so it is the behaviour worth pinning.
+	 */
+	@Test
+	public void registerInterceptors_shouldReportAContributedBeanHapiRefusesToRegister() {
+		withContextContaining("hookless", HooklessInterceptor.class);
+		
+		servlet.setLoggingInterceptor(new LoggingInterceptor());
+		
+		List<String> errors = new ArrayList<>();
+		Appender appender = collectErrorsInto(errors);
+		try {
+			servlet.registerInterceptors();
+		}
+		finally {
+			stopCollecting(appender);
+		}
+		
+		assertThat(errors, hasItem(allOf(containsString("hookless"), containsString("@Hook"))));
+	}
+	
+	private Appender collectErrorsInto(List<String> errors) {
+		Appender appender = new AbstractAppender("collectErrors", null, null, true, Property.EMPTY_ARRAY) {
+			
+			@Override
+			public void append(LogEvent event) {
+				if (event.getLevel() == Level.ERROR) {
+					errors.add(event.getMessage().getFormattedMessage());
+				}
+			}
+		};
+		appender.start();
+		loggerConfigFor(FhirRestServlet.class).addAppender(appender, Level.ERROR, null);
+		return appender;
+	}
+	
+	private void stopCollecting(Appender appender) {
+		loggerConfigFor(FhirRestServlet.class).removeAppender(appender.getName());
+		appender.stop();
+	}
+	
+	private LoggerConfig loggerConfigFor(Class<?> type) {
+		LoggerContext loggerContext = (LoggerContext) LogManager.getContext(false);
+		return loggerContext.getConfiguration().getLoggerConfig(type.getName());
+	}
+	
+	private long countRegistered(FhirRestServlet servlet, Class<?> type) {
+		return servlet.getInterceptorService().getAllRegisteredInterceptors().stream().filter(type::isInstance).count();
+	}
+	
+	private void givenARequestFor(String uri) {
+		when(mockRequest.getMethod()).thenReturn("GET");
+		when(mockRequest.getRequestURI()).thenReturn(uri);
+		when(mockRequest.getRequestURL()).thenReturn(new StringBuffer("http://localhost" + uri));
+		when(mockRequest.getServletPath()).thenReturn("");
+		when(mockRequest.getContextPath()).thenReturn("");
+		when(mockRequest.getQueryString()).thenReturn("");
+	}
+	
 	private int bindingCountFor(FhirRestServlet servlet, String resourceName) {
 		return servlet.getResourceBindings().stream().filter(b -> resourceName.equals(b.getResourceName()))
 		        .mapToInt(b -> b.getMethodBindings().size()).sum();
@@ -296,11 +584,15 @@ public class FhirRestServletTest {
 	 */
 	private ContributedInterceptor withRefreshableContext() {
 		ContributedInterceptor contributed = withContextContaining("contributed", ContributedInterceptor.class);
+		withRefreshableSingletons();
+		return contributed;
+	}
+	
+	private void withRefreshableSingletons() {
 		context.getBeanFactory().registerSingleton("hapiLoggingInterceptor", new LoggingInterceptor());
 		context.getBeanFactory().registerSingleton("adminService", mock(AdministrationService.class));
 		context.getBeanFactory().registerSingleton("fhirGlobalPropertyService", globalPropertyService);
 		context.getBeanFactory().registerSingleton("serverAddressStrategy", mock(IServerAddressStrategy.class));
-		return contributed;
 	}
 	
 	private <T> T withContextContaining(String beanName, Class<T> beanClass) {
@@ -360,6 +652,76 @@ public class FhirRestServletTest {
 		public boolean incomingRequest(HttpServletRequest request, HttpServletResponse response) {
 			sawRequest = true;
 			return true;
+		}
+	}
+	
+	/** Declares the order on the type, which is what HAPI reads when no hook overrides it. */
+	@FhirInterceptor
+	@Interceptor(order = -1)
+	public static class JumpsTheQueueInterceptor {
+		
+		@Hook(Pointcut.SERVER_INCOMING_REQUEST_PRE_PROCESSED)
+		public boolean incomingRequest(HttpServletRequest request, HttpServletResponse response) {
+			return true;
+		}
+	}
+	
+	/** The hook order wins over the type's, so a type-level check alone would let this through. */
+	@FhirInterceptor
+	public static class HookJumpsTheQueueInterceptor {
+		
+		@Hook(value = Pointcut.SERVER_INCOMING_REQUEST_PRE_PROCESSED, order = -1)
+		public boolean incomingRequest(HttpServletRequest request, HttpServletResponse response) {
+			return true;
+		}
+	}
+	
+	/** HAPI rejects a hook that returns anything but boolean or void, throwing as it is registered. */
+	@FhirInterceptor
+	public static class BadHookSignatureInterceptor {
+		
+		@Hook(Pointcut.SERVER_INCOMING_REQUEST_PRE_PROCESSED)
+		public String incomingRequest(HttpServletRequest request, HttpServletResponse response) {
+			return "not a boolean";
+		}
+	}
+	
+	/** Annotated, but nothing for HAPI to scan - the shape an interface-proxied bean presents. */
+	@FhirInterceptor
+	public static class HooklessInterceptor {
+		
+		public boolean incomingRequest(HttpServletRequest request, HttpServletResponse response) {
+			return true;
+		}
+	}
+	
+	@R3Provider
+	public static class R3PatientProvider implements IResourceProvider {
+		
+		@Read
+		public org.hl7.fhir.dstu3.model.Patient read(@IdParam org.hl7.fhir.dstu3.model.IdType id) {
+			return new org.hl7.fhir.dstu3.model.Patient();
+		}
+		
+		@Override
+		public Class<? extends IBaseResource> getResourceType() {
+			return org.hl7.fhir.dstu3.model.Patient.class;
+		}
+	}
+	
+	/**
+	 * Records, at each unregistration, whether an authentication interceptor other than the one being
+	 * removed is still on the server.
+	 */
+	static class AuthenticationWatchingInterceptorService extends InterceptorService {
+		
+		final List<Boolean> authenticatedAtEachUnregister = new ArrayList<>();
+		
+		@Override
+		public boolean unregisterInterceptor(Object theInterceptor) {
+			authenticatedAtEachUnregister.add(getAllRegisteredInterceptors().stream()
+			        .anyMatch(i -> i != theInterceptor && i instanceof RequireAuthenticationInterceptor));
+			return super.unregisterInterceptor(theInterceptor);
 		}
 	}
 	


### PR DESCRIPTION
https://openmrs.atlassian.net/browse/FM2-698

## What the ticket asked

`FhirRestServlet.refreshed()` called `unregisterAllInterceptors()` and then re-registered a fixed set
of interceptors, so an interceptor another module had registered was silently dropped — and that
happens on every OpenMRS context refresh, which is every module start or stop. The ticket asks for an
extension point that survives it, contributed through Spring the way resource providers already are,
without anyone having to subclass `FhirRestServlet`.

## What this does

`@FhirInterceptor` marks a Spring bean as a HAPI interceptor to register, beside the existing
`@R3Provider` / `@R4Provider`. `FhirRestServlet.registerInterceptors()` registers this module's own
interceptors and then every `@FhirInterceptor` bean in the application context, and both
`initialize()` and `refreshed()` call it.

The beans are re-resolved from the refreshed context on every call rather than captured once. The
ticket proposes the other shape — "the configured interceptors should be retained by the servlet" —
and that shape silently loses the case the ticket exists for, because a module that starts *after*
fhir2 has no beans in the context at `initialize()` time. Re-resolving picks it up. OpenMRS also
constructs a new servlet instance on module restart, so nothing held in a field would have survived
anyway. `refreshed_shouldRegisterAContributedInterceptorThatReachedTheContextAfterInitialize` pins
this; it was checked by building the captured-collection design and confirming it was the only test
of the eight to fail.

`getModuleApplicationContext()` is a seam over `FhirActivator`'s static context, read by
`registerInterceptors()`, `refreshed()` and `autoInject()`, and overridden by the tests.

## Three fixes beyond the ticket

Reviewing and verifying this change turned up three defects in the code it touches. Each is a
separate commit with its own regression test, and each was watched failing before the fix.

**1. Every module start or stop left the FHIR API returning 404 for every resource.**
`refreshed()` called `unregisterAllProviders()`, which destroys the method bindings a read routes on,
and then `setResourceProviders(...)`, whose whole body is validate / `clear()` / `addAll()` on a
field. Nothing rebound, because binding happens in `RestfulServer.init()`, which a module lifecycle
callback never reaches. `/metadata` kept returning 200 throughout, because the conformance provider is
bound separately — so the obvious health check stayed green while every read failed, and it did not
recover until the webapp was reloaded. Now `registerProviders(...)`, which adds to the field *and*
calls `findResourceMethods`, and which also re-runs the provider `@Initialize` methods that
`unregisterAllProviders()` had just destroyed. Present since `refreshed()` was introduced in
`4289a669` (FM2-163, April 2021); reproduced on unmodified 4.2.0, so not caused by this PR.

**2. A request arriving mid-refresh was served with no authentication.**
`refreshed()` unregistered every interceptor at the top of its block and did not put them back until
the bottom, with the provider rebuild and two uncached global-property reads in between. The servlet
keeps answering throughout, and a request carrying no credentials passes straight through
`AuthenticationFilter`, which rejects only a request whose Basic credentials fail. The window
predates this change, but moving the contributed-bean lookup to the end of the block widened it, so
the teardown and rebuild are now adjacent, with `RequireAuthenticationInterceptor` registered first
within the rebuild. Adjacency narrows the window to two statements rather than closing it; closing it
would mean populating a fresh `InterceptorService` and swapping it in with `setInterceptorService`,
which is a bigger change than this ticket justifies.

**3. One servlet's failure left the other un-refreshed.**
`FhirActivator` dispatched lifecycle events with `lifecycleListeners.forEach(...)`, which aborts at
the first listener that throws — and both FHIR servlets register as listeners. All five dispatch
sites now log and continue.

## The decision a reviewer should confirm

A contributed bean that cannot be supplied is deliberately not caught. That choice is inherited, not
new here, but this change is what first puts another module's code on the `initialize()` path, and the
blast radius there is larger than it looks: at server startup the `ModuleException` escapes
`Listener.performWebStartOfModules`, whose tail loop is unguarded, and aborts the whole OpenMRS boot
rather than just this module. Only a bean whose creation is deferred past the context refresh — lazy,
prototype or scoped — can reach that path; a plain singleton fails the context refresh first. If that
trade is not wanted, the fix is to catch and log around the contributed lookup in `initialize()` only.

Two facts a module author may want that are deliberately not in the annotation's javadoc, because
nothing can falsify them there: a contributed bean declaring a negative `@Interceptor(order)` runs
ahead of this module's own interceptors, authentication included, since those all leave order at 0;
and on `Pointcut.SERVER_INCOMING_REQUEST_PRE_PROCESSED`, which is handed no `RequestDetails`,
`FhirVersionUtils.getFhirVersion(request)` is how to tell R3 from R4.

## How it was verified

Every test here was watched failing on the pre-change code and then checked by mutation: revert the
behaviour it covers and confirm that test, and no other, goes red. To check one yourself, mutate the
line it covers and read which test fails. `mvn clean install` is green from the repository root.

Fix 1 was then verified on a running OpenMRS 2.8.8 reference-application backend, against a control.
Both builds were pinned by sha256 at every path the module can load from, and the module's own version
was read back over REST rather than inferred from the filename.

On the stock shipped 4.2.0, an authenticated `GET /ws/fhir2/R4/Patient?_count=1` returned a Bundle of
50. Restarting one unrelated started module (`teleconsultation`) via `POST /ws/rest/v1/moduleaction`
returned 201, and the log shows the context refresh running to completion. Reading the same URL
afterwards returned **404**, body `HAPI-0302: Unknown resource type 'Patient' - Server knows how to
handle: [OperationDefinition]`, and the R3 equivalent likewise. `/R4/metadata` stayed 200 throughout,
which is what makes the outage invisible to a health check.

On this branch the identical sequence returns **200** afterwards, on both R4 and R3, and `HAPI-0302`
does not appear in the log at all.

Authentication was checked on the same deployment: unauthenticated `/R4/Patient` is 401, authenticated
is 200, and unauthenticated `/R4/metadata` and `/R4/.well-known/smart-configuration` are both 200. That
split is the discriminator, since a servlet filter would have rejected all three, so the 401 is
produced inside the interceptor chain. The contributed-bean lookup ran against a real context holding
no `@FhirInterceptor` beans and left the boot clean.

Two facts a module author may want, kept here rather than in the annotation's javadoc because nothing
in the code can falsify them: a contributed bean declaring a negative `@Interceptor(order)` runs ahead
of this module's own interceptors, authentication included, since those all leave order at 0; and a
contributed bean whose constructor throws is deliberately not caught, so from `initialize()` at server
startup it aborts OpenMRS boot rather than coming up with that interceptor quietly missing.
