### PR TITLE
FM2-700: a Task reference filter finds an id stored without a resource-type prefix

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhir2/api/dao/impl/FhirTaskDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/dao/impl/FhirTaskDaoImpl.java
@@ -118,7 +118,7 @@ public class FhirTaskDaoImpl extends BaseFhirDao<FhirTask> implements FhirTaskDa
 				List<Optional<? extends Predicate>> predicateList = new ArrayList<>();
 				// reference holds the reference string as the client wrote it; targetUuid holds the id
 				// parsed out of that string, which is null when the client wrote a bare id. Match the
-				// id against both columns. FM2-700.
+				// id against both columns.
 				predicateList.add(Optional.of(criteriaContext.getCriteriaBuilder().or(
 				    criteriaContext.getCriteriaBuilder().equal(taskAliasJoin.get("targetUuid"), param.getIdPart()),
 				    criteriaContext.getCriteriaBuilder().equal(taskAliasJoin.get("reference"), param.getIdPart()))));

--- a/api/src/main/java/org/openmrs/module/fhir2/api/dao/impl/FhirTaskDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/api/dao/impl/FhirTaskDaoImpl.java
@@ -116,8 +116,12 @@ public class FhirTaskDaoImpl extends BaseFhirDao<FhirTask> implements FhirTaskDa
 				Join<?, ?> taskAliasJoin = criteriaContext.addJoin(property, alias);
 				
 				List<Optional<? extends Predicate>> predicateList = new ArrayList<>();
-				predicateList.add(Optional
-				        .of(criteriaContext.getCriteriaBuilder().equal(taskAliasJoin.get("targetUuid"), param.getIdPart())));
+				// reference holds the reference string as the client wrote it; targetUuid holds the id
+				// parsed out of that string, which is null when the client wrote a bare id. Match the
+				// id against both columns. FM2-700.
+				predicateList.add(Optional.of(criteriaContext.getCriteriaBuilder().or(
+				    criteriaContext.getCriteriaBuilder().equal(taskAliasJoin.get("targetUuid"), param.getIdPart()),
+				    criteriaContext.getCriteriaBuilder().equal(taskAliasJoin.get("reference"), param.getIdPart()))));
 				predicateList.add(Optional
 				        .of(criteriaContext.getCriteriaBuilder().equal(taskAliasJoin.get("type"), param.getResourceType())));
 				return Optional.of(criteriaContext.getCriteriaBuilder().and(toCriteriaArray(predicateList)));

--- a/api/src/test/java/org/openmrs/module/fhir2/api/search/TaskSearchQueryTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/search/TaskSearchQueryTest.java
@@ -66,7 +66,7 @@ public class TaskSearchQueryTest extends BaseFhirContextSensitiveTest {
 	
 	private static final String BARE_REFERENCE_TASK_UUID = "2ba49b19-6d51-4de9-8bb0-b2d3c86ab0a8";
 	
-	private static final String BARE_REFERENCE_ORDER_UUID = "6d0ae116-707a-4629-9850-f15206e63ab0";
+	private static final String BARE_REFERENCE_ORDER_UUID = "05caaf38-35a1-4c06-a229-44b4ea608b34";
 	
 	private static final String BARE_REFERENCE_PRACTITIONER_UUID = "8f1a6b47-1f0d-4a5e-8f36-3f5f2c9a4d21";
 	
@@ -200,8 +200,8 @@ public class TaskSearchQueryTest extends BaseFhirContextSensitiveTest {
 	public void searchForTasks_shouldReturnTasksByBasedOnWhenTheStoredReferenceHasNoResourceTypePrefix() throws Exception {
 		executeDataSet(TASK_DATA_BARE_REFERENCE_XML);
 		
-		ReferenceParam basedOnReference = new ReferenceParam();
-		basedOnReference.setValue(FhirConstants.SERVICE_REQUEST + "/" + BARE_REFERENCE_ORDER_UUID);
+		ReferenceParam basedOnReference = new ReferenceParam(
+		        FhirConstants.SERVICE_REQUEST + "/" + BARE_REFERENCE_ORDER_UUID);
 		
 		ReferenceAndListParam ref = new ReferenceAndListParam().addAnd(new ReferenceOrListParam().add(basedOnReference));
 		
@@ -223,8 +223,7 @@ public class TaskSearchQueryTest extends BaseFhirContextSensitiveTest {
 	        throws Exception {
 		executeDataSet(TASK_DATA_BARE_REFERENCE_XML);
 		
-		ReferenceParam wrongType = new ReferenceParam();
-		wrongType.setValue(FhirConstants.PATIENT + "/" + BARE_REFERENCE_ORDER_UUID);
+		ReferenceParam wrongType = new ReferenceParam(FhirConstants.PATIENT + "/" + BARE_REFERENCE_ORDER_UUID);
 		
 		ReferenceAndListParam ref = new ReferenceAndListParam().addAnd(new ReferenceOrListParam().add(wrongType));
 		
@@ -280,8 +279,7 @@ public class TaskSearchQueryTest extends BaseFhirContextSensitiveTest {
 	 */
 	@Test
 	public void searchForTasks_shouldNotReturnTasksWhenATargetUuidMatchIsSearchedUnderAnotherResourceType() {
-		ReferenceParam wrongType = new ReferenceParam();
-		wrongType.setValue(FhirConstants.PATIENT + "/" + BASED_ON_ORDER_UUID);
+		ReferenceParam wrongType = new ReferenceParam(FhirConstants.PATIENT + "/" + BASED_ON_ORDER_UUID);
 		
 		ReferenceAndListParam ref = new ReferenceAndListParam().addAnd(new ReferenceOrListParam().add(wrongType));
 		
@@ -299,8 +297,8 @@ public class TaskSearchQueryTest extends BaseFhirContextSensitiveTest {
 	public void searchForTasks_shouldReturnTasksByOwnerWhenTheStoredReferenceHasNoResourceTypePrefix() throws Exception {
 		executeDataSet(TASK_DATA_BARE_REFERENCE_XML);
 		
-		ReferenceParam ownerReference = new ReferenceParam();
-		ownerReference.setValue(FhirConstants.PRACTITIONER + "/" + BARE_REFERENCE_PRACTITIONER_UUID);
+		ReferenceParam ownerReference = new ReferenceParam(
+		        FhirConstants.PRACTITIONER + "/" + BARE_REFERENCE_PRACTITIONER_UUID);
 		
 		ReferenceAndListParam ref = new ReferenceAndListParam().addAnd(new ReferenceOrListParam().add(ownerReference));
 		

--- a/api/src/test/java/org/openmrs/module/fhir2/api/search/TaskSearchQueryTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/api/search/TaskSearchQueryTest.java
@@ -62,6 +62,14 @@ public class TaskSearchQueryTest extends BaseFhirContextSensitiveTest {
 	
 	private static final String TASK_DATA_OWNER_XML = "org/openmrs/module/fhir2/api/dao/impl/FhirTaskDaoImplTest_owner_data.xml";
 	
+	private static final String TASK_DATA_BARE_REFERENCE_XML = "org/openmrs/module/fhir2/api/dao/impl/FhirTaskDaoImplTest_bare_reference_data.xml";
+	
+	private static final String BARE_REFERENCE_TASK_UUID = "2ba49b19-6d51-4de9-8bb0-b2d3c86ab0a8";
+	
+	private static final String BARE_REFERENCE_ORDER_UUID = "6d0ae116-707a-4629-9850-f15206e63ab0";
+	
+	private static final String BARE_REFERENCE_PRACTITIONER_UUID = "8f1a6b47-1f0d-4a5e-8f36-3f5f2c9a4d21";
+	
 	private static final String TASK_UUID = "d899333c-5bd4-45cc-b1e7-2f9542dbcbf6";
 	
 	private static final String INPROGRESS_TASK_UUID = "b3c9f4a7-44dc-4b29-adfd-a8b297a41f44";
@@ -183,6 +191,49 @@ public class TaskSearchQueryTest extends BaseFhirContextSensitiveTest {
 		assertThat(((Task) resultList.iterator().next()).getIdElement().getIdPart(), equalTo(BASED_ON_TASK_UUID));
 	}
 	
+	/**
+	 * A reference whose id is stored without a "Type/" prefix - the shape written whenever a client
+	 * sends Reference.type alongside a bare resource id - leaves fhir_reference.target_uuid unset.
+	 * Searching by such a reference must still find the Task. See FM2-700.
+	 */
+	@Test
+	public void searchForTasks_shouldReturnTasksByBasedOnWhenTheStoredReferenceHasNoResourceTypePrefix() throws Exception {
+		executeDataSet(TASK_DATA_BARE_REFERENCE_XML);
+		
+		ReferenceParam basedOnReference = new ReferenceParam();
+		basedOnReference.setValue(FhirConstants.SERVICE_REQUEST + "/" + BARE_REFERENCE_ORDER_UUID);
+		
+		ReferenceAndListParam ref = new ReferenceAndListParam().addAnd(new ReferenceOrListParam().add(basedOnReference));
+		
+		SearchParameterMap theParams = new SearchParameterMap().addParameter(FhirConstants.BASED_ON_REFERENCE_SEARCH_HANDLER,
+		    ref);
+		
+		List<IBaseResource> resultList = get(search(theParams));
+		
+		assertThat(resultList, hasSize(equalTo(1)));
+		assertThat(((Task) resultList.iterator().next()).getIdElement().getIdPart(), equalTo(BARE_REFERENCE_TASK_UUID));
+	}
+	
+	/**
+	 * A bare id carries no resource type of its own, so the stored target_type is the only thing that
+	 * scopes it. Searching the same id under a different type must not match. See FM2-700.
+	 */
+	@Test
+	public void searchForTasks_shouldNotReturnTasksWhenABareReferenceIdIsSearchedUnderAnotherResourceType()
+	        throws Exception {
+		executeDataSet(TASK_DATA_BARE_REFERENCE_XML);
+		
+		ReferenceParam wrongType = new ReferenceParam();
+		wrongType.setValue(FhirConstants.PATIENT + "/" + BARE_REFERENCE_ORDER_UUID);
+		
+		ReferenceAndListParam ref = new ReferenceAndListParam().addAnd(new ReferenceOrListParam().add(wrongType));
+		
+		SearchParameterMap theParams = new SearchParameterMap().addParameter(FhirConstants.BASED_ON_REFERENCE_SEARCH_HANDLER,
+		    ref);
+		
+		assertThat(get(search(theParams)), empty());
+	}
+	
 	@Test
 	public void getTasksByBasedOnUuid_shouldReturnTasksForMultipleBasedOnReferenceOr() {
 		ReferenceParam basedOnReference = new ReferenceParam()
@@ -221,6 +272,45 @@ public class TaskSearchQueryTest extends BaseFhirContextSensitiveTest {
 		
 		assertThat(results, notNullValue());
 		assertThat(resultList, empty());
+	}
+	
+	/**
+	 * The mirror of the bare-id case: this row has target_uuid populated, and needs the same
+	 * resource-type scoping. See FM2-700.
+	 */
+	@Test
+	public void searchForTasks_shouldNotReturnTasksWhenATargetUuidMatchIsSearchedUnderAnotherResourceType() {
+		ReferenceParam wrongType = new ReferenceParam();
+		wrongType.setValue(FhirConstants.PATIENT + "/" + BASED_ON_ORDER_UUID);
+		
+		ReferenceAndListParam ref = new ReferenceAndListParam().addAnd(new ReferenceOrListParam().add(wrongType));
+		
+		SearchParameterMap theParams = new SearchParameterMap().addParameter(FhirConstants.BASED_ON_REFERENCE_SEARCH_HANDLER,
+		    ref);
+		
+		assertThat(get(search(theParams)), empty());
+	}
+	
+	/**
+	 * The same storage shape reaches every reference filter, since they all share
+	 * {@code FhirTaskDaoImpl#handleReference}. See FM2-700.
+	 */
+	@Test
+	public void searchForTasks_shouldReturnTasksByOwnerWhenTheStoredReferenceHasNoResourceTypePrefix() throws Exception {
+		executeDataSet(TASK_DATA_BARE_REFERENCE_XML);
+		
+		ReferenceParam ownerReference = new ReferenceParam();
+		ownerReference.setValue(FhirConstants.PRACTITIONER + "/" + BARE_REFERENCE_PRACTITIONER_UUID);
+		
+		ReferenceAndListParam ref = new ReferenceAndListParam().addAnd(new ReferenceOrListParam().add(ownerReference));
+		
+		SearchParameterMap theParams = new SearchParameterMap().addParameter(FhirConstants.OWNER_REFERENCE_SEARCH_HANDLER,
+		    ref);
+		
+		List<IBaseResource> resultList = get(search(theParams));
+		
+		assertThat(resultList, hasSize(equalTo(1)));
+		assertThat(((Task) resultList.iterator().next()).getIdElement().getIdPart(), equalTo(BARE_REFERENCE_TASK_UUID));
 	}
 	
 	@Test

--- a/integration-tests/src/test/java/org/openmrs/module/fhir2/providers/r4/TaskFhirResourceIntegrationTest.java
+++ b/integration-tests/src/test/java/org/openmrs/module/fhir2/providers/r4/TaskFhirResourceIntegrationTest.java
@@ -60,7 +60,7 @@ public class TaskFhirResourceIntegrationTest extends BaseFhirR4IntegrationTest<T
 	
 	private static final String FOCUS_OBSERVATION_UUID = "5085AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 	
-	private static final String BARE_BASED_ON_SERVICE_REQUEST_UUID = "6d0ae116-707a-4629-9850-f15206e63ab0";
+	private static final String BARE_BASED_ON_SERVICE_REQUEST_UUID = "05caaf38-35a1-4c06-a229-44b4ea608b34";
 	
 	private static final String JSON_MERGE_PATCH_TASK_PATH = "org/openmrs/module/fhir2/providers/Task_merge_json_patch.json";
 	

--- a/integration-tests/src/test/java/org/openmrs/module/fhir2/providers/r4/TaskFhirResourceIntegrationTest.java
+++ b/integration-tests/src/test/java/org/openmrs/module/fhir2/providers/r4/TaskFhirResourceIntegrationTest.java
@@ -60,6 +60,8 @@ public class TaskFhirResourceIntegrationTest extends BaseFhirR4IntegrationTest<T
 	
 	private static final String FOCUS_OBSERVATION_UUID = "5085AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 	
+	private static final String BARE_BASED_ON_SERVICE_REQUEST_UUID = "6d0ae116-707a-4629-9850-f15206e63ab0";
+	
 	private static final String JSON_MERGE_PATCH_TASK_PATH = "org/openmrs/module/fhir2/providers/Task_merge_json_patch.json";
 	
 	private static final String JSON_PATCH_TASK_PATH = "org/openmrs/module/fhir2/providers/Task_json_patch.json";
@@ -849,6 +851,40 @@ public class TaskFhirResourceIntegrationTest extends BaseFhirR4IntegrationTest<T
 		assertThat(results, notNullValue());
 		assertThat(results.getType(), equalTo(Bundle.BundleType.SEARCHSET));
 		assertThat(results.hasEntry(), is(true));
+		assertThat(results.getEntry(), hasSize(1));
+		assertThat(results.getEntry(), hasItem(
+		    hasResource(hasProperty("idElement", hasProperty("idPart", equalTo(createdTask.getIdElement().getIdPart()))))));
+	}
+	
+	/**
+	 * A client that carries the resource type in Reference.type and a bare id in Reference.reference
+	 * stores the id without a "Type/" prefix, which leaves fhir_reference.target_uuid unset. Searching
+	 * by that reference must still find the Task. See FM2-700.
+	 */
+	@Test
+	public void shouldSearchTasksByBasedOnReferenceStoredWithoutAResourceTypePrefixAsJson() throws Exception {
+		Task newTask = new Task();
+		newTask.setStatus(Task.TaskStatus.REQUESTED);
+		newTask.setIntent(Task.TaskIntent.ORDER);
+		newTask.addBasedOn(new Reference().setReference(BARE_BASED_ON_SERVICE_REQUEST_UUID).setType("ServiceRequest"));
+		
+		MockHttpServletResponse createResponse = post("/Task").accept(FhirMediaTypes.JSON).jsonContent(toJson(newTask)).go();
+		assertThat(createResponse, isCreated());
+		Task createdTask = readResponse(createResponse);
+		
+		// the precondition this test exists for: the id was stored as the client wrote it, unprefixed
+		assertThat(createdTask.getBasedOnFirstRep().getReference(), equalTo(BARE_BASED_ON_SERVICE_REQUEST_UUID));
+		
+		MockHttpServletResponse response = get("/Task?based-on=ServiceRequest/" + BARE_BASED_ON_SERVICE_REQUEST_UUID)
+		        .accept(FhirMediaTypes.JSON).go();
+		
+		assertThat(response, isOk());
+		assertThat(response.getContentType(), startsWith(FhirMediaTypes.JSON.toString()));
+		
+		Bundle results = readBundleResponse(response);
+		
+		assertThat(results, notNullValue());
+		assertThat(results.getType(), equalTo(Bundle.BundleType.SEARCHSET));
 		assertThat(results.getEntry(), hasSize(1));
 		assertThat(results.getEntry(), hasItem(
 		    hasResource(hasProperty("idElement", hasProperty("idPart", equalTo(createdTask.getIdElement().getIdPart()))))));

--- a/test-data/src/main/resources/org/openmrs/module/fhir2/api/dao/impl/FhirTaskDaoImplTest_bare_reference_data.xml
+++ b/test-data/src/main/resources/org/openmrs/module/fhir2/api/dao/impl/FhirTaskDaoImplTest_bare_reference_data.xml
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+-->
+<dataset>
+	<!--
+		A reference stored the way a client that sends Reference.type alongside a bare resource id
+		writes one: the type lands in target_type and the id in reference, and target_uuid is left
+		unset because FhirReference#setReference could not parse a resource id out of a bare id.
+		target_uuid is deliberately absent from these rows - do not add it.
+	-->
+	<fhir_reference reference_id="300" name="ServiceRequest/6d0ae116-707a-4629-9850-f15206e63ab0" target_type="ServiceRequest" reference="6d0ae116-707a-4629-9850-f15206e63ab0" uuid="3f3ecb0a-2ca2-4e21-a5cd-bb1af1ad1e94" creator="1" date_created="2026-01-01 00:00:00.0" retired="false"/>
+	<fhir_reference reference_id="301" name="Practitioner/8f1a6b47-1f0d-4a5e-8f36-3f5f2c9a4d21" target_type="Practitioner" reference="8f1a6b47-1f0d-4a5e-8f36-3f5f2c9a4d21" uuid="9c2f1e3b-6a44-4d8b-9f7c-0a5b8d2e1f60" creator="1" date_created="2026-01-01 00:00:00.0" retired="false"/>
+
+	<fhir_task task_id="300" name="Task based on a bare ServiceRequest reference" status="REQUESTED" intent="ORDER" owner_reference_id="301" creator="1" date_created="2026-01-01 00:00:00.0" retired="false" uuid="2ba49b19-6d51-4de9-8bb0-b2d3c86ab0a8"/>
+	<fhir_task_based_on_reference task_id="300" reference_id="300"/>
+</dataset>

--- a/test-data/src/main/resources/org/openmrs/module/fhir2/api/dao/impl/FhirTaskDaoImplTest_bare_reference_data.xml
+++ b/test-data/src/main/resources/org/openmrs/module/fhir2/api/dao/impl/FhirTaskDaoImplTest_bare_reference_data.xml
@@ -15,7 +15,7 @@
 		unset because FhirReference#setReference could not parse a resource id out of a bare id.
 		target_uuid is deliberately absent from these rows - do not add it.
 	-->
-	<fhir_reference reference_id="300" name="ServiceRequest/6d0ae116-707a-4629-9850-f15206e63ab0" target_type="ServiceRequest" reference="6d0ae116-707a-4629-9850-f15206e63ab0" uuid="3f3ecb0a-2ca2-4e21-a5cd-bb1af1ad1e94" creator="1" date_created="2026-01-01 00:00:00.0" retired="false"/>
+	<fhir_reference reference_id="300" name="ServiceRequest/05caaf38-35a1-4c06-a229-44b4ea608b34" target_type="ServiceRequest" reference="05caaf38-35a1-4c06-a229-44b4ea608b34" uuid="3f3ecb0a-2ca2-4e21-a5cd-bb1af1ad1e94" creator="1" date_created="2026-01-01 00:00:00.0" retired="false"/>
 	<fhir_reference reference_id="301" name="Practitioner/8f1a6b47-1f0d-4a5e-8f36-3f5f2c9a4d21" target_type="Practitioner" reference="8f1a6b47-1f0d-4a5e-8f36-3f5f2c9a4d21" uuid="9c2f1e3b-6a44-4d8b-9f7c-0a5b8d2e1f60" creator="1" date_created="2026-01-01 00:00:00.0" retired="false"/>
 
 	<fhir_task task_id="300" name="Task based on a bare ServiceRequest reference" status="REQUESTED" intent="ORDER" owner_reference_id="301" creator="1" date_created="2026-01-01 00:00:00.0" retired="false" uuid="2ba49b19-6d51-4de9-8bb0-b2d3c86ab0a8"/>


### PR DESCRIPTION
https://openmrs.atlassian.net/browse/FM2-700

## The problem

`GET /ws/fhir2/R4/Task?based-on=ServiceRequest/<uuid>` returns `"total": 0` while the unfiltered
`GET /Task` returns a Task whose `basedOn` is that ServiceRequest.

Reproduced on a reference application 3.7.1 standalone running `fhir2-4.2.0.omod`:

```
GET /Task?based-on=ServiceRequest/d9abe171-5444-4bfd-a252-5e52405b8332  ->  "total": 0
GET /Task?_summary=count                                               ->  "total": 331
GET /Task/6ec73b25-d984-4f95-9d4d-b651ff29def0                         ->  basedOn d9abe171-...
```

## Cause

`FhirTaskDaoImpl#handleReference` matched the search id against `fhir_reference.target_uuid` only.
`FhirReference#setReference` writes that column with the id it can parse out of the reference
string, and a bare resource id yields nothing to parse — so `target_uuid` stays null whenever a
client sends `Reference.type` alongside a bare id. On that install every one of the 331
`fhir_reference` rows is exactly that shape: `target_type='ServiceRequest'`,
`reference='<bare uuid>'`, `target_uuid=NULL`. `target_uuid` has one consumer in the module, that
predicate, so the filter could not match anything.

The predicate moved from `reference` to `targetUuid` in a2bc7a9a (FM2-682, #607), which is tagged
4.1.0 and 4.2.0 — `git log -S targetUuid -- .../FhirTaskDaoImpl.java` returns that one commit, and
the JPA-criteria migration before it (ee174cd3) still matched on `reference`. The same commit added
`target_uuid="<the bare reference>"` to every `fhir_reference` row in both shared fixtures, which is
why the existing search tests stayed green: with the two columns equal, the two predicates are
indistinguishable on that data.

`based-on`, `owner`, `subject` and `focus` all share `handleReference`, so all of them were
affected; the R3 provider routes its own reference params (`based-on`, `owner`, `subject`) through
the same method.

## The change

Match the id against either column, still scoped by the stored type:

```java
(bo.targetUuid = :idPart OR bo.reference = :idPart) AND bo.type = :resourceType
```

A strict superset of the previous predicate, so everything `target_uuid` was introduced to serve
keeps resolving through it, and ids stored bare resolve through `reference` as they did before
4.1.0. No schema change and no data migration — existing rows work as they are.

## Verification

Verified on the live 3.7.1 standalone, against the same 331-row database that returned 0, after
swapping in a build of this branch:

| request | on 4.2.0 | on this branch |
| --- | --- | --- |
| `?based-on=ServiceRequest/d9abe171-…` | 0 | **1** (Task `6ec73b25-…`) |
| `?based-on:ServiceRequest=d9abe171-…` | 0 | **1** |
| `?based-on=ServiceRequest/00000000-…` (unknown id) | 0 | 0 |
| `?based-on=Patient/d9abe171-…` (wrong type) | 0 | 0 |
| `?_summary=count` | 331 | 331 |

In the test suite:

- New fixture `FhirTaskDaoImplTest_bare_reference_data.xml` whose `fhir_reference` rows have **no**
  `target_uuid` — the shape measured on that install, and one no existing fixture has.
- `TaskSearchQueryTest`: `based-on` and `owner` searches over that fixture, plus two cases that
  search an id under a different resource type and expect no match — one over a row whose
  `target_uuid` is null, one over a row where it is populated.
- `TaskFhirResourceIntegrationTest` (R4): POSTs a Task whose `basedOn` carries `type` plus a bare id,
  asserts it really was stored unprefixed, then issues the ticket's own request over REST.
- Every clause of the predicate is discriminated — mutate a clause and read the failures.
  - Drop the `reference` arm: `TaskSearchQueryTest` fails 2 of 37.
  - Drop the `targetUuid` arm: the api module fails 1 of 4350,
    `FhirTaskDaoImplTest.searchForTasks_shouldReturnTasksByFocusReference`, which saves
    `Observation/<uuid>` programmatically and is therefore the only search in the module that
    reaches a row where `target_uuid` and `reference` differ.
  - Scope `type` to the `targetUuid` arm alone: both wrong-resource-type cases fail. Scope it to the
    `reference` arm alone: `searchForTasks_shouldNotReturnTasksWhenATargetUuidMatchIsSearchedUnderAnotherResourceType` fails.
  - Swap `getIdPart()` for `getValue()`: `TaskSearchQueryTest` fails 2 of 37. This is caught in the
    api module, not only over REST, because the new cases build their `ReferenceParam` through the
    single-argument constructor, which leaves `getValue()` as `ServiceRequest/<id>`, rather than
    through `setValue`, which re-parses it to a bare id and makes the two indistinguishable.
- Root `mvn clean install`: green apart from `ObservationNarrativeTest`, which fails identically on
  an unmodified `origin/master` checkout on this machine — a JDK locale renders `pm` where the
  expectation says `PM`.

## Not fixed here

A reference parameter with no resource type at all — `GET /Task?based-on=<bare uuid>` — is dropped
rather than applied, because `validReferenceParam` requires a non-null resource type and
`handleReference` then contributes no predicate, so the search returns every Task (measured: 331 of
331 on that install). The ticket reproduces with the typed form, so this is left alone here and
deserves its own issue.

